### PR TITLE
installer (64-bit): remove 2GB pack size limit

### DIFF
--- a/installer/install.iss.in
+++ b/installer/install.iss.in
@@ -1224,6 +1224,7 @@ end;
 procedure CurStepChanged(CurStep:TSetupStep);
 var
     AppDir,ProgramData,DllPath,FileName,Cmd,Msg:String;
+    PackSizeLimit:AnsiString;
     BuiltIns,ImageNames,EnvPath,EnvHome:TArrayOfString;
     Count,i:Longint;
     LinkCreated:Boolean;
@@ -1342,6 +1343,17 @@ begin
         end;
     end;
     if FileExists(ProgramData + '\Git\config') then begin
+#ifdef IS64
+        FileName:=AppDir+'tmp\packsize.txt';
+        if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config -f config pack.packsizelimit  >"'+FileName+'"',AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
+            LogError('Unable to read packsize limit')
+        else if not LoadStringFromFile(FileName,PackSizeLimit) then
+            LogError('Unable to read redirected packsize limit')
+        else if (PackSizeLimit='2g'#10) and not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config -f config --unset pack.packsizelimit',AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
+            LogError('Unable to unset packsize limit');
+SuppressibleMsgBox('PackSizeLimit: "'+PackSizeLimit+'"',mbError,MB_OK,IDOK);
+        DeleteFile(FileName);
+#endif
         Cmd:='http.sslCAInfo "' + AppDir + '/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt"';
         StringChangeEx(Cmd,'\','/',True);
         if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config -f config '+Cmd,


### PR DESCRIPTION

[githubflow-online.pdf](https://github.com/git-for-windows/build-extra/files/170407/githubflow-online.pdf)


TODO: fix redirection and test!!!

In 64-bit setups it does not make sense to limit the pack size to 2GB.

This fixes https://github.com/git-for-windows/git/issues/288.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>