### PR TITLE
msi: Fix shortcut working folder for other users

### DIFF
--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -49,8 +49,6 @@
         </Directory>
       </Directory>
 
-      <Directory Id='PersonalFolder' />
-
       <Directory Id='ProgramMenuFolder'>
         <Directory Id='GitProgramMenuFolder' Name='Git' />
       </Directory>

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -69,9 +69,9 @@ sed -e 's/\(.*\)\\\(.*\)/            <Component Directory="INSTALLFOLDER:\\\1\\"
 	    -e 's/^\([^\\]*\)$/            <Component Directory="INSTALLFOLDER">\
                 <File Source="&" \/>\
             <\/Component>/' \
-	    -e 's/\(<File Source="git-bash.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git Bash" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="PersonalFolder" Advertise="yes" \/>/' \
-	    -e 's/\(<File Source="git-cmd.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git CMD" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="PersonalFolder" Advertise="yes" \/>/' \
-	    -e 's/\(<File Source="cmd\\git-gui.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git GUI" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="PersonalFolder" Advertise="yes" \/>/'
+	    -e 's/\(<File Source="git-bash.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git Bash" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
+	    -e 's/\(<File Source="git-cmd.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git CMD" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
+	    -e 's/\(<File Source="cmd\\git-gui.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git GUI" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/'
 
 cat <<EOF
         </ComponentGroup>


### PR DESCRIPTION
The simple solution using `PersonalFolder` during install means the
Git shortcuts all use "My Documents" folder for the user that
installed Git for Windows. Unfortunately, that means subsequent users
attempt to start in the installing user's "My Documents" folder.

Obviously that is undersirable behavior at best and won't work at all
given folder permissions at worst.

So instead we'll use our INSTALLFOLDER as the working folder and the
`--cd-to-home` argument to let the tools start in a reasonable folder.

Based on outstanding research by @fourpastmidnight