### PR TITLE
installer: Change installer privileges to 'lowest'

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -55,11 +55,7 @@ DefaultGroupName={#APP_NAME}
 DisableProgramGroupPage=auto
 DisableReadyPage=yes
 InfoBeforeFile={#SourcePath}\gpl-2.0.rtf
-#ifdef OUTPUT_TO_TEMP
 PrivilegesRequired=lowest
-#else
-PrivilegesRequired=poweruser
-#endif
 UninstallDisplayIcon={app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 #ifndef COMPILE_FROM_IDE
 #if Pos('-',APP_VERSION)>0


### PR DESCRIPTION
Allows the installer to be run with normal user permissions again.

Fixes git-for-windows/git#497