### PR TITLE
add tar to list of packaged GNU utilities

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -28,7 +28,7 @@ pacman_list () {
 
 pacman_list mingw-w64-$ARCH-git mingw-w64-$ARCH-git-doc-html \
 	git-extra ncurses mintty vim openssh winpty \
-	sed awk less grep gnupg findutils coreutils \
+	sed awk less grep gnupg tar findutils coreutils \
 	dos2unix which subversion mingw-w64-$ARCH-tk "$@" |
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \


### PR DESCRIPTION
As per the discussion in https://groups.google.com/forum/#!topic/git-for-windows/jerxhdoS-20.

Adding tar in the list of packaged GNU utilities. This to increase compatibility with users coming from msysgit 1.x and causes a slight increase in filesize.

Comparing the Portable built package:

Build | Installer size (kb) | Unpacked size (kb)
------ | ---------------------- | ----------------------
Without tar | 48720 | 400196
With tar | 49094 | 402516
