### PR TITLE
installer: switch the default PATH option to 'CMD'

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -696,7 +696,7 @@ begin
     end;
 
     // Restore the setting chosen during a previous install.
-    Data:=ReplayChoice('Path Option','BashOnly');
+    Data:=ReplayChoice('Path Option','Cmd');
 
     if Data='BashOnly' then begin
         RdbPath[GP_BashOnly].Checked:=True;


### PR DESCRIPTION
Many Windows users are very familiar with `cmd.exe` and not really with
the Bash at all. Requiring them to call `Git CMD` explicitly just to be
able to use Git for Windows from their favorite command-line is not
really helpful, in particular when the command-line is launched from
within other software.

So let's just switch the default to adding the `git.exe` (and gitk.exe
and git-gui.exe`) to the PATH.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>