### PR TITLE
git-extra: Add key mappings to inputrc

### DIFF
--- a/git-extra/inputrc
+++ b/git-extra/inputrc
@@ -24,3 +24,49 @@ set mark-symlinked-directories on
 
 # Show all instead of beeping first
 set show-all-if-ambiguous on
+
+# MSYSTEM is emacs based
+$if mode=emacs
+  # Common to Console & RXVT
+  "\C-?": backward-kill-line        # Ctrl-BackSpace
+  "\e[2~": paste-from-clipboard     # "Ins. Key"
+  "\e[5~": beginning-of-history     # Page up
+  "\e[6~": end-of-history           # Page down
+
+  # Mintty
+  "\e[1;5D": "\eOD"                 # Ctrl-Left
+  "\e[1;5C": "\eOC"                 # Ctrl-Right
+  "\e[1;5A": "\eOA"                 # Ctrl-Up
+  "\e[1;5B": "\eOB"                 # Ctrl-Down
+  "\e[1;3D": "\e\e[D"               # Alt-Left
+  "\e[1;3C": "\e\e[C"               # Alt-Right
+
+  $if term=msys # RXVT
+    "\e[7~": beginning-of-line      # Home Key
+    "\e[8~": end-of-line            # End Key
+    "\e[11~": display-shell-version # F1
+    "\e[15~": re-read-init-file     # F5
+    "\e[12~": "Function Key 2"
+    "\e[13~": "Function Key 3"
+    "\e[14~": "Function Key 4"
+    "\e[17~": "Function Key 6"
+    "\e[18~": "Function Key 7"
+    "\e[19~": "Function Key 8"
+    "\e[20~": "Function Key 9"
+    "\e[21~": "Function Key 10"
+  $else
+  # Eh, normal Console is not really cygwin anymore, is it? Using 'else' instead. -mstormo
+  # $if term=cygwin # Console
+    "\e[1~": beginning-of-line      # Home Key
+    "\e[4~": end-of-line            # End Key
+    "\e[3~": delete-char            # Delete Key
+    "\e\e[C": forward-word          # Alt-Right
+    "\e\e[D": backward-word         # Alt-Left
+    "\e[17~": "Function Key 6"
+    "\e[18~": "Function Key 7"
+    "\e[19~": "Function Key 8"
+    "\e[20~": "Function Key 9"
+    "\e[21~": "Function Key 10"
+    "\e[23~": "Function Key 11"
+  $endif
+$endif


### PR DESCRIPTION
These are imported from MSYS2, except for the Mintty-specific macros.

Signed-off-by: Eli Young <elyscape@gmail.com>