### PR TITLE
git-prompt: Reset to default color after changing it for the branch name

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -18,6 +18,7 @@ then
 		. "$COMPLETION_PATH/git-prompt.sh"
 		PS1="$PS1"'\[\033[36m\]'  # change color to cyan
 		PS1="$PS1"'`__git_ps1`'   # bash function
+		PS1="$PS1"'\[\033[0m\]'   # reset to default color
 	fi
 fi
 PS1="$PS1"'\[\033[0m\]'        # change color


### PR DESCRIPTION
This makes color display correctly for programs that do not explicitly set
it but rely on the default color to be the current color.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>