### PR TITLE
make-file-list: Exclude skel files

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -35,6 +35,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \
 	-e '^/usr/lib/python' -e '^/usr/lib/ruby' \
 	-e '^/usr/share/awk' -e '^/usr/share/subversion' \
+	-e '^/etc/skel/' -e '^/mingw../etc/skel/' \
 	-e '^/usr/bin/svn' \
 	-e '^/mingw../share/doc/gettext/' \
 	-e '^/mingw../share/doc/lib' \


### PR DESCRIPTION
These aren't used by Git for Windows, as we don't create the user's home
directory.

Signed-off-by: Eli Young <elyscape@gmail.com>