### PR TITLE
git-extra: Enable core.fscache

### DIFF
--- a/git-extra/gitconfig
+++ b/git-extra/gitconfig
@@ -1,6 +1,7 @@
 [core]
 	symlinks = false
 	autocrlf = true
+	fscache = true
 [color]
 	diff = auto
 	status = auto


### PR DESCRIPTION
Enabling core.fscache provides a significant performance boost.

Signed-off-by: Eli Young <elyscape@gmail.com>