### PR TITLE
post-install.bat: give 03-mtab a chance to write to the correct path

### DIFF
--- a/post-install.bat
+++ b/post-install.bat
@@ -38,7 +38,7 @@
 )
 
 @REM Run the post-install scripts
-@usr\bin\bash.exe --norc -c "export PATH=/usr/bin:$PATH; for p in $(export LC_COLLATE=C; echo /etc/post-install/*.post); do test -e \"$p\" && . \"$p\"; done"
+@usr\bin\bash.exe --norc -c "export PATH=/usr/bin:$PATH; export SYSCONFDIR=/etc; for p in $(export LC_COLLATE=C; echo /etc/post-install/*.post); do test -e \"$p\" && . \"$p\"; done"
 
 @REM Remove this script
 @DEL post-install.bat


### PR DESCRIPTION
Since we do not run the post-install scripts in a full login shell
anymore, `/etc/profile` has no chance of defining the `SYSCONFDIR`
before `03-tab.post` wants to use it.

So let's just hard-code it in `post-install.bat`.

This fixes https://github.com/git-for-windows/git/issues/405

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>