### PR TITLE
installer: expand path when setting `http.sslCAInfo`

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1127,6 +1127,17 @@ begin
         end;
         if not FileCopy(AppDir + '\{#MINGW_BITNESS}\etc\gitconfig', ProgramData + '\Git\config', True) then begin
             Log('Line {#__LINE__}: Creating copy "' + ProgramData + '\Git\config" failed.');
+        end else begin
+            Cmd:='http.sslCAInfo "' + AppDir + '/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt"';
+            StringChangeEx(Cmd, '\', '/', True);
+            if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f config ' + Cmd,
+                        ProgramData + '\Git', SW_HIDE, ewWaitUntilTerminated, i) then begin
+                Msg:='Unable to configure SSL CA info: ' + Cmd;
+
+                // This is not a critical error, so just notify the user and continue.
+                SuppressibleMsgBox(Msg,mbError,MB_OK,IDOK);
+                Log(Msg);
+            end;
         end;
     end;
     if not DeleteFile(AppDir + '\{#MINGW_BITNESS}\etc\gitconfig') then begin


### PR DESCRIPTION
When installing the system wide config into `%PROGRAMDATA\Git\config` make
sure that the `http.sslCAInfo` config entry is expanded to the full path
of the new git installation.

Only try this if there is not yet an existing `config` file. We don't want
to override pre existing settings.

Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>