### PR TITLE
git-extra: add aliases to support interactive consoles in mintty

### DIFF
--- a/git-extra/aliases.sh
+++ b/git-extra/aliases.sh
@@ -4,3 +4,15 @@
 # --show-control-chars: help showing Korean or accented characters
 alias ls='ls -F --color=auto --show-control-chars'
 alias ll='ls -l'
+
+case "$TERM" in
+xterm*)
+	# The following programs are known to require a Win32 Console
+	# for interactive usage, therefore let's launch them through winpty
+	# when run inside `mintty`.
+	for name in node php php5 psql python2.7
+	do
+		alias $name="winpty $name.exe"
+	done
+	;;
+esac


### PR DESCRIPTION
This patch adds support for a couple of interactive consoles that users
invariably want to run in their Git Bash (despite our clear warning in the
release notes and the installer; Who reads text anyways?).

Of course, the list is non-exhaustive. The idea is that we can extend this
whenever needed. Or even better: users can extend this as needed and make
a Pull Request, in true Open Source style facilitated by... *drumroll*...
Git.

This fixes https://github.com/git-for-windows/git/issues/399 and
https://github.com/git-for-windows/git/issues/400

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>