### PR TITLE
installer: Invoke bash directly for post-install

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1302,8 +1302,8 @@ begin
         Run post-install scripts to set up system environment
     }
 
-    Cmd:=AppDir+'\git-bash.exe';
-    if not Exec(Cmd, '-c exit', AppDir, SW_HIDE, ewWaitUntilTerminated, i) then begin
+    Cmd:=AppDir+'\usr\bin\bash.exe';
+    if not Exec(Cmd, '--login -c exit', AppDir, SW_HIDE, ewWaitUntilTerminated, i) then begin
       Msg:='Line {#__LINE__}: Unable to run post-install scripts.';
 
       // This is not a critical error, so just notify the user and continue.


### PR DESCRIPTION
Invoking `git-bash.exe` to run the post-install scripts results in a
mintty window appearing, even when invoked with `SW_HIDE`. Invoking bash
directly avoids this.

Fixes git-for-windows/git#126.

Signed-off-by: Eli Young <elyscape@gmail.com>