### PR TITLE
installer: Prepare release notes and documentation

### DIFF
--- a/installer/HowToRelease.txt
+++ b/installer/HowToRelease.txt
@@ -34,47 +34,44 @@ The following is missing before we release a stable installer.
 We will *not* wait for
 
     * server functionality (git-daemon, git-shell, ...).
-    * git-cheetah.
 
-An msysgit release is tagged by a tag having a postfix '.msysgit.[0-9]+'.
+A Git for Windows release is tagged by a tag having a postfix '.windows.[0-9]+'.
 
 Here is a step-by-step instruction for the maintainer:
 
-   cd /git
-   git fetch mingw
-   git fetch junio
-   git checkout master
-   git merge mingw/master
-   git merge junio/master
-   make -k test | tee test.log
-   # check test.log
-
-   make clean
-   git tag -a v<version>.msysgit.<number>
-   make install
-
-   cd /doc/git/html
+   cd /usr/src/build-extra
    git fetch
    git checkout master
-   git merge origin/master
-
-   cd /share/WinGit
+   cd /usr/src/git
+   git remote add git https://github.com/git/git
+   git fetch git
    git checkout master
-   start ReleaseNotes.rtf # edit and save
-   git commit -a
-   git tag -a -m "Git-<version>" Git-<version>
-   ./release.sh <version>
+   BASE="$(git rev-parse ":/Start the merging-rebase")"
+   ../build-extra/./shears.sh --merging --onto <git-tag> $BASE
+   git diff <gittag>..origin/master > prev.diff
+   git diff <gittag>..master > curr.diff
+   git diff --no-index prev.diff curr.diff
+   # check diff of diff
+   make clean
+   make install install-html
+   cd t
+   /usr/bin/time prove -j 5 --state=failed,save ./t[0-9]*.sh
+   git tag -a <git-tag>.windows.<number>
+
+   # Make installer
+
+   cd /usr/src/build-extra/installer
+   ./release.sh <git-tag>-<preview><date>
 
    # Test installer.
 
-   # Upload to Google code (verify sha1).
+   # Upload to GitHub (verify sha1).
 
-   cd /git
+   cd /usr/src/git
    git push master
-   git push <version>-msysgit<number>
-   cd /
-   git push master
-   git push Git-<version>
+   git push <git-tag>.windows.<number>
+   cd /usr/src/build-extra/installer
+   git push Git-<git-tag>-<preview><date>
    # Don't forget to push tags.
 
    # Reply to Junio's announcement.

