### PR TITLE
Net installer fixes2

### DIFF
--- a/net-installer/setup-git-sdk.bat
+++ b/net-installer/setup-git-sdk.bat
@@ -37,6 +37,6 @@
 @IF MINGW32 == %MSYSTEM% CALL %cwd%\autorebase.bat
 
 @REM now clone the Git sources, build it, and start an interactive shell
-@bash --login -c "mkdir -p /usr/src && cd /usr/src && counter=1; while test $counter -lt 5; do git -c core.autocrlf=false clone -b @@GIT_BRANCH@@ https://github.com/git-for-windows/git; status=$?; test $status = 0 && break; test $status = 128 || exit $status; counter=$(($counter+1)); done && cd git && git config core.autocrlf false && make install; bash -i"
+@bash --login -c "mkdir -p /usr/src && cd /usr/src && counter=1; while test $counter -lt 5; do git clone -b @@GIT_BRANCH@@ -c core.autocrlf=false https://github.com/git-for-windows/git; status=$?; test $status = 0 && break; test $status = 128 || exit $status; counter=$(($counter+1)); done && cd git && git config core.autocrlf false && make install; bash -i"
 
 @IF NOT ERRORLEVEL 0 bash --login -i

--- a/net-installer/setup-git-sdk.bat
+++ b/net-installer/setup-git-sdk.bat
@@ -37,6 +37,6 @@
 @IF MINGW32 == %MSYSTEM% CALL %cwd%\autorebase.bat
 
 @REM now clone the Git sources, build it, and start an interactive shell
-@bash --login -c "mkdir -p /usr/src && cd /usr/src && counter=1; while test $counter -lt 5; do git clone -b @@GIT_BRANCH@@ -c core.autocrlf=false https://github.com/git-for-windows/git; status=$?; test $status = 0 && break; test $status = 128 || exit $status; counter=$(($counter+1)); done && cd git && git config core.autocrlf false && make install; bash -i"
+@bash --login -c "mkdir -p /usr/src && cd /usr/src && counter=1; while test $counter -lt 5; do git clone -b @@GIT_BRANCH@@ -c core.autocrlf=false https://github.com/git-for-windows/git; status=$?; test $status = 0 && break; test $status = 128 || exit $status; counter=$(($counter+1)); done && cd git && make install; bash -i"
 
 @IF NOT ERRORLEVEL 0 bash --login -i

--- a/net-installer/setup-git-sdk.bat
+++ b/net-installer/setup-git-sdk.bat
@@ -33,8 +33,10 @@
 	mingw-w64-@@ARCH@@-pcre
 
 @REM Avoid overlapping address ranges
-@IF MINGW32 == %MSYSTEM% ECHO "Auto-rebasing .dll files"
-@IF MINGW32 == %MSYSTEM% CALL %cwd%\autorebase.bat
+@IF MINGW32 == %MSYSTEM% (
+	ECHO "Auto-rebasing .dll files"
+	CALL %cwd%\autorebase.bat
+)
 
 @REM now clone the Git sources, build it, and start an interactive shell
 @bash --login -c "mkdir -p /usr/src && cd /usr/src && counter=1; while test $counter -lt 5; do git clone -b @@GIT_BRANCH@@ -c core.autocrlf=false https://github.com/git-for-windows/git; status=$?; test $status = 0 && break; test $status = 128 || exit $status; counter=$(($counter+1)); done && cd git && make install; bash -i"


### PR DESCRIPTION
This was meant to be another iteration of https://github.com/git-for-windows/build-extra/pull/9, but the latter was merged when still working on this. So this is pushed as a new PR for documentation purposes only. Compared to the original PR it only differs in [splitting out a change to a separate commit](https://github.com/git-for-windows/build-extra/commit/ee548ec1e2adecce928d55fda3e1cab8ee6cc919) and [rewording a commit message](https://github.com/git-for-windows/build-extra/commit/1b8d9e37571f7d3b78a9d9d0babefeb18fb7451a). The diff is the same.