### PR TITLE
Add column.exe to the installed files

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -109,3 +109,9 @@ mingw$BITNESS/etc/gitattributes
 mingw$BITNESS/bin/pdftotext.exe
 mingw$BITNESS/bin/libstdc++-6.dll
 EOF
+
+# extras
+# https://github.com/git-for-windows/git/issues/586
+# for https://github.com/tj/git-extras -> used in git line-summary, git summary and git ignore-io
+# from util-linux, 25kb, deps on msys-intl-8.dll, msys-iconv-2.dll, msys-2.0.dll (all included already)
+echo "usr/bin/column.exe"


### PR DESCRIPTION
column.exe is included for the benefit of https://github.com/tj/git-extras
which uses column.exe in git line-summary, git summary and git ignore-io.

It's a 25kb file with no additional dependencies (msys-intl-8.dll,
msys-iconv-2.dll and msys-2.0.dll are all included already). From the
util-linux package...

Closes: https://github.com/git-for-windows/git/issues/586