### PR TITLE
net-installer: install requirements to build doc

### DIFF
--- a/net-installer/setup-git-sdk.bat
+++ b/net-installer/setup-git-sdk.bat
@@ -71,8 +71,8 @@
 @%cwd%\usr\bin\pacman -S --force --noconfirm ^
 	base python less openssh patch make tar diffutils ca-certificates ^
 	perl-Error perl perl-Authen-SASL perl-libwww perl-MIME-tools ^
-	perl-Net-SMTP-SSL perl-TermReadKey dos2unix subversion ^
-	mintty vim git-extra ^
+	perl-Net-SMTP-SSL perl-TermReadKey dos2unix asciidoc xmlto ^
+	subversion mintty vim git-extra ^
 	mingw-w64-@@ARCH@@-git mingw-w64-@@ARCH@@-toolchain ^
 	mingw-w64-@@ARCH@@-curl mingw-w64-@@ARCH@@-expat ^
 	mingw-w64-@@ARCH@@-openssl mingw-w64-@@ARCH@@-tcl ^


### PR DESCRIPTION
Since the *Git for Windows SDK* should provide functionality to build git
it should also provide all required packages to build the git doc.
Building doc is needed when shipping the git mingw package lets just
install those reuqirements too then.

Signed-off-by: nalla <nalla@hamal.uberspace.de>