### PR TITLE
Proposal: Modify output color of `__git_ps1` call

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -16,6 +16,7 @@ then
 	then
 		. "$COMPLETION_PATH/git-completion.bash"
 		. "$COMPLETION_PATH/git-prompt.sh"
+		PS1="$PS1"'\[\033[36m\]'  # change color to cyan
 		PS1="$PS1"'`__git_ps1`'   # bash function
 	fi
 fi


### PR DESCRIPTION
To distinguish between the working directory and the current git branch
the output of the `__git_ps1` call should be in a different color than the
rest of the prompt.

This is more like a proposal. If you feel this is unnecessary and is up to the end user in general that's fine. The default color is of course debatable.