### PR TITLE
installer: remove temporary `git-wrapper.exe`

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1070,6 +1070,7 @@ begin
             end;
         end;
 
+        // Copy git-wrapper to the temp directory.
         if not FileCopy(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-log.exe',AppDir+'\tmp\git-wrapper.exe',False) then begin
             Log('Line {#__LINE__}: Creating copy "'+AppDir+'\tmp\git-wrapper.exe" failed.');
         end;
@@ -1087,6 +1088,11 @@ begin
             if FileExists(FileName) then begin
                 CopyBuiltin(FileName);
             end;
+        end;
+
+        // Delete git-wrapper from the temp directory.
+        if not DeleteFile(AppDir+'\tmp\git-wrapper.exe') then begin
+            Log('Line {#__LINE__}: Deleting temporary "'+AppDir+'\tmp\git-wrapper.exe" failed.');
         end;
     end else begin
         Msg:='Line {#__LINE__}: Unable to read file "{#MINGW_BITNESS}\{#APP_BUILTINS}".';


### PR DESCRIPTION
After copying the `git-log.exe` to the `tmp` directory for copying the
different `builtins` the temporary file is never cleaned up. This cleanup
call is now issued properly.

This fixes git-for-windows/git#114

Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>