### PR TITLE
build-extra: add $HOME/bin to path

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -65,5 +65,6 @@ package() {
   install -m755 create-shortcut.exe $pkgdir/$mingwdir/bin
   install -m755 $startdir/git-prompt.sh $pkgdir/etc/profile.d
   install -m755 $startdir/aliases.sh $pkgdir/etc/profile.d
+  install -m755 $startdir/env.sh $pkgdir/etc/profile.d
   install -m644 $startdir/msys2-32.ico $pkgdir/usr/share/git
 }

--- a/git-extra/env.sh
+++ b/git-extra/env.sh
@@ -1,0 +1,2 @@
+# Add bin path in the home directory ontop of the PATH variable
+export PATH="$HOME/bin:$PATH"


### PR DESCRIPTION
This behavior was present in the *msysgit* version of the `/etc/profile`
file. The `git-extra` package now adds a `homepath.sh` into the
`/etc/profile.d` directory to restore the behavior in the *MSYS2*
environment.

This *should* resolve https://github.com/git-for-windows/git/issues/57.

Signed-off-by: nalla <nalla@hamal.uberspace.de>