### PR TITLE
installer: record version and some paths in the registry

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -97,6 +97,11 @@ SetupAppTitle={#APP_NAME} {#APP_VERSION} Setup
 SetupWindowTitle={#APP_NAME} {#APP_VERSION} Setup
 
 [Registry]
+; Aides installing third-party (credential, remote, etc) helpers
+Root: HKLM; Subkey: Software\GitForWindows; ValueType: string; ValueName: CurrentVersion; ValueData: {#APP_VERSION}; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKLM; Subkey: Software\GitForWindows; ValueType: string; ValueName: InstallPath; ValueData: {app}; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKLM; Subkey: Software\GitForWindows; ValueType: string; ValueName: LibexecPath; ValueData: {app}\{#MINGW_BITNESS}\libexec\git-core; Flags: uninsdeletevalue uninsdeletekeyifempty
+
 ; There is no "Console" key in HKLM.
 Root: HKCU; Subkey: Console; ValueType: string; ValueName: FaceName; ValueData: Lucida Console; Flags: uninsclearvalue; Components: consolefont
 Root: HKCU; Subkey: Console; ValueType: dword; ValueName: FontFamily; ValueData: $00000036; Components: consolefont


### PR DESCRIPTION
The newly introduces registry key

	HKEY_LOCAL_MACHINE\Software\GitForWindows

will now be created and it will contain three values: CurrentVersion,
InstallPath and LibexecPath.

The intention is to support third-party tools' installers so that e.g.
additional remote or credential helpers can easily be installed into the
correct location.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>