### PR TITLE
Include post-install scripts and run after installation

### DIFF
--- a/git-extra/99-post-install-cleanup.post
+++ b/git-extra/99-post-install-cleanup.post
@@ -1,0 +1,6 @@
+# Only remove post-install scripts if we're not in the SDK.
+# They need to be there to build the installer packages.
+if [ -f /ReleaseNotes.html -o -f /README.portable ]
+then
+  rm -rf /etc/post-install
+fi

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -34,6 +34,7 @@ package() {
   esac
 
   install -d -m755 $pkgdir/etc/profile.d
+  install -d -m755 $pkgdir/etc/post-install
   install -d -m755 $pkgdir/usr/bin
   install -d -m755 $pkgdir/usr/share/git
   install -d -m755 $pkgdir/$mingwdir/bin
@@ -46,4 +47,5 @@ package() {
   install -m755 $startdir/aliases.sh $pkgdir/etc/profile.d
   install -m755 $startdir/env.sh $pkgdir/etc/profile.d
   install -m644 $startdir/msys2-32.ico $pkgdir/usr/share/git
+  install -m644 $startdir/99-post-install-cleanup.post $pkgdir/etc/post-install
 }

--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1263,6 +1263,19 @@ begin
     end;
 
     {
+        Run post-install scripts to set up system environment
+    }
+
+    Cmd:=AppDir+'\git-bash.exe';
+    if not Exec(Cmd, '-c exit', AppDir, SW_HIDE, ewWaitUntilTerminated, i) then begin
+      Msg:='Line {#__LINE__}: Unable to run post-install scripts.';
+
+      // This is not a critical error, so just notify the user and continue.
+      SuppressibleMsgBox(Msg,mbError,MB_OK,IDOK);
+      Log(msg);
+    end;
+
+    {
         Restart any processes that were shut down via the Restart Manager
     }
 

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -53,4 +53,7 @@ etc/bash.bashrc
 etc/fstab
 etc/nsswitch.conf
 mingw$BITNESS/etc/gitconfig
+etc/post-install/01-devices.post
+etc/post-install/03-mtab.post
+etc/post-install/06-windows-files.post
 EOF

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -75,6 +75,7 @@ echo "Creating archive" &&
  echo 'GUIMode="1"' &&
  echo 'InstallPath="%'$PROGRAMFILESENV'%\\Git"' &&
  echo 'OverwriteMode="0"' &&
+ echo 'RunProgram="git-bash.exe -c exit"' &&
  echo ';!@InstallEnd@!' &&
  cat "$TMPPACK") > "$TARGET" &&
 echo "Success! You will find the new installer at \"$TARGET\"." &&


### PR DESCRIPTION
This pull request adds the useful post-install scripts to the release packages and ensures that they are executed once after installation/extraction, at which point they are deleted.  Deletion is not done if `msys2.ico` is in the root directory, as that is (at present) a reliable indicator that we're in the SDK, and the post-install scripts need to be in place for the packages to be made.

Resolves git-for-windows/git#111.