### PR TITLE
git-extra: add git-prompt check to bash.bashrc

### DIFF
--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -25,6 +25,9 @@ GITCONFIG
 	! grep -q '^PS1=' /etc/bash.bashrc ||
 	sed -i 's/^PS1=/#&/' /etc/bash.bashrc
 
+	grep -q '^# Fixup git-bash in non login env' /etc/bash.bashrc ||
+	printf "\n# Fixup git-bash in non login env\nshopt -q login_shell || . /etc/profile.d/git-prompt.sh\n" >> /etc/bash.bashrc
+
 	grep -q git-for-windows etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i[git-for-windows]\nServer = https://dl.bintray.com/$repo/pacman/$arch\nSigLevel = Optional\n' etc/pacman.conf
 


### PR DESCRIPTION
If `bash` is called without the `--login` function, the `git-prompt.sh` in
the `profile.d` directory will not get sourced. Lets fix this behavior by
explicitly checking if this bash instance was called without the `--login`
argument and if so call the `git-prompt.sh`.

This fixes git-for-windows/git#290

Signed-off-by: 마누엘 <nalla@hamal.uberspace.de>