### PR TITLE
connect: include new connect package

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -29,7 +29,8 @@ pacman_list () {
 pacman_list mingw-w64-$ARCH-git mingw-w64-$ARCH-git-doc-html \
 	git-extra ncurses mintty vim openssh winpty \
 	sed awk less grep gnupg tar findutils coreutils diffutils \
-	dos2unix which subversion mingw-w64-$ARCH-tk "$@" |
+	dos2unix which subversion mingw-w64-$ARCH-tk \
+	mingw-w64-$ARCH-connect "$@" |
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \
 	-e '^/usr/lib/python' -e '^/usr/lib/ruby' \


### PR DESCRIPTION
Lets include the newly created package in the installer. Note that the
huble maintainer needs to build, release and install that package so that
it will indeed be picked up.

This fixes git-for-windows/git#293