### PR TITLE
installer: enable fscache by default

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1027,7 +1027,7 @@ begin
     end;
 
     // Restore the settings chosen during a previous install.
-    Data:=ReplayChoice('Performance Tweaks FSCache','Disabled');
+    Data:=ReplayChoice('Performance Tweaks FSCache','Enabled');
 
     if Data='Enabled' then begin
         RdbExtraOptions[GP_FSCache].Checked:=True;


### PR DESCRIPTION
This feature really stood the test of time by now, and the wish to
enable it by default has been mentioned quite a couple of times to the
Git for Windows maintainer. Let's make it so.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>