### PR TITLE
git-extra: Add inputrc

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -60,6 +60,7 @@ package() {
   install -d -m755 $pkgdir/usr/bin
   install -d -m755 $pkgdir/usr/share/git
   install -d -m755 $pkgdir/$mingwdir/bin
+  install -m644 $startdir/inputrc $pkgdir/etc
   install -m644 $startdir/vimrc $pkgdir/etc
   install -m755 $startdir/vi $pkgdir/usr/bin
   install -m755 $startdir/wordpad $pkgdir/usr/bin

--- a/git-extra/inputrc
+++ b/git-extra/inputrc
@@ -1,0 +1,26 @@
+# none, visible or audible
+set bell-style visible
+
+# Ask before displaying >40 items
+# Since $WINDIR $PATH var can be in $PATH, this could list
+# all window executables in C:\WINDOWS
+set completion-query-items 40
+
+# Ignore case for the command-line-completion functionality
+# on:  default on a Windows style console
+# off: default on a *nix style console
+set completion-ignore-case on
+
+# disable/enable 8bit input
+set input-meta on
+set output-meta on
+set convert-meta off
+
+# visible-stats
+# Append a mark according to the file type in a listing
+set visible-stats off
+set mark-directories on
+set mark-symlinked-directories on
+
+# Show all instead of beeping first
+set show-all-if-ambiguous on


### PR DESCRIPTION
This brings Git Bash's input and completion behavior in line with the
previous msysGit-based releases.

Signed-off-by: Eli Young <elyscape@gmail.com>

Fixes git-for-windows/git#62.