### PR TITLE
Add support for Git LFS

### DIFF
--- a/git-lfs/.gitignore
+++ b/git-lfs/.gitignore
@@ -1,0 +1,4 @@
+pkg
+src
+*.zip
+*.xz

--- a/git-lfs/PKGBUILD
+++ b/git-lfs/PKGBUILD
@@ -1,0 +1,34 @@
+# Maintainer: Brendan Forster <brendan@github.com>
+
+_realname="git-lfs"
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=1.2.0
+pkgrel=1
+pkgdesc="An open source Git extension for versioning large files"
+install=git-lfs.install
+arch=('any')
+url="https://github.com/github/git-lfs"
+license=('MIT')
+groups=('VCS')
+
+case "$CARCH" in
+i686)
+  folder="git-lfs-windows-386-$pkgver"
+  md5sum=0cea336e4c9d43314ebc692dfbbd1fc3
+  ;;
+x86_64)
+  folder="git-lfs-windows-amd64-$pkgver"
+  md5sum=95296495a70a31dd952de15bf7102ead
+  ;;
+esac
+
+source=("https://github.com/github/git-lfs/releases/download/v$pkgver/$folder.zip")
+
+md5sums=("$md5sum")
+options=('!strip')
+
+package() {
+  install -d -m755 $pkgdir/$MINGW_PREFIX/bin
+  install -m755 $srcdir/$folder/git-lfs.exe $pkgdir/$MINGW_PREFIX/bin/git-lfs.exe
+}

--- a/git-lfs/git-lfs.install
+++ b/git-lfs/git-lfs.install
@@ -1,0 +1,21 @@
+post_install() {
+  for arch in mingw32 mingw64; do
+    if [ -f "${arch}/bin/git-lfs.exe" ]; then
+      git config -f "${arch}/etc/gitconfig" filter.lfs.clean "git-lfs clean -- %f"
+      git config -f "${arch}/etc/gitconfig" filter.lfs.smudge "git-lfs smudge -- %f"
+      git config -f "${arch}/etc/gitconfig" filter.lfs.required true
+    fi
+  done
+}
+
+post_upgrade() {
+  post_install
+}
+
+pre_remove() {
+  for arch in mingw32 mingw64; do
+    if [ -f "${arch}/bin/git-lfs.exe" ]; then
+       git config -f "${arch}/etc/gitconfig" --remove-section filter.lfs
+    fi
+  done
+}


### PR DESCRIPTION
There's likely some improvements to do here, but opening this early for feedback:

 - [x] package and test i686 package locally
 - [x] package and test x86_64 package locally
 - [x] confirm compressed file size is accurate 
 - [x] wireup equivalent `git lfs install` and `git lfs uninstall` steps to update config
 - [x] understand the root cause of the issue with this file not being executable after install

```
brendanforster@SHIFTKEYDE8B MINGW32 /usr/src/build-extra/git-lfs (add-support-for-git-lfs)
$ /mingw32/bin/git-lfs.exe
bash: /mingw32/bin/git-lfs.exe: cannot execute binary file: Exec format error

brendanforster@SHIFTKEYDE8B MINGW32 /usr/src/build-extra/git-lfs (add-support-for-git-lfs)
$ file /mingw32/bin/git-lfs.exe
/mingw32/bin/git-lfs.exe: PE32 executable (console) Intel 80386 (stripped to external PDB), for MS Windows
```

 - [x] simplify packaging steps
 - [x] update version to v1.2
 - [x] correct installation to use new rules

cc @dscho as we discussed last week
cc @technoweenie just cause