### PR TITLE
Remove a mistakable comment from the release.sh scripts

### DIFF
--- a/net-installer/release.sh
+++ b/net-installer/release.sh
@@ -75,5 +75,5 @@ echo "Creating archive" &&
  echo ';!@InstallEnd@!' &&
  cat "$TMPPACK") > "$TARGET" &&
 echo "Success! You will find the new installer at \"$TARGET\"." &&
-echo "It is a self-extracting .7z archive (just append .exe to the filename)" &&
+echo "It is a self-extracting .7z archive." &&
 rm $TMPPACK

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -78,5 +78,5 @@ echo "Creating archive" &&
  echo ';!@InstallEnd@!' &&
  cat "$TMPPACK") > "$TARGET" &&
 echo "Success! You will find the new installer at \"$TARGET\"." &&
-echo "It is a self-extracting .7z archive (just append .exe to the filename)" &&
+echo "It is a self-extracting .7z archive." &&
 rm $TMPPACK


### PR DESCRIPTION
The user does not need to append .exe to the file name, that has already
been done.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>