### PR TITLE
git-extra: silence missing package error

### DIFF
--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -37,7 +37,7 @@ GITCONFIG
 	for arch in i686 x86_64
 	do
 		prefix=mingw-w64-$arch
-		case "$(pacman -Q $prefix-curl $prefix-nettle)" in
+		case "$(pacman -Q $prefix-curl $prefix-nettle 2> /dev/null)" in
 		*7.41.0-1*3.1-1*)
 			nettle=$prefix-nettle-2.7.1-3-any.pkg.tar.xz
 			(cd /var/cache/pacman/pkg &&


### PR DESCRIPTION
When checking for the https fix the script checks for every valid
comination to be patched. Since those packages are not installed on every
system lets not worry the user when updating `git-extra`.

Signed-off-by: nalla <nalla@hamal.uberspace.de>