### PR TITLE
installer: honor `%PROGRAMDATA%\Git\config`

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1019,7 +1019,7 @@ end;
 
 procedure CurStepChanged(CurStep:TSetupStep);
 var
-    AppDir,DllPath,FileName,Cmd,Msg:String;
+    AppDir,ProgramData,DllPath,FileName,Cmd,Msg:String;
     BuiltIns,ImageNames,EnvPath,EnvHome:TArrayOfString;
     Count,i:Longint;
     LinkCreated:Boolean;
@@ -1044,6 +1044,7 @@ begin
     end;
 
     AppDir:=ExpandConstant('{app}');
+    ProgramData:=ExpandConstant('{commonappdata}');
 
     {
         Bind the imported function addresses
@@ -1117,6 +1118,21 @@ begin
         Log(Msg);
     end;
 
+    // Create default system wide git config file
+    if not FileExists(ProgramData + '\Git\config') then begin
+        if not DirExists(ProgramData + '\Git') then begin
+            if not CreateDir(ProgramData + '\Git') then begin
+                Log('Line {#__LINE__}: Creating directory "' + ProgramData + '\Git" failed.');
+            end;
+        end;
+        if not FileCopy(AppDir + '\{#MINGW_BITNESS}\etc\gitconfig', ProgramData + '\Git\config', True) then begin
+            Log('Line {#__LINE__}: Creating copy "' + ProgramData + '\Git\config" failed.');
+        end;
+    end;
+    if not DeleteFile(AppDir + '\{#MINGW_BITNESS}\etc\gitconfig') then begin
+        Log('Line {#__LINE__}: Deleting template config "' + AppDir + '\{#MINGW_BITNESS}\etc\gitconfig failed.');
+    end;
+
     {
         Adapt core.autocrlf
     }
@@ -1128,8 +1144,8 @@ begin
     end else begin
         Cmd:='core.autocrlf false';
     end;
-    if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f gitconfig ' + Cmd,
-                AppDir + '\{#MINGW_BITNESS}\etc', SW_HIDE, ewWaitUntilTerminated, i) then begin
+    if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f config ' + Cmd,
+                ProgramData + '\Git', SW_HIDE, ewWaitUntilTerminated, i) then begin
         Msg:='Unable to configure the line ending conversion: ' + Cmd;
 
         // This is not a critical error, so just notify the user and continue.
@@ -1144,8 +1160,8 @@ begin
     if RdbPerfTweaks[GP_FSCache].checked then begin
         Cmd:='core.fscache true';
 
-        if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f gitconfig ' + Cmd,
-                    AppDir + '\{#MINGW_BITNESS}\etc', SW_HIDE, ewWaitUntilTerminated, i) then begin
+        if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f config ' + Cmd,
+                    ProgramData + '\Git', SW_HIDE, ewWaitUntilTerminated, i) then begin
             Msg:='Unable to enable the experimental performance tweak: ' + Cmd;
 
             // This is not a critical error, so just notify the user and continue.

--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -161,12 +161,26 @@ Type: files; Name: {app}\{#MINGW_BITNESS}\bin\git-*.exe
 Type: files; Name: {app}\{#MINGW_BITNESS}\libexec\git-core\git-*.exe
 Type: files; Name: {app}\{#MINGW_BITNESS}\libexec\git-core\git.exe
 
+; Delete the dynamical generated MSYS2 files
+Type: files; Name: {app}\etc\hosts
+Type: files; Name: {app}\etc\mtab
+Type: files; Name: {app}\etc\networks
+Type: files; Name: {app}\etc\protocols
+Type: files; Name: {app}\etc\services
+Type: files; Name: {app}\dev\fd
+Type: files; Name: {app}\dev\stderr
+Type: files; Name: {app}\dev\stdin
+Type: files; Name: {app}\dev\stdout
+Type: dirifempty; Name: {app}\dev\mqueue
+Type: dirifempty; Name: {app}\dev\shm
+Type: dirifempty; Name: {app}\dev
+
 ; Delete any manually created shortcuts.
 Type: files; Name: {userappdata}\Microsoft\Internet Explorer\Quick Launch\Git Bash.lnk
 Type: files; Name: {code:GetShellFolder|desktop}\Git Bash.lnk
 Type: files; Name: {app}\Git Bash.lnk
 
-; Delete a home directory inside the msysGit directory.
+; Delete a home directory inside the Git for Windows directory.
 Type: dirifempty; Name: {app}\home\{username}
 Type: dirifempty; Name: {app}\home
 


### PR DESCRIPTION
Before trying to set the selected config values in the installer the code
now checks if the system wide git config exists. If that is not the case
the installer copies the shipped config to `%PROGRAMDATA%\Git\config` and
then tries to alter it as choosen by the user.

The shipped gitconfig is deleted after checking if the system wide git
config already exists.