### PR TITLE
portable-release: handle spaces in install path

### DIFF
--- a/portable/git-bash.bat.in
+++ b/portable/git-bash.bat.in
@@ -8,9 +8,9 @@
 @SET MSYSTEM=MINGW@@BITNESS@@
 
 @IF NOT EXIST %git_install_root%usr\bin\mintty.exe GOTO startsh
-@START %git_install_root%usr\bin\mintty -i /usr/share/git/git-for-windows.ico /usr/bin/bash --login %*
+@START "Git Bash" "%git_install_root%usr\bin\mintty" -i /usr/share/git/git-for-windows.ico /usr/bin/bash --login %*
 @EXIT
 
 :startsh
-@START %git_install_root%usr\bin\bash --login -i %*
+@START "Git Bash" "%git_install_root%usr\bin\bash" --login -i %*
 @EXIT


### PR DESCRIPTION
The `git-bash.bat` can not handle setups that were installed in a path
with a space in it. According to `help start` you are providing a title if
you use quotes. Because of this a dummy title must be provided to quote
the path to the console application.

Signed-off-by: nalla <nalla@hamal.uberspace.de>