### PR TITLE
installer (64-bit): remove 2GB pack size limit

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1342,6 +1342,15 @@ begin
         end;
     end;
     if FileExists(ProgramData + '\Git\config') then begin
+#ifdef IS64
+        if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config -f config --unset pack.packsizelimit',ProgramData+'\Git',SW_HIDE,ewWaitUntilTerminated,i) then begin
+            Msg:='Unable to unset packsize limit';
+
+            // This is not a critical error, so just notify the user and continue.
+            SuppressibleMsgBox(Msg,mbError,MB_OK,IDOK);
+            Log(Msg);
+        end;
+#endif
         Cmd:='http.sslCAInfo "' + AppDir + '/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt"';
         StringChangeEx(Cmd,'\','/',True);
         if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config -f config '+Cmd,


### PR DESCRIPTION
In 64-bit setups it does not make sense to limit the pack size to 2GB,
so delete it from the installation defaults (which are not changeable
later anymore by git config).

This fixes https://github.com/git-for-windows/git/issues/288.

Signed-off-by: Thomas Ackermann <th.acker@arcor.de>
Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>