--- a/installer/ReleaseNotes.rtf
+++ b/installer/ReleaseNotes.rtf
@@ -1,615 +1,603 @@
-{\rtf1\ansi\ansicpg1252\deff0{\fonttbl{\f0\fswiss\fprq2\fcharset0 Arial;}{\f1\fnil\fcharset0 Arial;}{\f2\fnil\fcharset2 Symbol;}}
+{\rtf1\ansi\ansicpg1252\deff0\deflang1031\deflangfe1031{\fonttbl{\f0\fswiss\fprq2\fcharset0 Arial;}{\f1\fnil\fcharset2 Symbol;}}
 {\colortbl ;\red0\green0\blue0;\red0\green0\blue255;}
-{\*\generator Msftedit 5.41.21.2510;}\viewkind4\uc1\pard\cf1\lang1033\b\f0\fs32 Git Release Notes (Git-1.9.5-preview20150319)\b0\fs20\par
-Last update: 19 March 2015\par
+{\*\generator Msftedit 5.41.21.2510;}\viewkind4\uc1\pard\nowidctlpar\cf1\lang1033\b\f0\fs32 Git Release Notes (Git-2.3.5-preview20150402)\b0\fs20\par
+Last update: 2 April 2015\par
 \par
 \b\fs24 Introduction\b0\fs20\par
 \par
 These release notes describe issues specific to the Git for Windows release.\par
 \par
-General release notes covering the history of the core git commands are included in the subdirectory doc/git/html of the installation directory. Look for files starting with RelNotes.\par
+General release notes covering the history of the core git commands are included in the subdirectory mingw??\\share\\doc\\git-doc\\RelNotes of the installation directory.\par
 \par
-See \cf0{\field{\*\fldinst{HYPERLINK "http://git-scm.com/"}}{\fldrslt{\ul\cf2 http://git-scm.com/}}}\cf1\f0\fs20  for further details about Git including ports to other operating systems. Git for Windows is currently hosted at \cf0{\field{\*\fldinst{HYPERLINK "https://msysgit.github.io/"}}{\fldrslt{\ul\cf2 https://msysgit.github.io/}}}\cf1\f0\fs20 .\par
+\pard See \cf0{\field{\*\fldinst{HYPERLINK "http://git-scm.com/"}}{\fldrslt{\ul\cf2 http://git-scm.com/}}}\cf1\f0\fs20  for further details about Git including ports to other operating systems. Git for Windows is currently hosted at \cf0{\field{\*\fldinst{HYPERLINK "https://git-for-windows.github.io/"}}{\fldrslt{\ul\cf2 https://git-for-windows.github.io/}}}\cf1\f0\fs20 .\par
 \par
 \b\fs24 Known issues\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\fs20 Some commands are not yet supported on Windows and excluded from the installation; namely: git archimport, git cvsexportcommit, git cvsimport, git cvsserver, git instaweb, git shell.\par
-{\pntext\f2\'B7\tab}As Git for Windows is built without Python support, all Git commands requiring Python are not yet supported; namely: git p4, git remote-hg.\par
-{\pntext\f2\'B7\tab}The Logitec QuickCam software can cause spurious crashes. See "Why does \i make\i0  often crash creating a sh.exe.stackdump file when I try to compile my source code?" on the MinGW Wiki (\cf0{\field{\*\fldinst{HYPERLINK "http://www.mingw.org/wiki/Environment_issues"}}{\fldrslt{\ul\cf2 http://www.mingw.org/wiki/Environment_issues}}}\cf1\f0\fs20 )\par
-{\pntext\f2\'B7\tab}The Quick Launch icon will only be installed for the user running setup (typically the Administrator). This is a technical restriction and will not change.\par
-{\pntext\f2\'B7\tab}curl uses $HOME/_netrc instead of $HOME/.netrc.\par
-{\pntext\f2\'B7\tab}If you want to specify a different location for --upload-pack, you have to start the absolute path with two slashes. Otherwise MSys will mangle the path.\par
-{\pntext\f2\'B7\tab}Likewise, if you want to pass the \i -L/regex/\i0  option to \i git log\i0 , MSys will misinterpret it as an absolute path and mangle it into a DOS-style one. You can prevent that by putting a semicolon into the regular expression, e.g. \i git log -L/\\;*needle/\i0 .\par
-{\pntext\f2\'B7\tab}If configured to use Plink, you will have to connect with putty first and accept the host key.\par
-{\pntext\f2\'B7\tab}As merge tools are executed using the MSys bash, options starting with "/" need to be handled specially: MSys would interpret that as a POSIX path, so you need to double the slash (Issue 226).  Example: instead of "/base", say "//base".  Also, extra care has to be paid to pass Windows programs Windows paths, as they have no clue about MSys style POSIX paths -- You can use something like $(cmd //c echo "$POSIXPATH").\par
-\pard\li144 Unless you define the environment variable MSYS_WATCH_FSTAB (the value must be a non-empty string), Git Bash will not see any drives that have been attached after bash was started. This is a workaround to help the speed of cmd scripts using parts of Git that are implemented as shell scripts.\line\line Should you encounter other problems, please search the mailing list first (\cf0{\field{\*\fldinst{HYPERLINK "http://groups.google.com/group/msysgit"}}{\fldrslt{\ul\cf2 http://groups.google.com/group/msysgit}}}\cf1\f0\fs20 ) and ask there if you do not find anything.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\fs20 Some commands are not yet supported on Windows and excluded from the installation; namely: git archimport, git cvsexportcommit, git cvsimport, git cvsserver, git instaweb, git shell.\par
+{\pntext\f1\'B7\tab}As Git for Windows is built without Python support, all Git commands requiring Python are not yet supported; namely: git p4, git remote-hg.\par
+\pard\fi-288\li432 The Logitec QuickCam software can cause spurious crashes. See "Why does \i make\i0  often crash creating a sh.exe.stackdump file when I try to compile my source code?" on the MinGW Wiki (\cf0{\field{\*\fldinst{HYPERLINK "http://www.mingw.org/wiki/Environment_issues"}}{\fldrslt{\ul\cf2 http://www.mingw.org/wiki/Environment_issues}}}\cf1\f0\fs20 )\par
+\'b7\tab The Quick Launch icon will only be installed for the user running setup (typically the Administrator). This is a technical restriction and will not change.\par
+\'b7\tab curl uses $HOME/_netrc instead of $HOME/.netrc.\par
+\'b7\tab If you want to specify a different location for --upload-pack, you have to start the absolute path with two slashes. Otherwise MSys will mangle the path.\par
+\'b7\tab Likewise, if you want to pass the \i -L/regex/\i0  option to \i git log\i0 , MSys will misinterpret it as an absolute path and mangle it into a DOS-style one. You can prevent that by putting a semicolon into the regular expression, e.g. \i git log -L/\\;*needle/\i0 .\par
+\'b7\tab If configured to use Plink, you will have to connect with putty first and accept the host key.\par
+\'b7\tab As merge tools are executed using the MSys bash, options starting with "/" need to be handled specially: MSys would interpret that as a POSIX path, so you need to double the slash (Issue 226).  Example: instead of "/base", say "//base".  Also, extra care has to be paid to pass Windows programs Windows paths, as they have no clue about MSys style POSIX paths -- You can use something like $(cmd //c echo "$POSIXPATH").\par
+\pard\nowidctlpar\li144 Unless you define the environment variable MSYS_WATCH_FSTAB (the value must be a non-empty string), Git Bash will not see any drives that have been attached after bash was started. This is a workaround to help the speed of cmd scripts using parts of Git that are implemented as shell scripts.\line\line Should you encounter other problems, please search the mailing list first (\cf2\ul{\field{\*\fldinst{HYPERLINK "http://groups.google.com/group/git-for-windows"}}{\fldrslt{\ul\cf2 http://groups.google.com/group/git-for-windows}}}\cf1\ulnone\f0\fs20 ) and ask there if you do not find anything.\par
+\pard\nowidctlpar\b\fs24\par
 Licenses\par
-\b0\fs20 This software contains Embedded CAcert Root Certificates. For more information please go to \cf0{\field{\*\fldinst{HYPERLINK "https://www.cacert.org/policy/RootDistributionLicense.php"}}{\fldrslt{\ul\cf2 https://www.cacert.org/policy/RootDistributionLicense.php}}}\cf1\f0\fs20 .\par
+\pard\b0\fs20 This software contains Embedded CAcert Root Certificates. For more information please go to \cf0{\field{\*\fldinst{HYPERLINK "https://www.cacert.org/policy/RootDistributionLicense.php"}}{\fldrslt{\ul\cf2 https://www.cacert.org/policy/RootDistributionLicense.php}}}\cf1\f0\fs20 .\par
 \par
 This package contains software from a number of other projects including zlib, curl, msmtp, tcl/tk, perl, msys and a number of libraries and utilities from the GNU project.\par
 \par
 \b\fs24 Changes since Git-1.9.5-preview20141217\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.5 plus Windows-specific patches.\par
-{\pntext\f2\'B7\tab}Make vimdiff usable with git mergetool.\par
-\pard\b\fs24\par
-\i\fs20 Security Updates\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0 Mingw-openssl to 0.9.8zf and msys-openssl to 1.0.1m\par
-{\pntext\f2\'B7\tab}Bash to 3.1.23(6)\par
-{\pntext\f2\'B7\tab}Curl to 7.41.0\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 ssh-agent: only ask for password if not already loaded\par
-{\pntext\f2\'B7\tab}Reenable perl debugging ("perl -de 1" possible again)\par
-{\pntext\f2\'B7\tab}Set icon background color for Windows 8 tiles\par
-{\pntext\f2\'B7\tab}poll: honor the timeout on Win32\par
-{\pntext\f2\'B7\tab}For git.exe alone, use the same HOME directory fallback mechanism as /etc/profile\par
-\pard\par
-\b\fs24 Changes since Git-1.9.4-preview20140929\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.5 plus Windows-specific patches.\par
-\pard\b\fs24\par
-\i\fs20 Bugfixes\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0 Safeguards against bogus file names on NTFS (CVE-2014-9390).\par
-\pard\b\par
-\fs24 Changes since Git-1.9.4-preview20140815\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.4 plus Windows-specific patches.\par
-\pard\b\fs24\par
-\i\fs20 Bugfixes\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0 Update bash to patchlevel 3.1.20(4) (msysgit PR#254, msysgit issue #253).\b\line\b0 Fixes CVE-2014-6271, CVE-2014-7169, CVE-2014-7186 and CVE-2014-7187.\b\i\par
-\b0\i0{\pntext\f2\'B7\tab}gitk.cmd now works when paths contain the ampersand (&) symbol (msysgit PR #252)\par
-{\pntext\f2\'B7\tab}Default to automatically close and restart applications in silent mode installation type\par
-\pard Git svn is now usable again (regression in previous update, msysgit PR#245)\line\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 2.3.5 plus Windows-specific patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\par
+\b\fs24{\pntext\f1\'B7\tab}\par
+{\pntext\f1\'B7\tab}Changes since Git-1.9.4-preview20140929\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.9.5 plus Windows-specific patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+\i\fs20{\pntext\f1\'B7\tab}Bugfixes\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0 Safeguards against bogus file names on NTFS (CVE-2014-9390).\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\par
+\fs24{\pntext\f1\'B7\tab}Changes since Git-1.9.4-preview20140815\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.9.4 plus Windows-specific patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+\i\fs20{\pntext\f1\'B7\tab}Bugfixes\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0 Update bash to patchlevel 3.1.20(4) (msysgit PR#254, msysgit issue #253).\b\line\b0 Fixes CVE-2014-6271, CVE-2014-7169, CVE-2014-7186 and CVE-2014-7187.\b\i\par
+\b0\i0{\pntext\f1\'B7\tab}gitk.cmd now works when paths contain the ampersand (&) symbol (msysgit PR #252)\par
+{\pntext\f1\'B7\tab}Default to automatically close and restart applications in silent mode installation type\par
+\pard\nowidctlpar Git svn is now usable again (regression in previous update, msysgit PR#245)\line\par
 \b\fs24 Changes since Git-1.9.4-preview20140611\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.4 plus Windows-specific patches\par
-{\pntext\f2\'B7\tab}Add vimtutor (msysgit PR #220)\par
-{\pntext\f2\'B7\tab}Update OpenSSH to 6.6.1p1 and its OpenSSL to 1.0.1i (msysgit PR #221, \line #223, #224, #226,  #229, #234, #236)\par
-{\pntext\f2\'B7\tab}Update mingw OpenSSL to 0.9.8zb (msysgit PR #241, #242)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.9.4 plus Windows-specific patches\par
+{\pntext\f1\'B7\tab}Add vimtutor (msysgit PR #220)\par
+{\pntext\f1\'B7\tab}Update OpenSSH to 6.6.1p1 and its OpenSSL to 1.0.1i (msysgit PR #221, \line #223, #224, #226,  #229, #234, #236)\par
+{\pntext\f1\'B7\tab}Update mingw OpenSSL to 0.9.8zb (msysgit PR #241, #242)\par
+\pard\nowidctlpar\b\fs24\par
 \i\fs20 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Checkout problem with directories exceeding MAX_PATH (PR #212, msysgit #227)\par
-\pard Backport a webdav fix from junio/maint (d9037e http-push.c: make CURLOPT_IOCTLDATA a usable pointer, PR #230)\line\par
-\b\i Regressions\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 git svn is/might be broken. Fixes welcome.\par
-\pard\b\fs24\par
-Changes since Git-1.9.2-preview20140411\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.4 plus Windows-specific patches.\par
-\pard\b\fs24\par
-\i\fs20 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Upgrade openssl to 0.9.8za (msysgit PR #212)\par
-{\pntext\f2\'B7\tab}Config option to disable side-band-64k for transport (#101)\par
-{\pntext\f2\'B7\tab}Make git-http-backend, git-http-push, git-http-fetch available again (#174)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Checkout problem with directories exceeding MAX_PATH (PR #212, msysgit #227)\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar Backport a webdav fix from junio/maint (d9037e http-push.c: make CURLOPT_IOCTLDATA a usable pointer, PR #230)\line\par
+\b\i{\pntext\f1\'B7\tab}Regressions\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 git svn is/might be broken. Fixes welcome.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+{\pntext\f1\'B7\tab}Changes since Git-1.9.2-preview20140411\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.9.4 plus Windows-specific patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+\i\fs20{\pntext\f1\'B7\tab}Bugfixes\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Upgrade openssl to 0.9.8za (msysgit PR #212)\par
+{\pntext\f1\'B7\tab}Config option to disable side-band-64k for transport (#101)\par
+{\pntext\f1\'B7\tab}Make git-http-backend, git-http-push, git-http-fetch available again (#174)\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.9.0-preview20140217\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.2 plus Windows-specific patches.\par
-{\pntext\f2\'B7\tab}Custom installer settings can be saved and loaded, for unsupervised installation on batches of machines (msysGit PR #168).\par
-{\pntext\f2\'B7\tab}Comes with VIM 7.4 (msysGit PR #170).\par
-{\pntext\f2\'B7\tab}Comes with ZLib 1.2.8.\par
-{\pntext\f2\'B7\tab}Comes with xargs 4.4.2.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.9.2 plus Windows-specific patches.\par
+{\pntext\f1\'B7\tab}Custom installer settings can be saved and loaded, for unsupervised installation on batches of machines (msysGit PR #168).\par
+{\pntext\f1\'B7\tab}Comes with VIM 7.4 (msysGit PR #170).\par
+{\pntext\f1\'B7\tab}Comes with ZLib 1.2.8.\par
+{\pntext\f1\'B7\tab}Comes with xargs 4.4.2.\par
+\pard\nowidctlpar\b\fs24\par
 \i\fs20 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Work around stack limitations when listing an insane number of tags (PR #154).\par
-{\pntext\f2\'B7\tab}Assorted test fixes (PRs #156, #158).\par
-{\pntext\f2\'B7\tab}Compile warning fix in config.c (PR #159).\par
-{\pntext\f2\'B7\tab}Ships with \i actual\i0  dos2unix and unix2dos.\par
-{\pntext\f2\'B7\tab}The installer no longer recommends mixing with Cygwin.\par
-{\pntext\f2\'B7\tab}Fixes a regression in Git-Cheetah which froze the Explorer upon calling \i Git Bash\i0  from the context menu (Git-Cheetah PRs #14 and #15).\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Work around stack limitations when listing an insane number of tags (PR #154).\par
+{\pntext\f1\'B7\tab}Assorted test fixes (PRs #156, #158).\par
+{\pntext\f1\'B7\tab}Compile warning fix in config.c (PR #159).\par
+{\pntext\f1\'B7\tab}Ships with \i actual\i0  dos2unix and unix2dos.\par
+{\pntext\f1\'B7\tab}The installer no longer recommends mixing with Cygwin.\par
+{\pntext\f1\'B7\tab}Fixes a regression in Git-Cheetah which froze the Explorer upon calling \i Git Bash\i0  from the context menu (Git-Cheetah PRs #14 and #15).\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.8.5.2-preview20131230\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.9.0 plus Windows-specific patches.\par
-{\pntext\f2\'B7\tab}Better work-arounds for Windows-specific path length limitations (pull request #122)\par
-{\pntext\f2\'B7\tab}Uses optimized TortoiseGitPLink when detected (msysGit pull request #154)\par
-{\pntext\f2\'B7\tab}Allow Windows users to use Linux Git on their files, using Vagrant \cf0{\field{\*\fldinst{HYPERLINK "http://www.vagrantup.com/"}}{\fldrslt{\ul\cf2 http://www.vagrantup.com/}}}\cf1\f0\fs20  (msysGit pull request #159)\par
-{\pntext\f2\'B7\tab}InnoSetup 5.5.4 is now used to generate the installer (msysGit pull request #167)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.9.0 plus Windows-specific patches.\par
+{\pntext\f1\'B7\tab}Better work-arounds for Windows-specific path length limitations (pull request #122)\par
+{\pntext\f1\'B7\tab}Uses optimized TortoiseGitPLink when detected (msysGit pull request #154)\par
+\pard\fi-288\li432 Allow Windows users to use Linux Git on their files, using Vagrant \cf0{\field{\*\fldinst{HYPERLINK "http://www.vagrantup.com/"}}{\fldrslt{\ul\cf2 http://www.vagrantup.com/}}}\cf1\f0\fs20  (msysGit pull request #159)\par
+\'b7\tab InnoSetup 5.5.4 is now used to generate the installer (msysGit pull request #167)\par
+\pard\nowidctlpar\b\fs24\par
 \i\fs20 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Fixed regression with interactive password prompt for remotes using the HTTPS protocol (issue #111)\par
-{\pntext\f2\'B7\tab}We now work around Subversion servers printing non-ISO-8601-compliant time stamps (pull request #126)\par
-{\pntext\f2\'B7\tab}The installer no longer sets the HOME environment variable (msysGit pull request #166)\par
-{\pntext\f2\'B7\tab}Perl no longer creates empty sys$command files when no stdin is connected (msysGit pull request #152)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Fixed regression with interactive password prompt for remotes using the HTTPS protocol (issue #111)\par
+{\pntext\f1\'B7\tab}We now work around Subversion servers printing non-ISO-8601-compliant time stamps (pull request #126)\par
+{\pntext\f1\'B7\tab}The installer no longer sets the HOME environment variable (msysGit pull request #166)\par
+{\pntext\f1\'B7\tab}Perl no longer creates empty sys$command files when no stdin is connected (msysGit pull request #152)\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.8.4-preview20130916\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.8.5.2 plus Windows-specific patches.\par
-{\pntext\f2\'B7\tab}Windows-specific patches are now grouped into pseudo-branches which should make future development robust despite slow uptake of the Windows-specific patches by upstream git.git.\par
-{\pntext\f2\'B7\tab}Works around more path length limitations (pull request #86)\par
-{\pntext\f2\'B7\tab}Has an optional stat() cache toggled via \i core.fscache\i0  (pull request #107)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.8.5.2 plus Windows-specific patches.\par
+{\pntext\f1\'B7\tab}Windows-specific patches are now grouped into pseudo-branches which should make future development robust despite slow uptake of the Windows-specific patches by upstream git.git.\par
+{\pntext\f1\'B7\tab}Works around more path length limitations (pull request #86)\par
+{\pntext\f1\'B7\tab}Has an optional stat() cache toggled via \i core.fscache\i0  (pull request #107)\par
+\pard\nowidctlpar\b\fs24\par
 \i\fs20 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Lots of installer fixes\par
-{\pntext\f2\'B7\tab}git-cmd: Handle home directory on a different drive correctly (pull request #146)\par
-{\pntext\f2\'B7\tab}git-cmd: add a helper to work with the ssh agent (pull request #135)\par
-{\pntext\f2\'B7\tab}Git-Cheetah: prevent duplicate menu entries (pull request #7)\par
-{\pntext\f2\'B7\tab}No longer replaces dos2unix with hd2u (a more powerful, but slightly incompatible version of dos2unix)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Lots of installer fixes\par
+{\pntext\f1\'B7\tab}git-cmd: Handle home directory on a different drive correctly (pull request #146)\par
+{\pntext\f1\'B7\tab}git-cmd: add a helper to work with the ssh agent (pull request #135)\par
+{\pntext\f1\'B7\tab}Git-Cheetah: prevent duplicate menu entries (pull request #7)\par
+{\pntext\f1\'B7\tab}No longer replaces dos2unix with hd2u (a more powerful, but slightly incompatible version of dos2unix)\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.8.3-preview20130601\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.8.4 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}Enabled unicode support in bash (#42 and #79)\par
-{\pntext\f2\'B7\tab}Included iconv.exe to assist in writing encoding filters\par
-{\pntext\f2\'B7\tab}Updated openssl to 0.9.8y\par
-\pard\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.8.4 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}Enabled unicode support in bash (#42 and #79)\par
+{\pntext\f1\'B7\tab}Included iconv.exe to assist in writing encoding filters\par
+{\pntext\f1\'B7\tab}Updated openssl to 0.9.8y\par
+\pard\nowidctlpar\par
 \b\i Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Avoid emitting non-printing chars to set console title.\par
-{\pntext\f2\'B7\tab}Various encoding fixes for the git test suite\par
-{\pntext\f2\'B7\tab}Ensure wincred handles empty username/password.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Avoid emitting non-printing chars to set console title.\par
+{\pntext\f1\'B7\tab}Various encoding fixes for the git test suite\par
+{\pntext\f1\'B7\tab}Ensure wincred handles empty username/password.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.8.1.2-preview20130201\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.8.3 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}Updated curl to 7.30.0 with IPv6 support enabled.\par
-{\pntext\f2\'B7\tab}Updated gnupg to 1.4.13\par
-{\pntext\f2\'B7\tab}Installer improvements for update or reinstall options.\par
-\pard\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.8.3 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}Updated curl to 7.30.0 with IPv6 support enabled.\par
+{\pntext\f1\'B7\tab}Updated gnupg to 1.4.13\par
+{\pntext\f1\'B7\tab}Installer improvements for update or reinstall options.\par
+\pard\nowidctlpar\par
 \b\i Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Avoid emitting color coded ls output to pipes.\par
-{\pntext\f2\'B7\tab}ccache binary updated to work on XP.\par
-{\pntext\f2\'B7\tab}Fixed association of .sh files setup by the installer.\par
-{\pntext\f2\'B7\tab}Fixed registry-based explorer menu items for XP (#95)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Avoid emitting color coded ls output to pipes.\par
+{\pntext\f1\'B7\tab}ccache binary updated to work on XP.\par
+{\pntext\f1\'B7\tab}Fixed association of .sh files setup by the installer.\par
+{\pntext\f1\'B7\tab}Fixed registry-based explorer menu items for XP (#95)\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.8.0-preview20121022\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.8.1.2 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}Includes support for using the Windows Credential API to store access credentials securely and provide access via the control panel tool to manage git credentials.\par
-{\pntext\f2\'B7\tab}Rebase autosquash support is now enabled by default. See \cf0{\field{\*\fldinst{HYPERLINK "http://goo.gl/2kwKJ"}}{\fldrslt{\ul\cf2 http://goo.gl/2kwKJ}}}\cf1\f0\fs20  for some suggestions on using this.\par
-{\pntext\f2\'B7\tab}All msysGit development is now done on 'master' and the devel branches are deleted.\par
-{\pntext\f2\'B7\tab}Tcl/Tk upgraded to 8.5.13.\par
-{\pntext\f2\'B7\tab}InnoSetup updated to 5.5.3 (Unicode)\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.8.1.2 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}Includes support for using the Windows Credential API to store access credentials securely and provide access via the control panel tool to manage git credentials.\par
+\pard\fi-288\li432 Rebase autosquash support is now enabled by default. See \cf0{\field{\*\fldinst{HYPERLINK "http://goo.gl/2kwKJ"}}{\fldrslt{\ul\cf2 http://goo.gl/2kwKJ}}}\cf1\f0\fs20  for some suggestions on using this.\par
+\'b7\tab All msysGit development is now done on 'master' and the devel branches are deleted.\par
+\'b7\tab Tcl/Tk upgraded to 8.5.13.\par
+\'b7\tab InnoSetup updated to 5.5.3 (Unicode)\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Some changes to avoid clashing with cygwin quite so often.\par
-{\pntext\f2\'B7\tab}The installer will attempt to handle files mirrored in the virtualstore.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Some changes to avoid clashing with cygwin quite so often.\par
+{\pntext\f1\'B7\tab}The installer will attempt to handle files mirrored in the virtualstore.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.11-preview20120710\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.8.0 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}InnoSetup updated to 5.5.2\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.8.0 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}InnoSetup updated to 5.5.2\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Fixed icon backgrounds on low color systems\par
-{\pntext\f2\'B7\tab}Avoid installer warnings during writability testing.\par
-{\pntext\f2\'B7\tab}Fix bash prompt handling due to upstream changes.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Fixed icon backgrounds on low color systems\par
+{\pntext\f1\'B7\tab}Avoid installer warnings during writability testing.\par
+{\pntext\f1\'B7\tab}Fix bash prompt handling due to upstream changes.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.11-preview20120704\par
 \i\fs20\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Propagate error codes from git wrapper (issue #43, #45)\par
-{\pntext\f2\'B7\tab}Include CAcert root certificates in SSL bundle (issue #37)\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Propagate error codes from git wrapper (issue #43, #45)\par
+{\pntext\f1\'B7\tab}Include CAcert root certificates in SSL bundle (issue #37)\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.11-preview20120620\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with the beautiful Git logo from \cf0{\field{\*\fldinst{HYPERLINK "http://git-scm.com/downloads/logos"}}{\fldrslt{\ul\cf2 http://git-scm.com/downloads/logos}}}\cf1\f0\fs20\par
-{\pntext\f2\'B7\tab}The installer no longer asks for the directory and program group when updating\par
-{\pntext\f2\'B7\tab}The installer now also auto-detects TortoisePlink that comes with TortoiseGit\par
-\pard\b\i\par
+\pard\fi-288\li432\b0\i0 Comes with the beautiful Git logo from \cf0{\field{\*\fldinst{HYPERLINK "http://git-scm.com/downloads/logos"}}{\fldrslt{\ul\cf2 http://git-scm.com/downloads/logos}}}\cf1\f0\fs20\par
+\'b7\tab The installer no longer asks for the directory and program group when updating\par
+\'b7\tab The installer now also auto-detects TortoisePlink that comes with TortoiseGit\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Git::SVN is correctly installed again\par
-{\pntext\f2\'B7\tab}The default format for git help is HTML again\par
-{\pntext\f2\'B7\tab}Replaced the git.cmd script with an exe wrapper to fix issue #36\par
-{\pntext\f2\'B7\tab}Fixed executable detection to speed up help -a display.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Git::SVN is correctly installed again\par
+{\pntext\f1\'B7\tab}The default format for git help is HTML again\par
+{\pntext\f1\'B7\tab}Replaced the git.cmd script with an exe wrapper to fix issue #36\par
+{\pntext\f1\'B7\tab}Fixed executable detection to speed up help -a display.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.10-preview20120409\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.11 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}Updated curl to 7.26.0\par
-{\pntext\f2\'B7\tab}Updated zlib to 1.2.7\par
-{\pntext\f2\'B7\tab}Updated Inno Setup to 5.5.0 and avoid creating symbolic links (issue #16)\par
-{\pntext\f2\'B7\tab}Updated openssl to 0.9.8x and support reading certificate files from Unicode paths (issue #24)\par
-{\pntext\f2\'B7\tab}Version resource built into git executables.\par
-{\pntext\f2\'B7\tab}Support the Large Address Aware feature to reduce chance out-of-memory on 64 bit windows when repacking large repositories.\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.11 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}Updated curl to 7.26.0\par
+{\pntext\f1\'B7\tab}Updated zlib to 1.2.7\par
+{\pntext\f1\'B7\tab}Updated Inno Setup to 5.5.0 and avoid creating symbolic links (issue #16)\par
+{\pntext\f1\'B7\tab}Updated openssl to 0.9.8x and support reading certificate files from Unicode paths (issue #24)\par
+{\pntext\f1\'B7\tab}Version resource built into git executables.\par
+{\pntext\f1\'B7\tab}Support the Large Address Aware feature to reduce chance out-of-memory on 64 bit windows when repacking large repositories.\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.11.\par
-{\pntext\f2\'B7\tab}Fix backspace/delete key handling in rxvt terminals.\par
-{\pntext\f2\'B7\tab}Fixed TERM setting to avoid a warning from less.\par
-{\pntext\f2\'B7\tab}Various fixes for handling unicode paths.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.11.\par
+{\pntext\f1\'B7\tab}Fix backspace/delete key handling in rxvt terminals.\par
+{\pntext\f1\'B7\tab}Fixed TERM setting to avoid a warning from less.\par
+{\pntext\f1\'B7\tab}Various fixes for handling unicode paths.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.9-preview20120201\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.10 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}UTF-8 file name support.\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.10 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}UTF-8 file name support.\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.10.\par
-{\pntext\f2\'B7\tab}Clarifications in the installer.\par
-{\pntext\f2\'B7\tab}Console output is now even thread-safer.\par
-{\pntext\f2\'B7\tab}Better support for foreign remotes (Mercurial remotes are disabled for now, due to lack of a Python version that can be compiled within the development environment).\par
-{\pntext\f2\'B7\tab}Git Cheetah no longer writes big log files directly to C:\\.\par
-{\pntext\f2\'B7\tab}Development environment: enhancements in the script to make a 64-bit setup.\par
-{\pntext\f2\'B7\tab}Development environment: enhancements to the 64-bit Cheetah build.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.10.\par
+{\pntext\f1\'B7\tab}Clarifications in the installer.\par
+{\pntext\f1\'B7\tab}Console output is now even thread-safer.\par
+{\pntext\f1\'B7\tab}Better support for foreign remotes (Mercurial remotes are disabled for now, due to lack of a Python version that can be compiled within the development environment).\par
+{\pntext\f1\'B7\tab}Git Cheetah no longer writes big log files directly to C:\\.\par
+{\pntext\f1\'B7\tab}Development environment: enhancements in the script to make a 64-bit setup.\par
+{\pntext\f1\'B7\tab}Development environment: enhancements to the 64-bit Cheetah build.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.8-preview20111206\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.9 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}Improvements to the installer running application detection.\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.9 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}Improvements to the installer running application detection.\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.9\par
-{\pntext\f2\'B7\tab}Fixed initialization of the git-cheetah submodule in net-installer.\par
-{\pntext\f2\'B7\tab}Fixed duplicated context menu items with git-cheetah on Windows 7.\par
-{\pntext\f2\'B7\tab}Patched gitk to display filenames when run on a subdirectory.\par
-{\pntext\f2\'B7\tab}Tabbed gitk preferences dialog to allow use on smaller screens.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.9\par
+{\pntext\f1\'B7\tab}Fixed initialization of the git-cheetah submodule in net-installer.\par
+{\pntext\f1\'B7\tab}Fixed duplicated context menu items with git-cheetah on Windows 7.\par
+{\pntext\f1\'B7\tab}Patched gitk to display filenames when run on a subdirectory.\par
+{\pntext\f1\'B7\tab}Tabbed gitk preferences dialog to allow use on smaller screens.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.7.1-preview20111027\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.8 plus Windows specific patches.\par
-{\pntext\f2\'B7\tab}Updated Tcl/Tk to 8.5.11 and libiconv to 1.14\par
-{\pntext\f2\'B7\tab}Some changes to support building with MSVC compiler.\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.8 plus Windows specific patches.\par
+{\pntext\f1\'B7\tab}Updated Tcl/Tk to 8.5.11 and libiconv to 1.14\par
+{\pntext\f1\'B7\tab}Some changes to support building with MSVC compiler.\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.8\par
-{\pntext\f2\'B7\tab}Git documentation submodule location fixed.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.8\par
+{\pntext\f1\'B7\tab}Git documentation submodule location fixed.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.7-preview20111014\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.7.1 plus patches.\par
-\pard\b\i\par
-Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.7.1\par
-{\pntext\f2\'B7\tab}Includes an important upstream fix for a bug that sometimes corrupts the git index file.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.7.1 plus patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\i\par
+{\pntext\f1\'B7\tab}Bugfixes\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.7.1\par
+{\pntext\f1\'B7\tab}Includes an important upstream fix for a bug that sometimes corrupts the git index file.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.6-preview20110708\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.7 plus patches.\par
-{\pntext\f2\'B7\tab}Updated gzip/gunzip and include unzip and gvim\par
-{\pntext\f2\'B7\tab}Primary repositories moved to github.com at \cf0{\field{\*\fldinst{HYPERLINK "http://github.com/msysgit/"}}{\fldrslt{\ul\cf2 http://github.com/msysgit/}}}\cf1\f0\fs20\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.7 plus patches.\par
+{\pntext\f1\'B7\tab}Updated gzip/gunzip and include unzip and gvim\par
+\pard\fi-288\li432 Primary repositories moved to github.com at \cf0{\field{\*\fldinst{HYPERLINK "http://github.com/msysgit/"}}{\fldrslt{\ul\cf2 http://github.com/msysgit/}}}\cf1\f0\fs20\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.7\par
-{\pntext\f2\'B7\tab}Re-enable vim highlighting\par
-{\pntext\f2\'B7\tab}Fixed issue with libiconv/libiconv-2 location\par
-{\pntext\f2\'B7\tab}Fixed regressions in Git Bash script\par
-{\pntext\f2\'B7\tab}Fixed installation of mergetools for difftool and mergetool use and launching of beyond compare on windows.\par
-{\pntext\f2\'B7\tab}Fixed warning about mising hostname during git fetch\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.7\par
+{\pntext\f1\'B7\tab}Re-enable vim highlighting\par
+{\pntext\f1\'B7\tab}Fixed issue with libiconv/libiconv-2 location\par
+{\pntext\f1\'B7\tab}Fixed regressions in Git Bash script\par
+{\pntext\f1\'B7\tab}Fixed installation of mergetools for difftool and mergetool use and launching of beyond compare on windows.\par
+{\pntext\f1\'B7\tab}Fixed warning about mising hostname during git fetch\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.4-preview20110211\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.6 plus patches.\par
-{\pntext\f2\'B7\tab}Updates to various supporting tools (openssl, iconv, InnoSetup)\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.6 plus patches.\par
+{\pntext\f1\'B7\tab}Updates to various supporting tools (openssl, iconv, InnoSetup)\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.6\par
-{\pntext\f2\'B7\tab}Fixes to msys compat layer for directory entry handling and command line globbing.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.6\par
+{\pntext\f1\'B7\tab}Fixes to msys compat layer for directory entry handling and command line globbing.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.3.2-preview20101025\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.4 plus patches.\par
-{\pntext\f2\'B7\tab}Includes antiword to enable viewing diffs of .doc files\par
-{\pntext\f2\'B7\tab}Includes poppler to enable viewing diffs of .pdf files\par
-{\pntext\f2\'B7\tab}Removes cygwin paths from the bash shell PATH\par
-\pard\b\i\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.4 plus patches.\par
+{\pntext\f1\'B7\tab}Includes antiword to enable viewing diffs of .doc files\par
+{\pntext\f1\'B7\tab}Includes poppler to enable viewing diffs of .pdf files\par
+{\pntext\f1\'B7\tab}Removes cygwin paths from the bash shell PATH\par
+\pard\nowidctlpar\b\i\par
 Bugfixes\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.4\par
-\pard\b\fs24\par
-Changes since Git-1.7.3.1-preview20101002\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.3.2 plus patches.\par
-\pard\par
-\b\fs24 Changes since Git-1.7.2.3-preview20100911\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.3.1 plus patches.\par
-{\pntext\f2\'B7\tab}Updated to Vim 7.3, file-5.04 and InnoSetup 5.3.11\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Issue 528 (remove uninstaller from Start Menu) was fixed\par
-{\pntext\f2\'B7\tab}Issue 527 (failing to find the certificate authority bundle) was fixed\par
-{\pntext\f2\'B7\tab}Issue 524 (remove broken and unused sdl-config file) was fixed\par
-{\pntext\f2\'B7\tab}Issue 523 (crash pushing to WebDAV remote) was fixed\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Please refer to the release notes for official Git 1.7.4\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+{\pntext\f1\'B7\tab}Changes since Git-1.7.3.1-preview20101002\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.3.2 plus patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\par
+\b\fs24{\pntext\f1\'B7\tab}Changes since Git-1.7.2.3-preview20100911\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.3.1 plus patches.\par
+{\pntext\f1\'B7\tab}Updated to Vim 7.3, file-5.04 and InnoSetup 5.3.11\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Issue 528 (remove uninstaller from Start Menu) was fixed\par
+{\pntext\f1\'B7\tab}Issue 527 (failing to find the certificate authority bundle) was fixed\par
+{\pntext\f1\'B7\tab}Issue 524 (remove broken and unused sdl-config file) was fixed\par
+{\pntext\f1\'B7\tab}Issue 523 (crash pushing to WebDAV remote) was fixed\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.1-preview20100612\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.2.3 plus patches.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Issue 519 (build problem with compat/regex/regexec.c) was fixed\par
-{\pntext\f2\'B7\tab}Issue 430 (size of panes not preserved in git-gui) was fixed\par
-{\pntext\f2\'B7\tab}Issue 411 (git init failing to work with CIFS paths) was fixed\par
-{\pntext\f2\'B7\tab}Issue 501 (failing to clone repo from root dir using relative path) was fixed\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.2.3 plus patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\li144\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Issue 519 (build problem with compat/regex/regexec.c) was fixed\par
+{\pntext\f1\'B7\tab}Issue 430 (size of panes not preserved in git-gui) was fixed\par
+{\pntext\f1\'B7\tab}Issue 411 (git init failing to work with CIFS paths) was fixed\par
+{\pntext\f1\'B7\tab}Issue 501 (failing to clone repo from root dir using relative path) was fixed\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.7.0.2-preview20100309\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with Git 1.7.1 plus patches.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Issue 27 (git-send-mail not working properly) was fixed again\par
-{\pntext\f2\'B7\tab}Issue 433 (error while running git svn fetch) was fixed\par
-{\pntext\f2\'B7\tab}Issue 427 (Gitk reports error: "couldn't compile regular expression pattern: invalid repetition count(s)") was fixed\par
-{\pntext\f2\'B7\tab}Issue 192 (output truncated) was fixed again\par
-{\pntext\f2\'B7\tab}Issue 365 (Out of memory? mmap failed) was fixed\par
-{\pntext\f2\'B7\tab}Issue 387 (gitk reports "error: couldn't execute "git:" file name too long") was fixed\par
-{\pntext\f2\'B7\tab}Issue 409 (checkout of large files to network drive fails on XP) was fixed\par
-{\pntext\f2\'B7\tab}Issue 428 (The return value of git.cmd is not the same as git.exe) was fixed\par
-{\pntext\f2\'B7\tab}Issue 444 (Git Bash Here returns a "File not found error" in Windows 7 Professional - 64 bits) was fixed\par
-{\pntext\f2\'B7\tab}Issue 445 (git help does nothing) was fixed\par
-{\pntext\f2\'B7\tab}Issue 450 ("git --bare init" shouldn't set the directory to hidden.) was fixed\par
-{\pntext\f2\'B7\tab}Issue 456 (git script fails with error code 1) was fixed\par
-{\pntext\f2\'B7\tab}Issue 469 (error launch wordpad in last netinstall) was fixed\par
-{\pntext\f2\'B7\tab}Issue 474 (git update-index --index-info silently does nothing) was fixed\par
-{\pntext\f2\'B7\tab}Issue 482 (Add documentation to avoid "fatal: $HOME not set" error) was fixed\par
-{\pntext\f2\'B7\tab}Issue 489 (git.cmd issues warning if %COMSPEC% has spaces in it) was fixed\par
-{\pntext\f2\'B7\tab}Issue 436 ("mkdir : No such file or directory" error while using git-svn to fetch or rebase) was fixed\par
-{\pntext\f2\'B7\tab}Issue 440 (Uninstall does not remove cheetah.) was fixed\par
-{\pntext\f2\'B7\tab}Issue 441 (Git-1.7.0.2-preview20100309.exe installer fails with unwritable msys-1.0.dll when ssh-agent is running) was fixed\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with Git 1.7.1 plus patches.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\li144\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Issue 27 (git-send-mail not working properly) was fixed again\par
+{\pntext\f1\'B7\tab}Issue 433 (error while running git svn fetch) was fixed\par
+{\pntext\f1\'B7\tab}Issue 427 (Gitk reports error: "couldn't compile regular expression pattern: invalid repetition count(s)") was fixed\par
+{\pntext\f1\'B7\tab}Issue 192 (output truncated) was fixed again\par
+{\pntext\f1\'B7\tab}Issue 365 (Out of memory? mmap failed) was fixed\par
+{\pntext\f1\'B7\tab}Issue 387 (gitk reports "error: couldn't execute "git:" file name too long") was fixed\par
+{\pntext\f1\'B7\tab}Issue 409 (checkout of large files to network drive fails on XP) was fixed\par
+{\pntext\f1\'B7\tab}Issue 428 (The return value of git.cmd is not the same as git.exe) was fixed\par
+{\pntext\f1\'B7\tab}Issue 444 (Git Bash Here returns a "File not found error" in Windows 7 Professional - 64 bits) was fixed\par
+{\pntext\f1\'B7\tab}Issue 445 (git help does nothing) was fixed\par
+{\pntext\f1\'B7\tab}Issue 450 ("git --bare init" shouldn't set the directory to hidden.) was fixed\par
+{\pntext\f1\'B7\tab}Issue 456 (git script fails with error code 1) was fixed\par
+{\pntext\f1\'B7\tab}Issue 469 (error launch wordpad in last netinstall) was fixed\par
+{\pntext\f1\'B7\tab}Issue 474 (git update-index --index-info silently does nothing) was fixed\par
+{\pntext\f1\'B7\tab}Issue 482 (Add documentation to avoid "fatal: $HOME not set" error) was fixed\par
+{\pntext\f1\'B7\tab}Issue 489 (git.cmd issues warning if %COMSPEC% has spaces in it) was fixed\par
+{\pntext\f1\'B7\tab}Issue 436 ("mkdir : No such file or directory" error while using git-svn to fetch or rebase) was fixed\par
+{\pntext\f1\'B7\tab}Issue 440 (Uninstall does not remove cheetah.) was fixed\par
+{\pntext\f1\'B7\tab}Issue 441 (Git-1.7.0.2-preview20100309.exe installer fails with unwritable msys-1.0.dll when ssh-agent is running) was fixed\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.5.1-preview20091022\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official Git 1.7.0.2.\par
-{\pntext\f2\'B7\tab}Comes with Git-Cheetah (on 32-bit Windows only, for now).\par
-{\pntext\f2\'B7\tab}Comes with connect.exe, a SOCKS proxy.\par
-{\pntext\f2\'B7\tab}Tons of improvements in the installer, thanks to Sebastian Schuberth.\par
-{\pntext\f2\'B7\tab}On Vista, if possible, symlinks are used for the built-ins.\par
-{\pntext\f2\'B7\tab}Features Hany's dos2unix tool, thanks to Sebastian Schuberth.\par
-{\pntext\f2\'B7\tab}Updated Tcl/Tk to version 8.5.8 (thanks Pat Thoyts!).\par
-{\pntext\f2\'B7\tab}By default, only .git/ is hidden, to work around a bug in Eclipse (thanks to Erik Faye-Lund).\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Fixed threaded grep (thanks to Heiko Voigt).\par
-{\pntext\f2\'B7\tab}git gui was fixed for all kinds of worktree-related failures (thanks Pat Thoyts).\par
-{\pntext\f2\'B7\tab}git gui now fully supports themed widgets (thanks Pat Thoyts and Heiko Voigt).\par
-{\pntext\f2\'B7\tab}Git no longer complains about an unset RUNTIME_PREFIX (thanks Johannes Sixt).\par
-{\pntext\f2\'B7\tab}git gui can Explore Working Copy on Windows again (thanks Markus Heidelberg).\par
-{\pntext\f2\'B7\tab}git gui can create shortcuts again (fixes issue 425, thanks Heiko Voigt).\par
-{\pntext\f2\'B7\tab}When "git checkout" cannot overwrite files because they are in use, it will offer to try again, giving the user a chance to release the file (thanks Heiko Voigt).\par
-{\pntext\f2\'B7\tab}Ctrl+W will close gitk (thanks Jens Lehmann).\par
-{\pntext\f2\'B7\tab}git gui no longer binds Ctrl+C, which caused problems when trying to use said shortcut for the clipboard operation "Copy" (fixes issue 423, thanks Pat Thoyts).\par
-{\pntext\f2\'B7\tab}gitk does not give up when the command line length limit is reached (issue 387).\par
-{\pntext\f2\'B7\tab}The exit code is fixed when Git.cmd is called from cmd.exe (thanks Alexey Borzenkov).\par
-{\pntext\f2\'B7\tab}When launched via the (non-Cheetah) shell extension, the window icon is now correct (thanks Sebastian Schuberth).\par
-{\pntext\f2\'B7\tab}Uses a TrueType font for the console, to be able to render UTF-8 correctly.\par
-{\pntext\f2\'B7\tab}Clarified the installer's line ending options (issue 370).\par
-{\pntext\f2\'B7\tab}Substantially speeded up startup time from cmd unless NO_FSTAB_THREAD is set (thanks Johannes Sixt).\par
-{\pntext\f2\'B7\tab}Update msys-1.0.dll yet again, to handle quoted parameters better (thanks Heiko Voigt).\par
-{\pntext\f2\'B7\tab}Updated cURL to a version that supports SSPI.\par
-{\pntext\f2\'B7\tab}Updated tar to handle the pax headers generated by \i git archive\i0 .\par
-{\pntext\f2\'B7\tab}Updated sed to a version that can handle the filter-branch examples.\par
-{\pntext\f2\'B7\tab}.git* files can be associated with the default text editor (issue 397).\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official Git 1.7.0.2.\par
+{\pntext\f1\'B7\tab}Comes with Git-Cheetah (on 32-bit Windows only, for now).\par
+{\pntext\f1\'B7\tab}Comes with connect.exe, a SOCKS proxy.\par
+{\pntext\f1\'B7\tab}Tons of improvements in the installer, thanks to Sebastian Schuberth.\par
+{\pntext\f1\'B7\tab}On Vista, if possible, symlinks are used for the built-ins.\par
+{\pntext\f1\'B7\tab}Features Hany's dos2unix tool, thanks to Sebastian Schuberth.\par
+{\pntext\f1\'B7\tab}Updated Tcl/Tk to version 8.5.8 (thanks Pat Thoyts!).\par
+{\pntext\f1\'B7\tab}By default, only .git/ is hidden, to work around a bug in Eclipse (thanks to Erik Faye-Lund).\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Fixed threaded grep (thanks to Heiko Voigt).\par
+{\pntext\f1\'B7\tab}git gui was fixed for all kinds of worktree-related failures (thanks Pat Thoyts).\par
+{\pntext\f1\'B7\tab}git gui now fully supports themed widgets (thanks Pat Thoyts and Heiko Voigt).\par
+{\pntext\f1\'B7\tab}Git no longer complains about an unset RUNTIME_PREFIX (thanks Johannes Sixt).\par
+{\pntext\f1\'B7\tab}git gui can Explore Working Copy on Windows again (thanks Markus Heidelberg).\par
+{\pntext\f1\'B7\tab}git gui can create shortcuts again (fixes issue 425, thanks Heiko Voigt).\par
+{\pntext\f1\'B7\tab}When "git checkout" cannot overwrite files because they are in use, it will offer to try again, giving the user a chance to release the file (thanks Heiko Voigt).\par
+{\pntext\f1\'B7\tab}Ctrl+W will close gitk (thanks Jens Lehmann).\par
+{\pntext\f1\'B7\tab}git gui no longer binds Ctrl+C, which caused problems when trying to use said shortcut for the clipboard operation "Copy" (fixes issue 423, thanks Pat Thoyts).\par
+{\pntext\f1\'B7\tab}gitk does not give up when the command line length limit is reached (issue 387).\par
+{\pntext\f1\'B7\tab}The exit code is fixed when Git.cmd is called from cmd.exe (thanks Alexey Borzenkov).\par
+{\pntext\f1\'B7\tab}When launched via the (non-Cheetah) shell extension, the window icon is now correct (thanks Sebastian Schuberth).\par
+{\pntext\f1\'B7\tab}Uses a TrueType font for the console, to be able to render UTF-8 correctly.\par
+{\pntext\f1\'B7\tab}Clarified the installer's line ending options (issue 370).\par
+{\pntext\f1\'B7\tab}Substantially speeded up startup time from cmd unless NO_FSTAB_THREAD is set (thanks Johannes Sixt).\par
+{\pntext\f1\'B7\tab}Update msys-1.0.dll yet again, to handle quoted parameters better (thanks Heiko Voigt).\par
+{\pntext\f1\'B7\tab}Updated cURL to a version that supports SSPI.\par
+{\pntext\f1\'B7\tab}Updated tar to handle the pax headers generated by \i git archive\i0 .\par
+{\pntext\f1\'B7\tab}Updated sed to a version that can handle the filter-branch examples.\par
+{\pntext\f1\'B7\tab}.git* files can be associated with the default text editor (issue 397).\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.4-preview20090729\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.5.1.\par
-{\pntext\f2\'B7\tab}Thanks to Johan 't Hart, files and directories starting with a single dot (such as '.git') will now be marked hidden (you can disable this setting with core.hideDotFiles=false in your config) (Issue 288).\par
-{\pntext\f2\'B7\tab}Thanks to Thorvald Natvig, Git on Windows can simulate symbolic links by using reparse points when available.  For technical reasons, this only works for symbolic links pointing to files, not directories.\par
-{\pntext\f2\'B7\tab}A lot of work has been put into making it possible to compile Git's source code (the part written in C, of course, not the scripts) with Microsoft Visual Studio.  This work is ongoing.\par
-{\pntext\f2\'B7\tab}Thanks to Sebastian Schuberth, we only offer the (Tortoise)Plink option in the installer if the presence of Plink was detected \ul and\ulnone  at least one Putty session was found..\par
-{\pntext\f2\'B7\tab}Thanks to Sebastian Schuberth, the installer has a nicer icon now.\par
-{\pntext\f2\'B7\tab}Some more work by Sebastian Schuberth was done on better integration of Plink (Issues 305 & 319).\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432  Thanks to Sebastian Schuberth, \i git svn\i0  picks up the SSH setting specified with the installer (Issue 305).\par
-\pard\b\fs24\par
-Changes since Git-1.6.3.2-preview20090608\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.4.\par
-{\pntext\f2\'B7\tab}Supports \cf0{\field{\*\fldinst{HYPERLINK "https://"}}{\fldrslt{\ul\cf2 https://}}}\cf1\f0\fs20  URLs, thanks to Erik Faye-Lund.\par
-{\pntext\f2\'B7\tab}Supports send-email, thanks to Erik Faye-Lund (Issue 27).\par
-{\pntext\f2\'B7\tab}Updated Tcl/Tk to version 8.5.7, thanks to Pat Thoyts.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 The home directory is now discovered properly (Issues 108 & 259).\par
-{\pntext\f2\'B7\tab}IPv6 is supported now, thanks to Martin Martin Storsj\cf0\f1\'f6 (Issue 182).\cf1\f0\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.5.1.\par
+{\pntext\f1\'B7\tab}Thanks to Johan 't Hart, files and directories starting with a single dot (such as '.git') will now be marked hidden (you can disable this setting with core.hideDotFiles=false in your config) (Issue 288).\par
+{\pntext\f1\'B7\tab}Thanks to Thorvald Natvig, Git on Windows can simulate symbolic links by using reparse points when available.  For technical reasons, this only works for symbolic links pointing to files, not directories.\par
+{\pntext\f1\'B7\tab}A lot of work has been put into making it possible to compile Git's source code (the part written in C, of course, not the scripts) with Microsoft Visual Studio.  This work is ongoing.\par
+{\pntext\f1\'B7\tab}Thanks to Sebastian Schuberth, we only offer the (Tortoise)Plink option in the installer if the presence of Plink was detected \ul and\ulnone  at least one Putty session was found..\par
+{\pntext\f1\'B7\tab}Thanks to Sebastian Schuberth, the installer has a nicer icon now.\par
+{\pntext\f1\'B7\tab}Some more work by Sebastian Schuberth was done on better integration of Plink (Issues 305 & 319).\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432  Thanks to Sebastian Schuberth, \i git svn\i0  picks up the SSH setting specified with the installer (Issue 305).\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+{\pntext\f1\'B7\tab}Changes since Git-1.6.3.2-preview20090608\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.4.\par
+\pard\fi-288\li432 Supports \cf0{\field{\*\fldinst{HYPERLINK "https://"}}{\fldrslt{\ul\cf2 https://}}}\cf1\f0\fs20  URLs, thanks to Erik Faye-Lund.\par
+\'b7\tab Supports send-email, thanks to Erik Faye-Lund (Issue 27).\par
+\'b7\tab Updated Tcl/Tk to version 8.5.7, thanks to Pat Thoyts.\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 The home directory is now discovered properly (Issues 108 & 259).\par
+{\pntext\f1\'B7\tab}IPv6 is supported now, thanks to Martin Martin Storsj\cf0\'f6 (Issue 182).\cf1\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.3-preview20090507\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.3.2.\par
-{\pntext\f2\'B7\tab}Uses TortoisePlink instead of Plink if available.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Plink errors out rather than hanging when the user needs to accept a host key first (Issue 96).\par
-{\pntext\f2\'B7\tab}The user home directory is inferred from $HOMEDRIVE\\$HOMEPATH instead of $HOME (Issue 108).\par
-{\pntext\f2\'B7\tab}The environment setting $CYGWIN=tty is ignored (Issues 138, 248 and 251).\par
-{\pntext\f2\'B7\tab}The "ls" command shows non-ASCII filenames correctly now (Issue 188).\par
-{\pntext\f2\'B7\tab}Adds more syntax files for vi (Issue 250).\par
-{\pntext\f2\'B7\tab}$HOME/.bashrc is included last from /etc/profile, allowing .bashrc to override all settings in /etc/profile (Issue 255).\par
-{\pntext\f2\'B7\tab}Completion is case-insensitive again (Issue 256).\par
-{\pntext\f2\'B7\tab}The "start" command can handle arguments with spaces now (Issue 258).\par
-{\pntext\f2\'B7\tab}For some Git commands (such as "git commit"), vi no longer "restores" the cursor position.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.3.2.\par
+{\pntext\f1\'B7\tab}Uses TortoisePlink instead of Plink if available.\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Plink errors out rather than hanging when the user needs to accept a host key first (Issue 96).\par
+{\pntext\f1\'B7\tab}The user home directory is inferred from $HOMEDRIVE\\$HOMEPATH instead of $HOME (Issue 108).\par
+{\pntext\f1\'B7\tab}The environment setting $CYGWIN=tty is ignored (Issues 138, 248 and 251).\par
+{\pntext\f1\'B7\tab}The "ls" command shows non-ASCII filenames correctly now (Issue 188).\par
+{\pntext\f1\'B7\tab}Adds more syntax files for vi (Issue 250).\par
+{\pntext\f1\'B7\tab}$HOME/.bashrc is included last from /etc/profile, allowing .bashrc to override all settings in /etc/profile (Issue 255).\par
+{\pntext\f1\'B7\tab}Completion is case-insensitive again (Issue 256).\par
+{\pntext\f1\'B7\tab}The "start" command can handle arguments with spaces now (Issue 258).\par
+{\pntext\f1\'B7\tab}For some Git commands (such as "git commit"), vi no longer "restores" the cursor position.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.2.2-preview20090408\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.3.\par
-{\pntext\f2\'B7\tab}Thanks to Marius Storm-Olsen, Git has a substantially faster readdir() implementation now.\par
-{\pntext\f2\'B7\tab}Marius Storm-Olsen also contributed a patch to include nedmalloc, again speeding up Git noticably.\par
-{\pntext\f2\'B7\tab}Compiled with GCC 4.4.0\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Portable Git contains a README.portable.\par
-{\pntext\f2\'B7\tab}Portable Git now actually includes the builtins.\par
-{\pntext\f2\'B7\tab}Portable Git includes git-cmd.bat and git-bash.bat.\par
-{\pntext\f2\'B7\tab}Portable Git is now shipped as a .7z; it still is a self-extracting archive if you rename it to .exe.\par
-{\pntext\f2\'B7\tab}Git includes the Perl Encode module now.\par
-{\pntext\f2\'B7\tab}Git now includes the filter-branch tool.\par
-{\pntext\f2\'B7\tab}There is a workaround for a Windows 7 regression triggering a crash in the progress reporting (e.g. during a clone). This fixes issues 236 and 247.\par
-{\pntext\f2\'B7\tab}gitk tries not to crash when it is closed while reading references (Issue 125, thanks Pat Thoyts).\par
-{\pntext\f2\'B7\tab}In some setups, hard-linking is not as reliable as it should be, so we have a workaround which avoids hard links in some situations (Issues 222 and 229).\par
-{\pntext\f2\'B7\tab}git-svn sets core.autocrlf to false now, hopefully shutting up most of the git-svn reports.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.3.\par
+{\pntext\f1\'B7\tab}Thanks to Marius Storm-Olsen, Git has a substantially faster readdir() implementation now.\par
+{\pntext\f1\'B7\tab}Marius Storm-Olsen also contributed a patch to include nedmalloc, again speeding up Git noticably.\par
+{\pntext\f1\'B7\tab}Compiled with GCC 4.4.0\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Portable Git contains a README.portable.\par
+{\pntext\f1\'B7\tab}Portable Git now actually includes the builtins.\par
+{\pntext\f1\'B7\tab}Portable Git includes git-cmd.bat and git-bash.bat.\par
+{\pntext\f1\'B7\tab}Portable Git is now shipped as a .7z; it still is a self-extracting archive if you rename it to .exe.\par
+{\pntext\f1\'B7\tab}Git includes the Perl Encode module now.\par
+{\pntext\f1\'B7\tab}Git now includes the filter-branch tool.\par
+{\pntext\f1\'B7\tab}There is a workaround for a Windows 7 regression triggering a crash in the progress reporting (e.g. during a clone). This fixes issues 236 and 247.\par
+{\pntext\f1\'B7\tab}gitk tries not to crash when it is closed while reading references (Issue 125, thanks Pat Thoyts).\par
+{\pntext\f1\'B7\tab}In some setups, hard-linking is not as reliable as it should be, so we have a workaround which avoids hard links in some situations (Issues 222 and 229).\par
+{\pntext\f1\'B7\tab}git-svn sets core.autocrlf to false now, hopefully shutting up most of the git-svn reports.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.2.1-preview20090322\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.2.2.\par
-{\pntext\f2\'B7\tab}Upgraded Tcl/Tk to 8.5.5.\par
-{\pntext\f2\'B7\tab}TortoiseMerge is supported by mergetool now.\par
-{\pntext\f2\'B7\tab}Uses pthreads (faster garbage collection on multi-core machines).\par
-{\pntext\f2\'B7\tab}The test suite passes!\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Renaming was made more robust (due to Explorer or some virus scanners, files could not be renamed at the first try, so we have to try multiple times).\par
-{\pntext\f2\'B7\tab}Johannes Sixt made \ul lots\ulnone  of changes to the test-suite to identify properly which tests should pass, and which ones cannot pass due to limitations of the platform.\par
-{\pntext\f2\'B7\tab}Support PAGERs with spaces in their filename.\par
-{\pntext\f2\'B7\tab}Quite a few changes were undone which we needed in the olden days of msysGit.\par
-{\pntext\f2\'B7\tab}Fall back to / when HOME cannot be set to the real home directory due to locale issues (works around Issue 108 for the moment).\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.2.2.\par
+{\pntext\f1\'B7\tab}Upgraded Tcl/Tk to 8.5.5.\par
+{\pntext\f1\'B7\tab}TortoiseMerge is supported by mergetool now.\par
+{\pntext\f1\'B7\tab}Uses pthreads (faster garbage collection on multi-core machines).\par
+{\pntext\f1\'B7\tab}The test suite passes!\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Renaming was made more robust (due to Explorer or some virus scanners, files could not be renamed at the first try, so we have to try multiple times).\par
+{\pntext\f1\'B7\tab}Johannes Sixt made \ul lots\ulnone  of changes to the test-suite to identify properly which tests should pass, and which ones cannot pass due to limitations of the platform.\par
+{\pntext\f1\'B7\tab}Support PAGERs with spaces in their filename.\par
+{\pntext\f1\'B7\tab}Quite a few changes were undone which we needed in the olden days of msysGit.\par
+{\pntext\f1\'B7\tab}Fall back to / when HOME cannot be set to the real home directory due to locale issues (works around Issue 108 for the moment).\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.2-preview20090308\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.2.1.\par
-{\pntext\f2\'B7\tab}A portable application is shipped in addition to the installer (Issue 195).\par
-{\pntext\f2\'B7\tab}Comes with a Windows-specific mmap() implementation (Issue 198).\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 ANSI control characters are no longer shown verbatim (Issue 124).\par
-{\pntext\f2\'B7\tab}Temporary files are created respecting core.autocrlf (Issue 177).\par
-{\pntext\f2\'B7\tab}The Git Bash prompt is colorful again (Issue 199).\par
-{\pntext\f2\'B7\tab}Fixed crash when hardlinking during a clone failed (Issue 204).\par
-{\pntext\f2\'B7\tab}An infinite loop was fixed in git-gui (Issue 205).\par
-{\pntext\f2\'B7\tab}The ssh protocol is always used with plink.exe (Issue 209).\par
-{\pntext\f2\'B7\tab}More vim files are shipped now, so that syntax highlighting works.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.2.1.\par
+{\pntext\f1\'B7\tab}A portable application is shipped in addition to the installer (Issue 195).\par
+{\pntext\f1\'B7\tab}Comes with a Windows-specific mmap() implementation (Issue 198).\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 ANSI control characters are no longer shown verbatim (Issue 124).\par
+{\pntext\f1\'B7\tab}Temporary files are created respecting core.autocrlf (Issue 177).\par
+{\pntext\f1\'B7\tab}The Git Bash prompt is colorful again (Issue 199).\par
+{\pntext\f1\'B7\tab}Fixed crash when hardlinking during a clone failed (Issue 204).\par
+{\pntext\f1\'B7\tab}An infinite loop was fixed in git-gui (Issue 205).\par
+{\pntext\f1\'B7\tab}The ssh protocol is always used with plink.exe (Issue 209).\par
+{\pntext\f1\'B7\tab}More vim files are shipped now, so that syntax highlighting works.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.1-preview20081225\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.2.\par
-{\pntext\f2\'B7\tab}Comes with upgraded vim 7.2.\par
-{\pntext\f2\'B7\tab}Compiled with GCC 4.3.3.\par
-{\pntext\f2\'B7\tab}The user can choose the preferred CR/LF behavior in the installer now.\par
-{\pntext\f2\'B7\tab}Peter Kodl contributed support for hardlinks on Windows.\par
-{\pntext\f2\'B7\tab}The bash prompt shows information about the current repository.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 If supported by the file system, pack files can grow larger than 2gb.\par
-{\pntext\f2\'B7\tab}Comes with updated msys-1.0.dll (should fix some Vista issues).\par
-{\pntext\f2\'B7\tab}Assorted fixes to support the new libexec/git-core/ layout better.\par
-{\pntext\f2\'B7\tab}Read-only files can be properly replaced now.\par
-{\pntext\f2\'B7\tab}git-svn is included again (original caveats still apply).\par
-{\pntext\f2\'B7\tab}Obsolete programs from previous installations are cleaned up.\par
-\pard\li144\par
-\pard\b\fs24 Changes since Git-1.6.0.2-preview20080923\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.2.\par
+{\pntext\f1\'B7\tab}Comes with upgraded vim 7.2.\par
+{\pntext\f1\'B7\tab}Compiled with GCC 4.3.3.\par
+{\pntext\f1\'B7\tab}The user can choose the preferred CR/LF behavior in the installer now.\par
+{\pntext\f1\'B7\tab}Peter Kodl contributed support for hardlinks on Windows.\par
+{\pntext\f1\'B7\tab}The bash prompt shows information about the current repository.\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 If supported by the file system, pack files can grow larger than 2gb.\par
+{\pntext\f1\'B7\tab}Comes with updated msys-1.0.dll (should fix some Vista issues).\par
+{\pntext\f1\'B7\tab}Assorted fixes to support the new libexec/git-core/ layout better.\par
+{\pntext\f1\'B7\tab}Read-only files can be properly replaced now.\par
+{\pntext\f1\'B7\tab}git-svn is included again (original caveats still apply).\par
+{\pntext\f1\'B7\tab}Obsolete programs from previous installations are cleaned up.\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\fs24 Changes since Git-1.6.0.2-preview20080923\par
 \i\fs20\par
 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.1.\par
-{\pntext\f2\'B7\tab}Avoid useless console windows.\par
-{\pntext\f2\'B7\tab}Installer remembers how to handle PATH. \par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.1.\par
+{\pntext\f1\'B7\tab}Avoid useless console windows.\par
+{\pntext\f1\'B7\tab}Installer remembers how to handle PATH. \par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.6.0.2-preview20080921\par
 \i\fs20\par
 Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 ssh works again.\par
-{\pntext\f2\'B7\tab}'git add -p' works again.\par
-{\pntext\f2\'B7\tab}Various programs that aborted with 'Assertion failed: argv0_path' are fixed.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 ssh works again.\par
+{\pntext\f1\'B7\tab}'git add -p' works again.\par
+{\pntext\f1\'B7\tab}Various programs that aborted with 'Assertion failed: argv0_path' are fixed.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.5.6.1-preview20080701\par
 \i\fs20\par
 Removed Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 git svn is excluded from the end-user installer (see Known Issues).\par
-\pard\b\fs24\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.6.0.2.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 No Windows-specific bugfixes.\par
-\pard\b\fs24\par
-Changes since Git-1.5.6-preview20080622\par
-\par
-\i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.5.6.1.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Includes fixed msys-1.0.dll that supports Vista and Windows Server 2008 (Issue 122).\par
-{\pntext\f2\'B7\tab}cmd wrappers do no longer switch off echo.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 git svn is excluded from the end-user installer (see Known Issues).\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.6.0.2.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\li144\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 No Windows-specific bugfixes.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+{\pntext\f1\'B7\tab}Changes since Git-1.5.6-preview20080622\par
+{\pntext\f1\'B7\tab}\par
+\i\fs20{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.5.6.1.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\li144\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Includes fixed msys-1.0.dll that supports Vista and Windows Server 2008 (Issue 122).\par
+{\pntext\f1\'B7\tab}cmd wrappers do no longer switch off echo.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.5.5-preview20080413\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.5.6.\par
-{\pntext\f2\'B7\tab}Installer supports configuring a user provided Plink (PuTTY).\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Comes with tweaked msys-1.0.dll to solve some command line mangling issues.\par
-{\pntext\f2\'B7\tab}cmd wrapper does no longer close the command window.\par
-{\pntext\f2\'B7\tab}Programs in the system PATH, for example editors, can be launched from Git without specifying their full path.\par
-{\pntext\f2\'B7\tab}"git stash apply stash@\{1\}" works.\par
-{\pntext\f2\'B7\tab}Comes with basic ANSI control code emulation for the Windows console to avoid wrapping of pull/merge's diffstats.\par
-{\pntext\f2\'B7\tab}Git correctly passes port numbers to PuTTY's Plink \par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.5.6.\par
+{\pntext\f1\'B7\tab}Installer supports configuring a user provided Plink (PuTTY).\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Comes with tweaked msys-1.0.dll to solve some command line mangling issues.\par
+{\pntext\f1\'B7\tab}cmd wrapper does no longer close the command window.\par
+{\pntext\f1\'B7\tab}Programs in the system PATH, for example editors, can be launched from Git without specifying their full path.\par
+{\pntext\f1\'B7\tab}"git stash apply stash@\{1\}" works.\par
+{\pntext\f1\'B7\tab}Comes with basic ANSI control code emulation for the Windows console to avoid wrapping of pull/merge's diffstats.\par
+{\pntext\f1\'B7\tab}Git correctly passes port numbers to PuTTY's Plink \par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.5.4-preview20080202\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.5.5.\par
-{\pntext\f2\'B7\tab}core.autocrlf is enabled (true) by default. This means git converts to Windows line endings (CRLF) during checkout and converts to Unix line endings (LF) during commit. This is the right choice for cross-platform projects. If the conversion is not reversible, git warns the user. The installer warns about the new default before the installation starts.\par
-{\pntext\f2\'B7\tab}The user does no longer have to "accept" the GPL but only needs to press "continue".\par
-{\pntext\f2\'B7\tab}Installer deletes shell scripts that have been replaced by builtins. Upgrading should be safer.\par
-{\pntext\f2\'B7\tab}Supports "git svn". Note that the performance might be below your expectation.\par
-\pard\li144\par
-\pard\b\i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Newer ssh fixes connection failures (issue 74).\par
-{\pntext\f2\'B7\tab}Comes with MSys-1.0.11-20071204.  This should solve some "fork: resource unavailable" issues.\par
-{\pntext\f2\'B7\tab}All DLLs are rebased to avoid problems with "fork" on Vista.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.5.5.\par
+{\pntext\f1\'B7\tab}core.autocrlf is enabled (true) by default. This means git converts to Windows line endings (CRLF) during checkout and converts to Unix line endings (LF) during commit. This is the right choice for cross-platform projects. If the conversion is not reversible, git warns the user. The installer warns about the new default before the installation starts.\par
+{\pntext\f1\'B7\tab}The user does no longer have to "accept" the GPL but only needs to press "continue".\par
+{\pntext\f1\'B7\tab}Installer deletes shell scripts that have been replaced by builtins. Upgrading should be safer.\par
+{\pntext\f1\'B7\tab}Supports "git svn". Note that the performance might be below your expectation.\par
+\pard\nowidctlpar\li144\par
+\pard\nowidctlpar\b\i Bugfixes\b0\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Newer ssh fixes connection failures (issue 74).\par
+{\pntext\f1\'B7\tab}Comes with MSys-1.0.11-20071204.  This should solve some "fork: resource unavailable" issues.\par
+{\pntext\f1\'B7\tab}All DLLs are rebased to avoid problems with "fork" on Vista.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.5.3.6-preview20071126\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Comes with official git 1.5.4.\par
-{\pntext\f2\'B7\tab}Some commands that are not yet suppoted on Windows are no longer included (see Known Issues above).\par
-{\pntext\f2\'B7\tab}Release notes are displayed in separate window.\b\fs24\par
-\b0\fs20{\pntext\f2\'B7\tab}Includes qsort replacement to improve performance on Windows 2000.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Comes with official git 1.5.4.\par
+{\pntext\f1\'B7\tab}Some commands that are not yet suppoted on Windows are no longer included (see Known Issues above).\par
+{\pntext\f1\'B7\tab}Release notes are displayed in separate window.\b\fs24\par
+\b0\fs20{\pntext\f1\'B7\tab}Includes qsort replacement to improve performance on Windows 2000.\par
+\pard\nowidctlpar\b\fs24\par
 \i\fs20 Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Fixes invalid error message that setup.ini cannot be deleted on uninstall.\par
-{\pntext\f2\'B7\tab}Setup tries harder to finish the installation and reports more detailed errors.\par
-{\pntext\f2\'B7\tab}Vim's syntax highlighting is suitable for dark background.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Fixes invalid error message that setup.ini cannot be deleted on uninstall.\par
+{\pntext\f1\'B7\tab}Setup tries harder to finish the installation and reports more detailed errors.\par
+{\pntext\f1\'B7\tab}Vim's syntax highlighting is suitable for dark background.\par
+\pard\nowidctlpar\b\fs24\par
 Changes since Git-1.5.3.5-preview20071114\par
 \par
 \i\fs20 New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Git is included in version 1.5.3.6.\b\i\par
-\b0\i0{\pntext\f2\'B7\tab}Setup displays release notes.\par
-\pard\b\fs24\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Git is included in version 1.5.3.6.\b\i\par
+\b0\i0{\pntext\f1\'B7\tab}Setup displays release notes.\par
+\pard\nowidctlpar\b\fs24\par
 \i\fs20 Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 pull/fetch/push in git-gui works. Note, there is no way for ssh to ask for a passphrase or for confirmation if you connect to an unknown host. So, you must have ssh set up to work without passphrase. Either you have a key without passphrase, or you started ssh-agent. You may also consider using PuTTY by pointing GIT_SSH to plink.exe and handle your ssh keys with Pageant. In this case you should include your login name in urls. You must also connect to an unknown host once from the command line and confirm the host key, before you can use it from git-gui.\par
-\pard\b\fs24\par
-Changes since Git-1.5.3-preview20071027\fs20\par
-\i\par
-New Features\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0\i0 Git is included in version 1.5.3.5.\par
-{\pntext\f2\'B7\tab}Setup can be installed as normal user.\par
-{\pntext\f2\'B7\tab}When installing as Administrator, all icons except the Quick Launch icon will be created for all users.\par
-{\pntext\f2\'B7\tab}"git help user-manual" displays the user manual.\par
-\pard\b\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 pull/fetch/push in git-gui works. Note, there is no way for ssh to ask for a passphrase or for confirmation if you connect to an unknown host. So, you must have ssh set up to work without passphrase. Either you have a key without passphrase, or you started ssh-agent. You may also consider using PuTTY by pointing GIT_SSH to plink.exe and handle your ssh keys with Pageant. In this case you should include your login name in urls. You must also connect to an unknown host once from the command line and confirm the host key, before you can use it from git-gui.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\b\fs24\par
+{\pntext\f1\'B7\tab}Changes since Git-1.5.3-preview20071027\fs20\par
+\i{\pntext\f1\'B7\tab}\par
+{\pntext\f1\'B7\tab}New Features\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0\i0 Git is included in version 1.5.3.5.\par
+{\pntext\f1\'B7\tab}Setup can be installed as normal user.\par
+{\pntext\f1\'B7\tab}When installing as Administrator, all icons except the Quick Launch icon will be created for all users.\par
+{\pntext\f1\'B7\tab}"git help user-manual" displays the user manual.\par
+\pard\nowidctlpar\b\par
 \i Bugfixes\b0\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432 Git Bash works on Windows XP 64.\par
-\pard\par
-\b\fs24 Changes since Git-1.5.3-preview20071019\par
-\fs20\par
-\i Bugfixes\i0\par
-\pard{\pntext\f2\'B7\tab}{\*\pn\pnlvlblt\pnf2\pnindent0{\pntxtb\'B7}}\fi-288\li432\b0 The templates for a new repository are found.\par
-{\pntext\f2\'B7\tab}The global configuration /etc/gitconfig is found.\par
-{\pntext\f2\'B7\tab}Git Gui localization works. It falls back to English if a translation has errors.\par
-\pard\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432 Git Bash works on Windows XP 64.\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlcont\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\par
+\b\fs24{\pntext\f1\'B7\tab}Changes since Git-1.5.3-preview20071019\par
+\fs20{\pntext\f1\'B7\tab}\par
+\i{\pntext\f1\'B7\tab}Bugfixes\i0\par
+\pard{\pntext\f1\'B7\tab}{\*\pn\pnlvlblt\pnf1\pnindent0{\pntxtb\'B7}}\nowidctlpar\fi-288\li432\b0 The templates for a new repository are found.\par
+{\pntext\f1\'B7\tab}The global configuration /etc/gitconfig is found.\par
+{\pntext\f1\'B7\tab}Git Gui localization works. It falls back to English if a translation has errors.\par
+\pard\nowidctlpar\par
 \b\fs24 Changes since WinGit-0.2-alpha\par
 \b0\fs20 The history of the release notes stops here. Various new features and bugfixes are available since WinGit-0.2-alpha. Please check the git history of the msysgit project for details.\par
 }


### PR DESCRIPTION
Adapted the release notes for the upcoming first *Git for Windows*
release. Furthermore the instructions to build and deploy a new upstream
release were adapted to the current process. That process is described in
the `HowToRelease.txt` file.

Signed-off-by: nalla <nalla@hamal.uberspace.de>