### PR TITLE
installer: Do not be silent when uninstalling a previous version

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1168,13 +1168,14 @@ begin
             end;
         end;
 
-        if RegQueryStringValue(Domain,Key,'UninstallString',UninstallString) then
+        if RegQueryStringValue(Domain,Key,'UninstallString',UninstallString) then begin
             // Using ShellExec() here, in case privilege elevation is required
-            if not ShellExec('',UninstallString,'/SILENT /NORESTART /SUPPRESSMSGBOXES','',SW_HIDE,ewWaitUntilTerminated,ErrorCode) then begin
+            if not ShellExec('',UninstallString,'/NORESTART','',SW_SHOW,ewWaitUntilTerminated,ErrorCode) then begin
                 Msg:='Could not uninstall previous version. Trying to continue anyway.';
                 SuppressibleMsgBox(Msg,mbError,MB_OK,IDOK);
                 Log(Msg);
             end;
+        end;
     end;
 end;
 


### PR DESCRIPTION
It is bad practice to remove files from the user's system without any
confirmation. Especially users who just want to give the new MSYS2-based
Git a try most likely want to keep their existing MSYS1-based Git
installation. Also, even just installing the 64-bit version of GfW 2.x
removes Gfw 1.x, which is 32-bit, preveting to have a 32-bit and 64-bit
version of Git installed in parallel, which again is useful for testing.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>