### PR TITLE
git-prompt: fully enable the PS1 prompt on the SDK

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -30,3 +30,4 @@ fi
 PS1="$PS1"'\[\033[0m\]'        # change color
 PS1="$PS1"'\n'                 # new line
 PS1="$PS1"'$ '                 # prompt: always $
+MSYS2_PS1="$PS1"               # for detection by MSYS2 SDK's bash.basrc


### PR DESCRIPTION
The SDK installation, at some point, overwrites the /etc/bash.bashrc file
and now detects a $MSYS2_PS1 prompt as an alternative to setting a default
PS1 prompt. Any pre-prepared PS1 is overwritten.

Provide that alternate environment variable.

The Git-for-Windows installation does not use that version of the
/etc/bash.bashrc file, so is unaffected.

Signed-off-by: Philip Oakley <philipoakley@iee.org>