### PR TITLE
portable: Remove unused PROGRAMFILESENV variable

### DIFF
--- a/portable/release.sh
+++ b/portable/release.sh
@@ -13,14 +13,12 @@ die () {
 }
 
 ARCH="$(uname -m)"
-PROGRAMFILESENV=PROGRAMFILES
 case "$ARCH" in
 i686)
 	BITNESS=32
 	;;
 x86_64)
 	BITNESS=64
-	PROGRAMFILESENV=ProgramW6432
 	;;
 *)
 	die "Unhandled architecture: $ARCH"


### PR DESCRIPTION
Signed-off-by: Eli Young <elyscape@gmail.com>

In response to @sschuberth's [comment](https://github.com/git-for-windows/build-extra/pull/45#discussion_r29124904).