### PR TITLE
Support generating NuGet packages of Git for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@
 /msi/obj/
 /msi/package-versions.txt
 /msi/wix40-binaries.zip
+/nuget/GitForWindows.nuspec
+/nuget/nuget.exe
+/nuget/package-versions.txt
 /portable/root/bin/
 /portable/root/cmd/
 /portable/root/etc/

--- a/nuget/GitForWindows.nuspec.in
+++ b/nuget/GitForWindows.nuspec.in
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>@@ID@@</id>
+    <version>@@VERSION@@</version>
+    <authors>@@AUTHOR@@</authors>
+    <owners>@@AUTHOR@@</owners>
+    <licenseUrl>https://github.com/git-for-windows/git/blob/master/COPYING</licenseUrl>
+    <projectUrl>https://git-for-windows.github.io/</projectUrl>
+    <iconUrl>https://avatars2.githubusercontent.com/u/4571183</iconUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Git for Windows</description>
+    <releaseNotes>See embedded ReleaseNotes.html</releaseNotes>
+    <copyright>Copyright 2016</copyright>
+    <tags>git scm vcs command line shell</tags>
+  </metadata>
+  <files>
+    <file src="$buildextra$\nuget\ReleaseNotes.html" />
+    <file src="$buildextra$\installer\usr\share\git\ReleaseNotes.css" target="content" />
+    <file src="$buildextra$\nuget\Install.ps1" target="tools" />
+    <file src="$buildextra$\post-install.bat" target="tools" />
+    <file src="$buildextra$\nuget\package-versions.txt" target="tools\etc" />
+    @@FILELIST@@
+  </files>
+</package>

--- a/nuget/Install.ps1
+++ b/nuget/Install.ps1
@@ -1,0 +1,3 @@
+param($installPath, $toolsPath, $package, $project)
+
+"$toolsPath\post-install.bat"

--- a/nuget/release.sh
+++ b/nuget/release.sh
@@ -1,0 +1,95 @@
+#!/bin/sh
+
+BUILDEXTRA="$(cd "$(dirname "$0")"/.. && pwd)"
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+AUTHOR=$USERNAME
+ID=GitForWindows
+while test $# -gt 1
+do
+	case "$1" in
+	--author=*) AUTHOR=${1#--*=};;
+	--id=*) ID=${1#--*=};;
+	-*) die "Unknown option: $1";;
+	*) break;;
+	esac
+	shift
+done
+
+test $# -ge 1 ||
+die "Usage: $0 [--author=<name>] [--id=<name>] <version> [<extra-package>...]"
+
+VERSION=$1
+shift
+
+if test -x "$BUILDEXTRA"/nuget/nuget.exe
+then
+	PATH=$BUILDEXTRA/nuget:$PATH
+elif ! type -p nuget.exe
+then
+	(cd "$BUILDEXTRA"/nuget &&
+	 curl -O https://dist.nuget.org/win-x86-commandline/latest/nuget.exe) ||
+	die "Could not download nuget.exe"
+fi
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+i686)
+	BITNESS=32
+	;;
+x86_64)
+	BITNESS=64
+	;;
+*)
+	die "Unhandled architecture: $ARCH"
+	;;
+esac
+
+# Generate release notes for NuGet
+RELNOTES="$BUILDEXTRA"/nuget/ReleaseNotes.html
+RELNOTESMD="$BUILDEXTRA"/installer/ReleaseNotes.md
+test -f "$RELNOTES" &&
+test "$RELNOTES" -nt "$RELNOTESMD" || {
+	# Install markdown
+	type markdown ||
+	pacman -Sy --noconfirm markdown ||
+	die "Could not install markdown"
+
+	(printf '%s\n%s\n%s\n%s %s\n%s %s\n%s\n%s\n%s\n' \
+		'<!DOCTYPE html>' \
+		'<html>' \
+		'<head>' \
+		'<meta http-equiv="Content-Type" content="text/html;' \
+		'charset=UTF-8">' \
+		'<link rel="stylesheet"' \
+		' href="content/ReleaseNotes.css">' \
+		'</head>' \
+		'<body class="details">' \
+		'<div class="content">'
+	 markdown "$RELNOTESMD" ||
+	 die "Could not generate ReleaseNotes.html"
+	 printf '</div>\n</body>\n</html>\n') >"$RELNOTES"
+}
+
+SPECIN="$BUILDEXTRA"/nuget/GitForWindows.nuspec.in
+SPEC="$BUILDEXTRA/nuget/$ID".nuspec
+sed -e "s/@@VERSION@@/$VERSION/g" -e "s/@@AUTHOR@@/$AUTHOR/g" \
+	-e "s/@@ID@@/$ID/g" -e '/@@FILELIST@@/,$d' <"$SPECIN" >"$SPEC"
+
+# Make a list of files to include
+LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
+	PACKAGE_VERSIONS_FILE="$BUILDEXTRA"/nuget/package-versions.txt \
+	sh "$BUILDEXTRA"/make-file-list.sh "$@")" ||
+die "Could not generate file list"
+
+echo "$LIST" |
+sed -e 'y/\//\\/' -e 's/.*/    <file src="&" target="tools\\&" \/>/' >>"$SPEC"
+
+sed '1,/@@FILELIST@@/d' <"$SPECIN" >>"$SPEC"
+
+nuget pack -BasePath / -Properties buildextra="$(cd "$BUILDEXTRA" && pwd -W)" \
+	-OutputDirectory "$HOME" -Verbosity detailed "$SPEC"


### PR DESCRIPTION
We steal heavily from ourselves here...

Please note that the Install.ps1 script is only called if the NuGet
package is installed inside Visual Studio (and not if installed via
nuget.exe; this is a bug in nuget.exe as of time of writing).

Therefore, the user should still call tools\post-install.bat manually
or start tools\git-bash.exe once before doing anything else, if
nuget.exe is used to install this package.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>