### PR TITLE
Replace usage of .bat with .exe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,3 @@
 /markdown/pkg/
 /markdown/src/
 /portable/root/cmd/
-/portable/root/git-bash.bat
-/portable/root/git-cmd.bat

--- a/portable/root/README.portable
+++ b/portable/root/README.portable
@@ -39,9 +39,9 @@ to your %path%.
 How to start using PortableGit
 ------------------------------
 
-If you are comfortable with a Unix-like shell, just launch 'git-bash.bat'.
+If you are comfortable with a Unix-like shell, just launch 'git-bash.exe'.
 
-If not, just launch 'git-cmd.bat'.
+If not, just launch 'git-cmd.exe'.
 
 Alternatively, you can execute these commands to modify the %path%
 variable temporarily:


### PR DESCRIPTION
It appears the README has diverged from the packaged portable files. Instead of `git-bash.bat` and `git-cmd.bat` existing, it is now `git-bash.exe` and `git-cmd.exe` in PortableGit-2.3.5.8-dev-preview-64-bit.