### PR TITLE
msi: Respect user's choice of terminal emulator

### DIFF
--- a/edit-git-bash.c
+++ b/edit-git-bash.c
@@ -76,7 +76,17 @@ int main(int argc, char **argv)
 	int wargc, result;
 	LPWSTR *wargv;
 
+#ifdef DEBUG
+	LPTSTR cmdLine = GetCommandLineW();
+	fwprintf(stderr, L"Command Line: %s\n", cmdLine);
+	
+	wargv = CommandLineToArgvW(cmdLine, &wargc);
+
+	for (int i = 1; i < wargc; ++i)
+		fwprintf(stderr, L"Arg %d: %s\n", i, wargv[i]);
+#else
 	wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+#endif
 
 	if (wargc != 3) {
 		fwprintf(stderr, L"Usage: %s <path-to-exe> <new-commad-line>\n",

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -72,7 +72,20 @@
       LINEENDINGS~="false"
     </SetProperty>
 
+    <Property Id="CMDLINE_TERMINAL" Value="MinTTY" />
     <Property Id="TERMINAL" Value="MinTTY" />
+    <SetProperty Id="CMDLINE_TERMINAL" Value="[TERMINAL]" Before="AppSearch" Sequence="first"><![CDATA[ TERMINAL <> CMDLINE_TERMINAL AND (TERMINAL~="CmdPrompt" OR TERMINAL~="MinTTY") ]]></SetProperty>
+    <Property Id="TERMINALSEARCH">
+      <RegistrySearch Id="TerminalSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="Terminal" Type="raw" />
+    </Property>
+    <SetProperty Id="TERMINAL" Value="[TERMINALSEARCH]" Action="GetUpgradeTERMINALValue" After="AppSearch" Sequence="first">TERMINALSEARCH</SetProperty>
+    <SetProperty Id="TERMINAL" Value="[CMDLINE_TERMINAL]" After="GetUpgradeTERMINALValue" Sequence="first"><![CDATA[ CMDLINE_TERMINAL <> TERMINAL ]]></SetProperty>
+    <SetProperty Id="TERMINAL" Value="MinTTY" Action="NormalizeMinTTYCasing" After="SetTERMINAL" Sequence="first">
+      TERMINAL~="MinTTY"
+    </SetProperty>
+    <SetProperty Id="TERMINAL" Value="CmdPrompt" Action="NormalizeCmdPromptCasing" After="SetTERMINAL" Sequence="first">
+      TERMINAL~="CmdPrompt"
+    </SetProperty>
 
     <SetProperty Id="CMDLINE_ENABLEFSCACHE" Value="false" Before="AppSearch" Sequence="first">
       ENABLEFSCACHE~="false" OR ENABLEFSCACHE=0
@@ -342,6 +355,10 @@
     <CustomAction Id="ExecConfigureFsCache" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="ignore" Impersonate="no" />
     <SetProperty Id="ExecConfigureGcm" Value='"[#GitExe]" config --system credential.helper manager' Sequence="execute" Before="ExecConfigureGcm"><![CDATA[ REMOVE <> "ALL" AND ENABLEGCM=1 ]]></SetProperty>
     <CustomAction Id="ExecConfigureGcm" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="ignore" Impersonate="no" />
+    <SetProperty Id="ExecEditGitBash" Value='"[#EditGitBash]" "[#GitBash]" "SHOW_CONSOLE=1 APPEND_QUOTE=1 @@COMSPEC@@ /S /C \"\"@@EXEPATH@@\usr\bin\bash.exe\" --login -i"' Sequence="execute" Before="ExecEditGitBash"><![CDATA[ REMOVE <> "ALL" AND TERMINAL = "CmdPrompt" ]]></SetProperty>
+    <CustomAction Id="ExecEditGitBash" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="check" Impersonate="no" />
+    <SetProperty Id="DeleteEditGitBash" Value='"[System$(var.SixtyFourBit)Folder]cmd.exe" /S /C del "[#EditGitBash]"' Sequence="execute" Before="DeleteEditGitBash"><![CDATA[ REMOVE <> "ALL" AND TERMINAL = "CmdPrompt" ]]></SetProperty>
+    <CustomAction Id="DeleteEditGitBash" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="ignore" Impersonate="no" />
     <!-- Schedule two "best effort" actions:
           1. Write the command to run the post-install.bat to the transaction log
           2. Execute the command during the installation transaction
@@ -356,7 +373,9 @@
       <Custom Action="ExecConfigureSslCAInfo" Before="ExecConfigureCoreAutoCrlf"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
       <Custom Action="ExecConfigureCoreAutoCrlf" Before="ExecConfigureFsCache"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
       <Custom Action="ExecConfigureFsCache" Before="ExecConfigureGcm"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
-      <Custom Action="ExecConfigureGcm" Before="ExecPostInstallBat"><![CDATA[ REMOVE <> "ALL" AND ENABLEGCM=1 ]]></Custom>
+      <Custom Action="ExecConfigureGcm" Before="ExecEditGitBash"><![CDATA[ REMOVE <> "ALL" AND ENABLEGCM=1 ]]></Custom>
+      <Custom Action="ExecEditGitBash" Before="DeleteEditGitBash"><![CDATA[ TERMINAL = "CmdPrompt" AND REMOVE <> "ALL" ]]></Custom>
+      <Custom Action="DeleteEditGitBash" Before="ExecPostInstallBat"><![CDATA[ TERMINAL = "CmdPrompt" AND REMOVE <> "ALL" ]]></Custom>
       <!-- Execute the post-install.bat at the end of the installation transaction on install and repair but not removal. -->
       <Custom Action="ExecPostInstallBat" Before="InstallFinalize"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
     </InstallExecuteSequence>

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -171,7 +171,9 @@ sed -e 's/\(.*\)\\\(.*\)/            <Component Directory="INSTALLFOLDER:\\\1\\"
 	-e "s/<File Source=\"\(mingw$BITNESS.*\(ca\)-\(bundle\.crt\)\)\" \/>/<File Id=\"\2_\3\" Source=\"\1\" \/>/"\
 	-e 's/\(<File Source="git-bash.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git Bash" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
 	-e 's/\(<File Source="git-cmd.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git CMD" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
-	-e 's/\(<File Source="cmd\\git-gui.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git GUI" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/'
+	-e 's/\(<File Source="cmd\\git-gui.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git GUI" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
+	-e 's/\(<Component Directory="INSTALLFOLDER:\\etc\\post-install\\"\)>/\1 Guid="" >/' \
+	-e 's/\(<File Source="etc\\post-install\\.*\.post"\) \/>/\1 KeyPath="yes" \/>/'
 cat <<EOF
         </ComponentGroup>
     </Fragment>

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -117,7 +117,9 @@ cd "$SCRIPT_PATH" ||
 die "Could not switch directory to $SCRIPT_PATH"
 
 # Generate the ReleaseNotes.html file
-../render-release-notes.sh --css usr/share/git/
+../render-release-notes.sh --css usr/share/git/ ||
+die "Could not generate ReleaseNotes.html."
+
 
 # Make a list of files to include
 LIST="$(ARCH=$ARCH BITNESS=$BITNESS \

--- a/nuget/release.sh
+++ b/nuget/release.sh
@@ -50,7 +50,8 @@ x86_64)
 esac
 
 # Generate release notes for NuGet
-../render-release-notes.sh --css content/
+../render-release-notes.sh --css content/ ||
+die "Could not generate ReleaseNotes.html."
 
 SPECIN="$BUILDEXTRA"/nuget/GitForWindows.nuspec.in
 SPEC="$BUILDEXTRA/nuget/$ID".nuspec


### PR DESCRIPTION
This pull request teaches the MSI installer to respect the user's choice of terminal emulator: mintty or ConHost (i.e. the standard Windows Command Prompt DOS box).

This pull request also incorporates a few fixes to the MSI and NuGet `release.sh` scripts, aborting the creation of the installer or NuGet package if the Release Notes could not be generated.