### PR TITLE
Double slash path conversion, and drive letter examples

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -17,6 +17,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
   > `MSYS_NO_PATHCONV=1 git blame -L/pathconv/ msys2_path_conv.cc`
 
   Alternatively, you can double the first slash to avoid POSIX-to-Windows path conversion, e.g. "`//usr/bin/bash.exe`".
+* Windows drives are normally recognised within the POSIX path as `/c/path/to/dir/` where `/c/` (or appropriate drive letter) is equivalent to the `C:\` Windows prefix to the `\path\to\dir`. If this is not recoginsed, revert to the `C:\path\to\dir` Windows style.
 * Git for Windows will not allow commits containing DOS-style truncated 8.3-format filenames ending with a tilde and digit, such as `mydocu~1.txt`. A workaround is to call `git config core.protectNTFS false`, which is not advised. Instead, add a rule to .gitignore to ignore the file(s), or rename the file(s).
 * Many Windows programs (including the Windows Explorer) have problems with directory trees nested so deeply that the absolute path is longer than 260 characters. Therefore, Git for Windows refuses to check out such files by default. You can overrule this default by setting `core.longPaths`, e.g. `git clone -c core.longPaths=true ...`.
 *   Some commands are not yet supported on Windows and excluded from the installation.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -16,7 +16,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
 
   > `MSYS_NO_PATHCONV=1 git blame -L/pathconv/ msys2_path_conv.cc`
 
-  Alternatively, you can double the first slash to avoid POSIX-to-Windows path conversion.
+  Alternatively, you can double the first slash to avoid POSIX-to-Windows path conversion, e.g. "`//usr/bin/bash.exe`".
 * Git for Windows will not allow commits containing DOS-style truncated 8.3-format filenames ending with a tilde and digit, such as `mydocu~1.txt`. A workaround is to call `git config core.protectNTFS false`, which is not advised. Instead, add a rule to .gitignore to ignore the file(s), or rename the file(s).
 * Many Windows programs (including the Windows Explorer) have problems with directory trees nested so deeply that the absolute path is longer than 260 characters. Therefore, Git for Windows refuses to check out such files by default. You can overrule this default by setting `core.longPaths`, e.g. `git clone -c core.longPaths=true ...`.
 *   Some commands are not yet supported on Windows and excluded from the installation.


### PR DESCRIPTION
Update the (G4W) Release Notes with an example of using the double slash, and also an example of the Windows drive letter conversion.

This is a fall out from my attempt to use `git apply <path>` to a patch which wasn't within the root path of the git bash invocation (neither my SDK install, nor my Program Files install). 

I could `cat` the file, but git said it didn't exist. (repeated below)

```
Philip@PhilipOakley MINGW32 /c/git-sdk-32/usr/src/build-extra (dslash)
$ git apply '/c/Documents and Settings/Philip/My Documents/git stuff/[PATCHv4] Documentation_ triangular workflow.eml'
fatal: can't open patch '/c/Documents and Settings/Philip/My Documents/git stuff/[PATCHv4] Documentation_ triangular workflow.eml': No such file or directory

Philip@PhilipOakley MINGW32 /c/git-sdk-32/usr/src/build-extra (dslash)
$ cat '/c/Documents and Settings/Philip/My Documents/git stuff/[PATCHv4] Documentation_ triangular workflow.eml' Return-Path: <git-owner@vger.kernel.org>
Received: from cm8nec (10.103.251.8) by mail.svcgb1.int.opaltelecom.net (8.6.141.04)
        id 574E529600663FCB for philipoakley@talktalk.net; Thu, 9 Jun 2016 13:35:34 +0100
[...]

Philip@PhilipOakley MINGW32 /c/git-sdk-32/usr/src/build-extra (dslash)
$ git version
git version 2.8.4.windows.1
```

This is on a little old XP (SP3) netbook

I knew it was probably something to do with the quoting & drive letter, but couldn't find the right notes.

I've updated the G4W wiki FAQ to cover the location of the Release Notes (which are easily forgotten).

I spotted that the release notes themselves do not give the double slash example I was expecting when I scanned the page (which is commit 1)

I was also expecting something about the drive letter mapping, so I created a short example (commit 2).

The [MSYS2 wiki](https://sourceforge.net/p/msys2/wiki/Path%20Conversion%20Rules/) suggests that the hueristics will be documented soon, so this is my minimalistic note for the user who actually looks at the Release notes;-)
