### PR TITLE
portable: Install Portable Git to a portable directory

### DIFF
--- a/portable/release.sh
+++ b/portable/release.sh
@@ -73,7 +73,7 @@ echo "Creating archive" &&
  echo 'ExtractTitle="Extracting..."' &&
  echo 'GUIFlags="8+32+64+256+4096"' &&
  echo 'GUIMode="1"' &&
- echo 'InstallPath="%'$PROGRAMFILESENV'%\\Git"' &&
+ echo 'InstallPath="%%S\\PortableGit"' &&
  echo 'OverwriteMode="0"' &&
  echo ';!@InstallEnd@!' &&
  cat "$TMPPACK") > "$TARGET" &&


### PR DESCRIPTION
Portable applications should not be installed to Program Files. `%%S`
expands to the folder containing the self-extracting archive.

Signed-off-by: Eli Young <elyscape@gmail.com>