### PR TITLE
Simplify Windows MKDIR calls a bit

### DIFF
--- a/net-installer/setup-git-sdk.bat
+++ b/net-installer/setup-git-sdk.bat
@@ -99,9 +99,8 @@
 
 @REM Before running a shell, let's prevent complaints about "permission denied"
 @REM from MSys2's /etc/post-install/01-devices.post
-@IF NOT EXIST dev @MKDIR dev
-@IF NOT EXIST dev\shm @MKDIR dev\shm
-@IF NOT EXIST dev\mqueue @MKDIR dev\mqueue
+@MKDIR %cwd%\dev\shm 2> NUL
+@MKDIR %cwd%\dev\mqueue 2> NUL
 
 @REM Install shortcut on the desktop
 @ECHO.


### PR DESCRIPTION
Windows' "MKDIR creates any intermediate directories in the path, if
needed", so just suppress the "A subdirectory or file a already exists"
message eventually. Also ensure to create the "dev" directories in the
installation directory in case setup-git-sdk.bat was called from another
directory.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>