### PR TITLE
Integrate ssh-pageant

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -31,9 +31,10 @@ pacman_list () {
 required=
 for req in mingw-w64-$ARCH-connect git-flow unzip docx2txt \
 	mingw-w64-$ARCH-antiword mingw-w64-$ARCH-xpdf \
-	mingw-w64-$ARCH-git-credential-manager
+	mingw-w64-$ARCH-git-credential-manager ssh-pageant
 do
 	test -d /var/lib/pacman/local/$req-[0-9]* ||
+	test -d /var/lib/pacman/local/$req-git-[0-9]* ||
 	required="$required $req"
 done
 test -z "$required" ||
@@ -45,7 +46,8 @@ pacman_list mingw-w64-$ARCH-git mingw-w64-$ARCH-git-doc-html \
 	git-extra ncurses mintty vim openssh winpty \
 	sed awk less grep gnupg tar findutils coreutils diffutils patch \
 	dos2unix which subversion mingw-w64-$ARCH-tk \
-	mingw-w64-$ARCH-connect git-flow docx2txt mingw-w64-$ARCH-antiword "$@" |
+	mingw-w64-$ARCH-connect git-flow docx2txt mingw-w64-$ARCH-antiword \
+	ssh-pageant "$@" |
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \
 	-e '^/usr/lib/python' -e '^/usr/lib/ruby' \

--- a/sdk-installer/setup-git-sdk.bat
+++ b/sdk-installer/setup-git-sdk.bat
@@ -138,7 +138,7 @@
 	mingw-w64-@@ARCH@@-curl mingw-w64-@@ARCH@@-expat ^
 	mingw-w64-@@ARCH@@-openssl mingw-w64-@@ARCH@@-tcl ^
 	mingw-w64-@@ARCH@@-pcre mingw-w64-@@ARCH@@-connect ^
-	git-flow
+	git-flow ssh-pageant
 
 @IF ERRORLEVEL 1 GOTO INSTALL_REST
 


### PR DESCRIPTION
@dscho This is my first stab at integrating ssh-pageant support into Git for Windows [[Issue #683]](https://github.com/git-for-windows/git/issues/683). This has been working flawlessly for me under Windows 7 64-bit, provided that the _ssh-pageant_ package was already installed (performed via `pacman -Sy ssh-pageant`) when the installer/portable was built. The reason for request being marked as DO NOT MERGE YET is because I'm unsure if additional action is required, in order to ensure the package is present (by default) when you make a build... my guess is that it needs to somehow be tagged as "install by default" for the SDK, or similar.

The benefit of this integration is that it actually helps us to become _less_ reliant on PuTTY, within the specific context of Git for Windows. For those of us using PuTTY outside of this tool, it removes the need to run and manage multiple agents to manage key-based authentication. In this case, OpenSSH is able to seamlessly handle all of the heavy lifting.