### PR TITLE
installer: Remove the radio button group for Windows Explorer integr…

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -71,9 +71,8 @@ Name: icons; Description: Additional icons
 Name: icons\quicklaunch; Description: In the Quick Launch
 Name: icons\desktop; Description: On the Desktop
 Name: ext; Description: Windows Explorer integration; Types: default
-Name: ext\reg; Description: Simple context menu (Registry based); Flags: exclusive; Types: default
-Name: ext\reg\shellhere; Description: Git Bash Here; Types: default
-Name: ext\reg\guihere; Description: Git GUI Here; Types: default
+Name: ext\shellhere; Description: Git Bash Here; Types: default
+Name: ext\guihere; Description: Git GUI Here; Types: default
 Name: assoc; Description: Associate .git* configuration files with the default text editor; Types: default
 Name: assoc_sh; Description: Associate .sh files to be run with Bash; Types: default
 Name: consolefont; Description: Use a TrueType font in all console windows
@@ -1452,7 +1451,7 @@ begin
         RootKey:=HKEY_CURRENT_USER;
     end;
 
-    if IsComponentSelected('ext\reg\shellhere') then begin
+    if IsComponentSelected('ext\shellhere') then begin
         Msg:='Git Ba&sh Here';
         Cmd:='"'+AppDir+'\git-bash.exe" "--cd=%1"';
         if (not RegWriteStringValue(RootKey,'SOFTWARE\Classes\Directory\shell\git_shell','',Msg)) or
@@ -1469,7 +1468,7 @@ begin
         end;
     end;
 
-    if IsComponentSelected('ext\reg\guihere') then begin
+    if IsComponentSelected('ext\guihere') then begin
         Msg:='Git &GUI Here';
         Cmd:='"'+AppDir+'\cmd\git-gui.exe" "--working-dir" "%1"';
         if (not RegWriteStringValue(RootKey,'SOFTWARE\Classes\Directory\shell\git_gui','',Msg)) or


### PR DESCRIPTION
…ation

Now that we do not ship git-cheetah anymore there is only one choice
left, thus we do not need a radio button group.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>