### PR TITLE
In #101 fscache was enabled by default but was not in with with RdbExtraOptions[GP_FSCache]

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1016,7 +1016,7 @@ begin
         Height:=ScaleY(17);
         Font.Style:=[fsBold];
         TabOrder:=0;
-        Checked:=False;
+        Checked:=True;
     end;
     LblFSCache:=TLabel.Create(ExtraOptionsPage);
     with LblFSCache do begin


### PR DESCRIPTION
This patches enables it there.