### PR TITLE
Include `getopt.exe` into the installers

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -29,7 +29,7 @@ pacman_list () {
 pacman_list mingw-w64-$ARCH-git mingw-w64-$ARCH-git-doc-html \
 	git-extra ncurses mintty vim openssh winpty \
 	sed awk less grep gnupg tar findutils coreutils diffutils \
-	dos2unix which subversion mingw-w64-$ARCH-tk "$@" |
+	dos2unix which subversion getopt mingw-w64-$ARCH-tk "$@" |
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \
 	-e '^/usr/lib/python' -e '^/usr/lib/ruby' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -58,6 +58,7 @@ etc/post-install/03-mtab.post
 etc/post-install/06-windows-files.post
 usr/bin/start
 usr/bin/dash.exe
+usr/bin/getopt.exe
 usr/bin/rebase.exe
 usr/bin/rebaseall
 EOF


### PR DESCRIPTION
## Why?
For supporting the popular [Nvie's Git-Flow](https://github.com/nvie/gitflow) ([Blueprint](http://nvie.com/posts/a-successful-git-branching-model/)) & it's [AVH Edition](https://github.com/petervanderdoes/gitflow) and potentially other Git extensions & hooks.

Having a direct support to the __Git-Flow__ branching model workflow in "Git for Windows" may motivate many Windows users to follow a smart and successful workflow with Git for all of their projects!

Also, notice that `getopt` is standard on many Unix-based operating systems such as Linux, FreeBSD and MacOSX.

## Build details

Using __Windows x86_64 64-bit__ from upstream of [build-extra](https://github.com/git-for-windows/build-extra/commit/56dcda494a9389622fac3337cf9731f41f08bf3a), here some information about the size:

##### PortableGit (Extracted)
- __With__ `getopt.exe` and it's dependencies: __295,079,148 bytes__
- __Without__ `getopt.exe` and it's dependencies: __288,562,474 bytes__
- _Diff_: __6,516,674 bytes__

##### PortableGit (Archived)
- __With__ `getopt.exe` and it's dependencies: __45,962,703 bytes__
- __Without__ `getopt.exe` and it's dependencies: __44,928,507 bytes__
- _Diff_: __1,034,196 bytes__

##### Git Installer (InnoSetup)
- __With__ `getopt.exe` and it's dependencies: __49,962,067 bytes__
- __Without__ `getopt.exe` and it's dependencies: __48,951,269 bytes__
- _Diff_: __1,010,798 bytes__

## Build tests

You can test it by yourself from my fork's [release section](https://github.com/silverkorn/build-extra/releases/tag/v2.4.6.windows.1.getopt) (Currently only built for x64_84 / 64-bit)
Both builds with and without `getopt.exe` are available for comparisons.

To install and test out Gitflow and/or Gitflow AVH Edition: 
- Download the file `install-gitflow.sh` or `install-gitflow-avh.sh` from this gist: https://gist.github.com/silverkorn/af2e55dbef1e7089af70
  - *_Tip_: Right-click "RAW" and "Save As..." into the directory's root of your "Git For Windows"
- Start `git-bash.exe` from the directory's root:
  - Launch `./install-gitflow.sh` or `./install-gitflow-avh.sh` depending on your previous decision
  - _(You can restart or start a new `git-bash.exe` for auto-completion of "gitflow")_
  - `mkdir -p tmp/gitflow-test-repo && cd tmp/gitflow-test-repo`
  - `git flow init`

I hope this will make you accept to add `getopt.exe` in further releases.
Thanks!