### PR TITLE
default-gitconfig

### DIFF
--- a/gitconfig
+++ b/gitconfig
@@ -1,0 +1,19 @@
+[core]
+	symlinks = false
+	autocrlf = false
+[color]
+	diff = auto
+	status = auto
+	branch = auto
+	interactive = true
+[pack]
+	packSizeLimit = 2g
+[help]
+	format = html
+[http]
+	sslCAinfo = /ssl/certs/ca-bundle.crt
+[diff "astextplain"]
+	textconv = astextplain
+[rebase]
+	autosquash = true
+


### PR DESCRIPTION
Added a `default-gitconfig`. This file will be parsed by the `git-extra`
`PKGBUILD` file. The content will then be written in the respective
location based on the `MinGW` system (either `mingw32` or `mingw64`) installed.

Signed-off-by: nalla <nalla@hamal.uberspace.de>