### PR TITLE
installer: correction in release notes

### DIFF
--- a/installer/ReleaseNotes.md
+++ b/installer/ReleaseNotes.md
@@ -33,7 +33,7 @@ This package contains software from a number of other projects including zlib, c
 
 ###New Features
 
-* Comes with Git 2.4.5
+* Comes with Git 2.4.6
 
 ###Bug fixes
 


### PR DESCRIPTION
The release notes of the latest installer are still referring to the
previous git version. Lets fix this.