### PR TITLE
git-extra: fix call of `~/.bashrc`

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -46,6 +46,7 @@ package() {
   install -m755 $startdir/git-prompt.sh $pkgdir/etc/profile.d
   install -m755 $startdir/aliases.sh $pkgdir/etc/profile.d
   install -m755 $startdir/env.sh $pkgdir/etc/profile.d
+  install -m755 $startdir/bash_profile.sh $pkgdir/etc/profile.d
   install -m644 $startdir/msys2-32.ico $pkgdir/usr/share/git
   install -m644 $startdir/99-post-install-cleanup.post $pkgdir/etc/post-install
 }

--- a/git-extra/bash_profile.sh
+++ b/git-extra/bash_profile.sh
@@ -1,0 +1,7 @@
+# add ~/.bash_profile if needed for executing ~/.bashrc
+if [ -e ~/.bashrc -a ! -e ~/.bash_profile -a ! -e ~/.bash_login -a ! -e ~/.profile ]; then
+  printf "\n\033[31mWARNING: Found ~/.bashrc but no ~/.bash_profile, ~/.bash_login or ~/.profile.\033[m\n\n"
+  echo "This looks like an incorrect setup."
+  echo "A ~/.bash_profile containing \"if [ -f ~/.bashrc ]; then . ~/.bashrc; fi\" will be created for you."
+  echo "if [ -f ~/.bashrc ]; then . ~/.bashrc; fi" > ~/.bash_profile
+fi


### PR DESCRIPTION
This is a conversion of commit ebf60bd55e88693ceb73dea49783b5965cd2619b
originally created in the msysgit project. The new file in the `profile.d`
folder will try to create an appropriate `~/.bash_profile` file if it
encounterns a `~/.bashrc` file.

This fixes git-for-windows/git#191

Helped-by: Arlo Louis <MailToArlo@gmail.com>
Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>