### PR TITLE
installer: hardlink creation reworked

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -894,6 +894,37 @@ begin
     end;
 end;
 
+// Procedure to create hardlinks for builtins. This procedure relies upon that
+// git-wrapper.exe is already copied to {app}/tmp.
+procedure CopyBuiltin(FileName:String);
+var
+    AppDir:String;
+    LinkCreated:Boolean;
+begin
+    if (not DeleteFile(FileName)) then begin
+        Log('Line {#__LINE__}: Unable to delete existing built-in "'+FileName+'", skipping.');
+        Exit;
+    end;
+
+    AppDir:=ExpandConstant('{app}');
+
+    try
+        // This will throw an exception on pre-Win2k systems.
+        LinkCreated:=CreateHardLink(FileName,AppDir+'\{#MINGW_BITNESS}\bin\git.exe',0);
+    except
+        LinkCreated:=False;
+        Log('Line {#__LINE__}: Creating hardlink "'+FileName+'" failed, will try a copy.');
+    end;
+
+    if not LinkCreated then begin
+        if not FileCopy(AppDir+'\tmp\git-wrapper.exe',FileName,False) then begin
+            Log('Line {#__LINE__}: Creating copy "'+FileName+'" failed.');
+            // This is not a critical error, Git could basically be used without the
+            // aliases for built-ins, so we continue.
+        end;
+    end;
+end;
+
 procedure CurStepChanged(CurStep:TSetupStep);
 var
     AppDir,DllPath,FileName,TempName,Cmd,Msg:String;
@@ -967,42 +998,17 @@ begin
 
         // Create built-ins as aliases for git.exe.
         for i:=0 to Count do begin
-            FileName:=AppDir+'\'+BuiltIns[i];
+            FileName:=AppDir+'\{#MINGW_BITNESS}\bin\'+BuiltIns[i];
 
-            // Delete any existing built-in.
-            if FileExists(FileName) and (not DeleteFile(FileName)) then begin
-                Log('Line {#__LINE__}: Unable to delete existing built-in "'+FileName+'", skipping.');
-                continue;
+            if FileExists(FileName) then begin
+                CopyBuiltin(FileName);
             end;
 
-            try
-                // This will throw an exception on pre-Win2k systems.
-                LinkCreated:=CreateHardLink(FileName,AppDir+'\{#MINGW_BITNESS}\bin\git.exe',0);
-            except
-                LinkCreated:=False;
-                Log('Line {#__LINE__}: Creating hardlink "'+FileName+'" failed, will try a copy.');
-            end;
+            FileName:=AppDir+'\{#MINGW_BITNESS}\libexec\git-core\'+BuiltIns[i];
 
-            if not LinkCreated then begin
-                if not FileCopy(AppDir+'\tmp\git-wrapper.exe',FileName,False) then begin
-                    Log('Line {#__LINE__}: Creating copy "'+FileName+'" failed.');
-                    // This is not a critical error, Git could basically be used without the
-                    // aliases for built-ins, so we continue.
-                end;
+            if FileExists(FileName) then begin
+                CopyBuiltin(FileName);
             end;
-        end;
-
-        // Delete any duplicate files in case we are updating from a non-libexec to a libexec directory layout.
-        if FindFirst(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\*',FindRec) then begin
-            repeat
-                if (FindRec.Attributes and FILE_ATTRIBUTE_DIRECTORY)=0 then begin
-                    FileName:=AppDir+'\{#MINGW_BITNESS}\bin\'+FindRec.name;
-                    if (Pos(FindRec.name,'git.exe')<>1) and FileExists(FileName) and (not DeleteFile(FileName)) then begin
-                        Log('Line {#__LINE__}: Unable to delete dupe "'+FileName+'", ignoring.');
-                    end;
-                end;
-            until not FindNext(FindRec);
-            FindClose(FindRec);
         end;
     end else begin
         Msg:='Line {#__LINE__}: Unable to read file "{#MINGW_BITNESS}\{#APP_BUILTINS}".';


### PR DESCRIPTION
The old implementation did not work because every builtin was copied
to the toplevel directory. So this commit adapts the hardlink
creation to the following algorithm:

```
copy mingw??\libexec\git-core\git-log tmp\git-wrapper.exe

foreach builtin
	if file_exists(mingw??\bin\builtin) then
		delete mingw??\bin\builtin
		if !create_hardlink(mingw??\bin\builtin) then
			copy \tmp\git-wrapper.exe mingw??\bin\builtin
		fi
	fi

	if file_exists(mingw??\libexec\builtin) then
		delete mingw??\libexec\builtin
		if ! create_hardlink(mingw??\libexec\builtin) then
			copy \tmp\git-wrapper.exe mingw??\libexec\builtin
		fi
	fi
hcaerof
```

Signed-off-by: nalla <nalla@hamal.uberspace.de>