### PR TITLE
Include `diff.exe` into the installers

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -28,7 +28,7 @@ pacman_list () {
 
 pacman_list mingw-w64-$ARCH-git mingw-w64-$ARCH-git-doc-html \
 	git-extra ncurses mintty vim openssh winpty \
-	sed awk less grep gnupg tar findutils coreutils \
+	sed awk less grep gnupg tar findutils coreutils diffutils \
 	dos2unix which subversion mingw-w64-$ARCH-tk "$@" |
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \


### PR DESCRIPTION
It is required by `git mergetool`.

This fixes https://github.com/git-for-windows/git/issues/163

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>