### PR TITLE
installer: ship `nsswitch.conf` too

### DIFF
--- a/installer/release.sh
+++ b/installer/release.sh
@@ -75,12 +75,13 @@ LIST="$(pacman_list mingw-w64-$ARCH-git mingw-w64-$ARCH-git-doc-html \
 		-e '^/usr/share/info/' -e '^/mingw32/share/info/' |
 	sed 's/^\///')"
 
-LIST="$(printf "%s\n%s\n%s\n%s\n%s\n%s\n" \
+LIST="$(printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
 	"$LIST" \
 	etc/profile \
 	etc/bash.bash_logout \
 	etc/bash.bashrc \
 	etc/fstab \
+	etc/nsswitch.conf \
 	mingw$BITNESS/etc/gitconfig)"
 
 echo "; List of files" > file-list.iss ||


### PR DESCRIPTION
To have a working ssh we need to ship that file too. Otherwise OpenSSH
will look in `/home/<username>/.ssh/` for the configuration. But we need
it to look in the windows home dir.

Signed-off-by: nalla <nalla@hamal.uberspace.de>