### PR TITLE
msi: Fix Git for Windows MSI installer properties implementation [HOLD OFF]

### DIFF
--- a/msi/GitAdditionalOptionsDlg.wxs
+++ b/msi/GitAdditionalOptionsDlg.wxs
@@ -10,11 +10,7 @@
           <Condition Action="disable">NOT WIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED</Condition>
         </Control>
         <Control Type="PushButton" Id="Back" Width="56" Height="17" X="180" Y="243" Text="!(loc.WixUIBack)" />
-        <Control Type="PushButton" Id="Next" Width="56" Height="17" X="236" Y="243" Default="yes" Text="!(loc.WixUINext)">
-          <Publish Property="ENABLEFSCACHE" Value="false"><![CDATA[ ENABLEFSCACHE <> "true" ]]></Publish>
-          <Publish Property="ENABLEFSCACHE" Value="true">ENABLEFSCACHE = "true"</Publish>
-          <Publish Property="ENABLEGCM" Value="0"><![CDATA[ ENABLEGCM <> 1 ]]></Publish>
-        </Control>
+        <Control Type="PushButton" Id="Next" Width="56" Height="17" X="236" Y="243" Default="yes" Text="!(loc.WixUINext)" />
         <Control Type="PushButton" Id="Cancel" Width="56" Height="17" X="304" Y="243" Text="!(loc.WixUICancel)" Cancel="yes">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
         </Control>

--- a/msi/GitLineEndingsDlg.wxs
+++ b/msi/GitLineEndingsDlg.wxs
@@ -9,8 +9,12 @@
             <RadioButton Text="!(loc.GitLineEndingsDlg_RbCustomize)" Height="30" Value="Yes" Width="310" X="0" Y="15" />
           </RadioButtonGroup>
         </Control>
-        <Control Type="PushButton" Id="Back" Width="56" Height="17" X="180" Y="243" Text="!(loc.WixUIBack)" />
-        <Control Type="PushButton" Id="Next" Width="56" Height="17" X="236" Y="243" Default="yes" Text="!(loc.WixUINext)" />
+        <Control Type="PushButton" Id="Back" Width="56" Height="17" X="180" Y="243" Text="!(loc.WixUIBack)">
+          <Publish Property="LINEENDINGS" Value="true">CustomizeLineEndings = "No"</Publish>
+        </Control>
+        <Control Type="PushButton" Id="Next" Width="56" Height="17" X="236" Y="243" Default="yes" Text="!(loc.WixUINext)">
+          <Publish Property="LINEENDINGS" Value="true">CustomizeLineEndings = "No"</Publish>
+        </Control>
         <Control Type="PushButton" Id="Cancel" Width="56" Height="17" X="304" Y="243" Cancel="yes" Text="!(loc.WixUICancel)">
           <Publish Event="SpawnDialog" Value="CancelDlg">1</Publish>
         </Control>

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -69,6 +69,7 @@
 
     <Property Id="AUTOCRLF" Value="Unset" />
     <Property Id="GfwLineEndings" Value="true" />
+    <Property Id="SkipGitLineEndingsDlg" Value="No" />
     <Property Id="LINEENDINGS" Value="true" />
     <Property Id="LINEENDINGSSEARCH">
       <RegistrySearch Id="LineEndingsSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="core.autocrlf" Type="raw" />
@@ -83,6 +84,9 @@
     <SetProperty Id="GfwLineEndings" Value="input" Action="NormalizeCaseGfwLineEndingsInput" After="SetGfwLineEndingsFromCommandLine" Sequence="first">GfwLineEndings~="input"</SetProperty>
     <SetProperty Id="GfwLineEndings" Value="false" Action="NormalizeCaseGfwLineEndingsFalse" After="SetGfwLineEndingsFromCommandLine" Sequence="first">GfwLineEndings~="false"</SetProperty>
     <SetProperty Id="LINEENDINGS" Value="[GfwLineEndings]" Before="CostFinalize" Sequence="first" />
+    <SetProperty Id="SkipGitLineEndingsDlg" Value="Yes" Before="CostFinalize" Sequence="ui">
+      NOT GfwLineEndings="true" OR AUTOCRLF~="true" OR AUTOCRLF~="input" OR AUTOCRLF~="false"
+    </SetProperty>
 
     <Property Id="CMDLINE_TERMINAL" Value="MinTTY" />
     <Property Id="TERMINAL" Value="MinTTY" />
@@ -317,17 +321,19 @@
       <Property Id="WIXUI_INSTALLDIR" Value="INSTALLFOLDER" />
 
       <Publish Dialog="GitChooseEnvironmentDlg" Control="Back" Event="NewDialog" Value="InstallDirDlg">1</Publish>
-      <Publish Dialog="GitChooseEnvironmentDlg" Control="Next" Event="NewDialog" Value="GitLineEndingsDlg">1</Publish>
+      <Publish Dialog="GitChooseEnvironmentDlg" Control="Next" Event="NewDialog" Value="GitLineEndingsDlg">SkipGitLineEndingsDlg = "No"</Publish>
+      <Publish Dialog="GitChooseEnvironmentDlg" Control="Next" Event="NewDialog" Value="GitCustomizeLineEndingsDlg">SkipGitLineEndingsDlg = "Yes"</Publish>
 
       <Publish Dialog="GitLineEndingsDlg" Control="Back" Event="NewDialog" Value="GitChooseEnvironmentDlg">1</Publish>
       <Publish Dialog="GitLineEndingsDlg" Control="Next" Event="NewDialog" Value="GitCustomizeLineEndingsDlg">CustomizeLineEndings = "Yes"</Publish>
       <Publish Dialog="GitLineEndingsDlg" Control="Next" Event="NewDialog" Value="GitChooseTerminalDlg">CustomizeLineEndings = "No"</Publish>
 
-      <Publish Dialog="GitCustomizeLineEndingsDlg" Control="Back" Event="NewDialog" Value="GitLineEndingsDlg">1</Publish>
+      <Publish Dialog="GitCustomizeLineEndingsDlg" Control="Back" Event="NewDialog" Value="GitLineEndingsDlg">SkipGitLineEndingsDlg = "No"</Publish>
+      <Publish Dialog="GitCustomizeLineEndingsDlg" Control="Back" Event="NewDialog" Value="GitChooseEnvironmentDlg">SkipGitLineEndingsDlg = "Yes"</Publish>
       <Publish Dialog="GitCustomizeLineEndingsDlg" Control="Next" Event="NewDialog" Value="GitChooseTerminalDlg">1</Publish>
 
-      <Publish Dialog="GitChooseTerminalDlg" Control="Back" Event="NewDialog" Value="GitLineEndingsDlg">CustomizeLineEndings = "No"</Publish>
-      <Publish Dialog="GitChooseTerminalDlg" Control="Back" Event="NewDialog" Value="GitCustomizeLineEndingsDlg">CustomizeLineEndings = "Yes"</Publish>
+      <Publish Dialog="GitChooseTerminalDlg" Control="Back" Event="NewDialog" Value="GitLineEndingsDlg">CustomizeLineEndings = "No" AND SkipGitLineEndingsDlg = "No"</Publish>
+      <Publish Dialog="GitChooseTerminalDlg" Control="Back" Event="NewDialog" Value="GitCustomizeLineEndingsDlg">CustomizeLineEndings = "Yes" OR SkipGitLineEndingsDlg = "Yes"</Publish>
       <Publish Dialog="GitChooseTerminalDlg" Control="Next" Event="NewDialog" Value="GitAdditionalOptionsDlg">1</Publish>
 
       <Publish Dialog="GitAdditionalOptionsDlg" Control="Back" Event="NewDialog" Value="GitChooseTerminalDlg">1</Publish>

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -127,23 +127,27 @@
       UILevel = 5 AND ENABLEFSCACHE="false"
     </SetProperty>
 
-    <SetProperty Id="CMDLINE_ENABLEGCM" Value="0" Before="AppSearch" Sequence="first">
-      ENABLEGCM~="false" OR ENABLEGCM=0
-    </SetProperty>
-    <Property Id="ENABLEGCM" Value="1">
+    <Property Id="USEGCM" Value="Unset" />
+    <Property Id="GfwEnableGcm" Value="1" />
+    <Property Id="ENABLEGCM" Value="1" />
+    <Property Id="GCMSEARCH">
       <RegistrySearch Id="EnableGcmSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="EnableGcm" Type="raw" />
     </Property>
-    <SetProperty Id="ENABLEGCM" Action="SetENABLEGCMTo1OnUpgradeIfPreviouslyEnabled" Value="1" After="AppSearch" Sequence="first">
-      ENABLEGCM~="true" OR ENABLEGCM="#1"
+    <SetProperty Id="GfwEnableGcm" Value="[GCMSEARCH]" Action="SetGfwEnableGcmUsingPreviouslyInstalledValue" After="AppSearch" Sequence="first">
+      (WIX_UPGRADE_DETECTED OR REINSTALL) AND (GCMSEARCH="#1" OR GCMSEARCH="#0")
     </SetProperty>
-    <SetProperty Id="ENABLEGCM" Action="SetENABLEGCMTo0FromCmdLineOrOnUpgradeIfDisabled" Value="0" After="AppSearch" Sequence="first">
-      CMDLINE_ENABLEGCM OR ENABLEGCM~="false" OR ENABLEGCM="#0"
+    <SetProperty Id="GfwEnableGcm" Value="[USEGCM]" Action="SetGfwEnableGcmFromCommandLine" After="SetGfwEnableGcmUsingPreviouslyInstalledValue" Sequence="first">
+      USEGCM~="true" OR USEGCM~="false" OR USEGCM~="yes" OR USEGCM~="no" OR USEGCM~="on" OR USEGCM~="off" OR USEGCM="1" OR USEGCM="0"
     </SetProperty>
-    <SetProperty Id="ENABLEGCM" Action="SetENABLEGCMTo0IfNoNetFx451Plus" Value="0" After="SetWIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED" Sequence="first">
-      NOT WIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED
+    <SetProperty Id="GfwEnableGcm" Value="1" Action="NormalizeGfwEnableGcmTrue" After="SetWIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED" Sequence="first">
+      GfwEnableGcm~="true" OR GfwEnableGcm~="yes" OR GfwEnableGcm~="on" OR GfwEnableGcm="1" OR GfwEnableGcm="#1"
     </SetProperty>
-    <SetProperty Id="ENABLEGCM" Action="SetENABLEGCMToNullIfDisabledAndFullUIInstall" Value="{}" After="SetENABLEGCMTo0IfNoNetFx451Plus" Sequence="ui">
-      UILevel = 5 AND ENABLEGCM=0
+    <SetProperty Id="GfwEnableGcm" Value="0" Action="NormalizeGfwEnableGcmIfFalseOrSetFalseIfNetFx451NotInstalled" After="SetWIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED" Sequence="first">
+      NOT WIX_IS_NETFRAMEWORK_451_OR_LATER_INSTALLED OR GfwEnableGcm~="false" OR GfwEnableGcm~="no" OR GfwEnableGcm~="off" OR GfwEnableGcm="0" OR GfwEnableGcm="#0"
+    </SetProperty>
+    <SetProperty Id="ENABLEGCM" Value="[GfwEnableGcm]" Before="CostFinalize" Sequence="first" />
+    <SetProperty Id="ENABLEGCM" Value="{}" Action="ClearENABLEGCMIfFalseAndFullUIInstall" After="SetENABLEGCM" Sequence="ui">
+      UILevel = 5 AND ENABLEGCM = 0
     </SetProperty>
 
     <Property Id="GITBASHHERE" Value="1" />

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -67,22 +67,22 @@
     </SetProperty>
     <SetProperty Id="CLIENVIRONMENT" Value="[GfwCliEnvironment]" Before="CostFinalize" Sequence="first" />
 
-    <SetProperty Id="CMDLINE_LINEENDINGS" Value="[LINEENDINGS]" Before="AppSearch" Sequence="first">
-      <![CDATA[ LINEENDINGS~="input" OR LINEENDINGS~="false" ]]>
-    </SetProperty>
-    <Property Id="LINEENDINGS" Value="true">
+    <Property Id="AUTOCRLF" Value="Unset" />
+    <Property Id="GfwLineEndings" Value="true" />
+    <Property Id="LINEENDINGS" Value="true" />
+    <Property Id="LINEENDINGSSEARCH">
       <RegistrySearch Id="LineEndingsSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="core.autocrlf" Type="raw" />
     </Property>
-    <SetProperty Id="LINEENDINGS" Value="[CMDLINE_LINEENDINGS]" After="AppSearch" Sequence="first">CMDLINE_LINEENDINGS</SetProperty>
-    <SetProperty Id="LINEENDINGS" Value="true" Action="NormalizeTrueLINEENDINGSCasing" After="SetLINEENDINGS" Sequence="first">
-      LINEENDINGS~="true"
+    <SetProperty Id="GfwLineEndings" Value="[LINEENDINGSSEARCH]" Action="SetGfwLineEndingsUsingPreviouslyInstalledValue" After="AppSearch" Sequence="first">
+      (WIX_UPGRADE_DETECTED OR REINSTALL) AND (LINEENDINGSSEARCH~="true" OR LINEENDINGSSEARCH~="input" OR LINEENDINGSSEARCH~="false")
     </SetProperty>
-    <SetProperty Id="LINEENDINGS" Value="input" Action="NormalizeInputLINEENDINGSCasing" After="SetLINEENDINGS" Sequence="first">
-      LINEENDINGS~="input"
+    <SetProperty Id="GfwLineEndings" Value="[AUTOCRLF]" Action="SetGfwLineEndingsFromCommandLine" After="SetGfwLineEndingsUsingPreviouslyInstalledValue" Sequence="first">
+      AUTOCRLF~="true" OR AUTOCRLF~="input" OR AUTOCRLF~="false"
     </SetProperty>
-    <SetProperty Id="LINEENDINGS" Value="false" Action="NormalizeFalseLINEENDINGSCasing" After="SetLINEENDINGS" Sequence="first">
-      LINEENDINGS~="false"
-    </SetProperty>
+    <SetProperty Id="GfwLineEndings" Value="true" Action="NormalizeCaseGfwLineEndingsTrue" After="SetGfwLineEndingsFromCommandLine" Sequence="first">GfwLineEndings~="true"</SetProperty>
+    <SetProperty Id="GfwLineEndings" Value="input" Action="NormalizeCaseGfwLineEndingsInput" After="SetGfwLineEndingsFromCommandLine" Sequence="first">GfwLineEndings~="input"</SetProperty>
+    <SetProperty Id="GfwLineEndings" Value="false" Action="NormalizeCaseGfwLineEndingsFalse" After="SetGfwLineEndingsFromCommandLine" Sequence="first">GfwLineEndings~="false"</SetProperty>
+    <SetProperty Id="LINEENDINGS" Value="[GfwLineEndings]" Before="CostFinalize" Sequence="first" />
 
     <Property Id="CMDLINE_TERMINAL" Value="MinTTY" />
     <Property Id="TERMINAL" Value="MinTTY" />

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -104,20 +104,27 @@
     <SetProperty Id="GfwTerminal" Value="CmdPrompt" Action="NormalizeCaseGfwTerminalCmdPrompt" After="SetGfwTerminalFromCommandLine" Sequence="first">GfwTerminal~="CmdPrompt"</SetProperty>
     <SetProperty Id="TERMINAL" Value="[GfwTerminal]" Before="CostFinalize" Sequence="first" />
 
-    <SetProperty Id="CMDLINE_ENABLEFSCACHE" Value="false" Before="AppSearch" Sequence="first">
-      ENABLEFSCACHE~="false" OR ENABLEFSCACHE=0
-    </SetProperty>
-    <Property Id="ENABLEFSCACHE" Value="true">
+    <Property Id="USEFSCACHE" Value="Unset" />
+    <Property Id="GfwEnableFsCache" Value="true" />
+    <Property Id="ENABLEFSCACHE" Value="true" />
+    <Property Id="FSCACHESEARCH">
       <RegistrySearch Id="EnableFsCacheSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="core.fscache" Type="raw" />
     </Property>
-    <SetProperty Id="ENABLEFSCACHE" Action="SetENABLESCACHEToTrue" Value="true" After="AppSearch" Sequence="first">
-      <![CDATA[ UILevel < 5 AND (ENABLEFSCACHE~="true" OR ENABLEFSCACHE=1) ]]>
+    <SetProperty Id="GfwEnableFsCache" Value="[FSCACHESEARCH]" Action="SetGfwEnableFsCacheUsingPreviouslyInstalledValue" After="AppSearch" Sequence="first">
+      (WIX_UPGRADE_DETECTED OR REINSTALL) AND (FSCACHESEARCH~="true" OR FSCACHESEARCH~="false" OR FSCACHESEARCH~="yes" OR FSCACHESEARCH~="no" OR FSCACHESEARCH~="on" OR FSCACHESEARCH~="off" OR FSCACHESEARCH="0" OR FSCACHESEARCH="1")
     </SetProperty>
-    <SetProperty Id="ENABLEFSCACHE" Action="SetENABLEFSCACHEToFalse" Value="false" After="AppSearch" Sequence="first">
-      <![CDATA[ UILevel < 5 AND (ENABLEFSCACHE~="false" OR ENABLEFSCACHE=0) ]]>
+    <SetProperty Id="GfwEnableFsCache" Value="[USEFSCACHE]" Action="SetGfwEnableFsCacheFromCommandLine" After="SetGfwEnableFsCacheUsingPreviouslyInstalledValue" Sequence="first">
+      USEFSCACHE~="true" OR USEFSCACHE~="false" OR USEFSCACHE~="yes" OR USEFSCACHE~="no" OR USEFSCACHE~="on" OR USEFSCACHE~="off" OR USEFSCACHE="1" OR USEFSCACHE="0"
     </SetProperty>
-    <SetProperty Id="ENABLEFSCACHE" Action="ClearENABLEFSCACHEForFullUIInstallIfFalse" Value="{}" After="AppSearch" Sequence="ui">
-      UILevel = 5 AND (CMDLINE_ENABLEFSCACHE OR ENABLEFSCACHE~="false" OR ENABLEFSCACHE=0)
+    <SetProperty Id="GfwEnableFsCache" Value="true" Action="NormalizeGfwEnableFsCacheTrue" After="SetGfwEnableFsCacheFromCommandLine" Sequence="first">
+      GfwEnableFsCache~="true" OR GfwEnableFsCache~="yes" OR GfwEnableFsCache~="on" OR GfwEnableFsCache="1"
+    </SetProperty>
+    <SetProperty Id="GfwEnableFsCache" Value="false" Action="NormalizeGfwEnableFsCacheFalse" After="SetGfwEnableFsCacheFromCommandLine" Sequence="first">
+      GfwEnableFsCache~="false" OR GfwEnableFsCache~="no" OR GfwEnableFsCache~="off" OR GfwEnableFsCache="0"
+    </SetProperty>
+    <SetProperty Id="ENABLEFSCACHE" Value="[GfwEnableFsCache]" Before="CostFinalize" Sequence="first" />
+    <SetProperty Id="ENABLEFSCACHE" Value="{}" Action="ClearENABLEFSCACHEOnFullUIInstallIfFalse" After="SetENABLEFSCACHE" Sequence="ui">
+      UILevel = 5 AND ENABLEFSCACHE="false"
     </SetProperty>
 
     <SetProperty Id="CMDLINE_ENABLEGCM" Value="0" Before="AppSearch" Sequence="first">

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -56,7 +56,7 @@
     <SetProperty Id="GfwCliEnvironment" Value="CmdTools" Action="NormalizeCaseGfwCliEnvironmentCmdTools" After="SetGfwCliEnvironmentFromCommandLine" Sequence="first">
       GfwCliEnvironment~="CmdTools"
     </SetProperty>
-    <SetProperty Action="SetBashCliEnvironmentPaths" Id="CLIENVIORNMENTPATHS" Value="{}" Before="InstallValidate" Sequence="execute">
+    <SetProperty Action="SetBashCliEnvironmentPaths" Id="CLIENVIRONMENTPATHS" Value="{}" Before="InstallValidate" Sequence="execute">
       GfwCliEnvironment = "Bash"
     </SetProperty>
     <SetProperty Action="SetCmdCliEnvironmentPaths" Id="CLIENVIRONMENTPATHS" Value="[INSTALLFOLDER]cmd" Before="InstallValidate" Sequence="execute">

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -126,6 +126,7 @@
     <SetProperty Id="ENABLEFSCACHE" Value="{}" Action="ClearENABLEFSCACHEOnFullUIInstallIfFalse" After="SetENABLEFSCACHE" Sequence="ui">
       UILevel = 5 AND ENABLEFSCACHE="false"
     </SetProperty>
+    <SetProperty Id="ENABLEFSCACHE" Value="false" Action="SetENABLEFSCACHEToFalseIfItDoesNotExistAfterUISequenceIsComplete" Before="InstallValidate" Sequence="execute">NOT ENABLEFSCACHE</SetProperty>
 
     <Property Id="USEGCM" Value="Unset" />
     <Property Id="GfwEnableGcm" Value="1" />
@@ -149,6 +150,7 @@
     <SetProperty Id="ENABLEGCM" Value="{}" Action="ClearENABLEGCMIfFalseAndFullUIInstall" After="SetENABLEGCM" Sequence="ui">
       UILevel = 5 AND ENABLEGCM = 0
     </SetProperty>
+    <SetProperty Id="ENABLEGCM" Value="0" Action="SetENABLEGCMToZeroIfItDoesNotExistAfterUISequenceIsComplete" Before="InstallValidate" Sequence="execute">NOT ENABLEGCM</SetProperty>
 
     <Property Id="GITBASHHERE" Value="1" />
     <Property Id="GITGUIHERE" Value="1" />

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -35,25 +35,37 @@
     <!-- Git for Windows MSI Properties -->
     <SetProperty Id="BindImagePaths" Value="[INSTALLFOLDER]usr\bin;[MingwFolder]bin;[System$(var.SixtyFourBit)Folder]" After="CostFinalize" />
 
-    <SetProperty Id="CMDLINE_CLIENVIRONMENT" Value="[CLIENVIRONMENT]" Before="AppSearch" Sequence="first">
-      CLIENVIRONMENT~="Bash" OR CLIENVIRONMENT~="CmdTools"
-    </SetProperty>
-    <Property Id="CLIENVIRONMENT" Value="Cmd">
+    <Property Id="CLI" Value="Unset" />
+    <Property Id="GfwCliEnvironment" Value="Cmd" />
+    <Property Id="CLIENVIRONMENT" Value="Cmd" />
+    <Property Id="CLIENVIRONMENTSEARCH">
       <RegistrySearch Id="CliEnvironmentSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="CliEnvironment" Type="raw" />
     </Property>
-    <SetProperty Id="CLIENVIRONMENT" Value="[CMDLINE_CLIENVIRONMENT]" After="AppSearch" Sequence="first">CMDLINE_CLIENVIRONMENT</SetProperty>
-    <SetProperty Id="CLIENVIRONMENT" Value="Bash" Action="NomalizeBashCLIENVIRONMENTCasing" After="SetCLIENVIRONMENT" Sequence="first">
-      CLIENVIRONMENT~="Bash"
+    <SetProperty Id="GfwCliEnvironment" Value="[CLIENVIRONMENTSEARCH]" Action="SetGfwCliEnvironmentUsingPreviouslyInstalledValue" After="AppSearch" Sequence="first">
+      (WIX_UPGRADE_DETECTED OR REINSTALL) AND (CLIENVIRONMENTSEARCH~="Bash" OR CLIENVIRONMENTSEARCH~="Cmd" OR CLIENVIRONMENTSEARCH~="CmdTools")
     </SetProperty>
-    <SetProperty Id="CLIENVIRONMENT" Value="Cmd" Action="NormalizeCmdCLIENVIRONMENTCasing" After="SetCLIENVIRONMENT" Sequence="first">
-      CLIENVIRONMENT~="Cmd"
+    <SetProperty Id="GfwCliEnvironment" Value="[CLI]" Action="SetGfwCliEnvironmentFromCommandLine" After="SetGfwCliEnvironmentUsingPreviouslyInstalledValue" Sequence="first">
+      CLI~="Bash" OR CLI~="Cmd" OR CLI~="CmdTools"
     </SetProperty>
-    <SetProperty Id="CLIENVIRONMENT" Value="CmdTools" Action="NormalizeCmdToolsCLIENVIRONMENTCasing" After="SetCLIENVIRONMENT" Sequence="first">
-      CLIENVIRONMENT~="CmdTools"
+    <SetProperty Id="GfwCliEnvironment" Value="Bash" Action="NormalizeCaseGfwCliEnvironmentBash" After="SetGfwCliEnvironmentFromCommandLine" Sequence="first">
+      GfwCliEnvironment~="Bash"
     </SetProperty>
-    <SetProperty Action="SetBashCliEnvironmentPaths" Id="CLIENVIORNMENTPATHS" Value="{}" Before="InstallValidate" Sequence="execute">CLIENVIRONMENT = "Bash"</SetProperty>
-    <SetProperty Action="SetCmdCliEnvironmentPaths" Id="CLIENVIRONMENTPATHS" Value="[INSTALLFOLDER]cmd" Before="InstallValidate" Sequence="execute">CLIENVIRONMENT = "Cmd"</SetProperty>
-    <SetProperty Action="SetCmdToolsCliEnvironmentPaths" Id="CLIENVIRONMENTPATHS" Value="[INSTALLFOLDER]cmd;[MingwFolder]bin;[INSTALLFOLDER]usr\bin" Before="InstallValidate" Sequence="execute">CLIENVIRONMENT = "CmdTools"</SetProperty>
+    <SetProperty Id="GfwCliEnvironment" Value="Cmd" Action="NormalizeCaseGfwCliEnvironmentCmd" After="SetGfwCliEnvironmentFromCommandLine" Sequence="first">
+      GfwCliEnvironment~="Cmd"
+    </SetProperty>
+    <SetProperty Id="GfwCliEnvironment" Value="CmdTools" Action="NormalizeCaseGfwCliEnvironmentCmdTools" After="SetGfwCliEnvironmentFromCommandLine" Sequence="first">
+      GfwCliEnvironment~="CmdTools"
+    </SetProperty>
+    <SetProperty Action="SetBashCliEnvironmentPaths" Id="CLIENVIORNMENTPATHS" Value="{}" Before="InstallValidate" Sequence="execute">
+      GfwCliEnvironment = "Bash"
+    </SetProperty>
+    <SetProperty Action="SetCmdCliEnvironmentPaths" Id="CLIENVIRONMENTPATHS" Value="[INSTALLFOLDER]cmd" Before="InstallValidate" Sequence="execute">
+      GfwCliEnvironment = "Cmd"
+    </SetProperty>
+    <SetProperty Action="SetCmdToolsCliEnvironmentPaths" Id="CLIENVIRONMENTPATHS" Value="[INSTALLFOLDER]cmd;[MingwFolder]bin;[INSTALLFOLDER]usr\bin" Before="InstallValidate" Sequence="execute">
+      GfwCliEnvironment = "CmdTools"
+    </SetProperty>
+    <SetProperty Id="CLIENVIRONMENT" Value="[GfwCliEnvironment]" Before="CostFinalize" Sequence="first" />
 
     <SetProperty Id="CMDLINE_LINEENDINGS" Value="[LINEENDINGS]" Before="AppSearch" Sequence="first">
       <![CDATA[ LINEENDINGS~="input" OR LINEENDINGS~="false" ]]>

--- a/msi/GitProduct.wxs
+++ b/msi/GitProduct.wxs
@@ -88,20 +88,21 @@
       NOT GfwLineEndings="true" OR AUTOCRLF~="true" OR AUTOCRLF~="input" OR AUTOCRLF~="false"
     </SetProperty>
 
-    <Property Id="CMDLINE_TERMINAL" Value="MinTTY" />
+    <Property Id="CONSOLE" Value="Unset" />
+    <Property Id="GfwTerminal" Value="MinTTY" />
     <Property Id="TERMINAL" Value="MinTTY" />
-    <SetProperty Id="CMDLINE_TERMINAL" Value="[TERMINAL]" Before="AppSearch" Sequence="first"><![CDATA[ TERMINAL <> CMDLINE_TERMINAL AND (TERMINAL~="CmdPrompt" OR TERMINAL~="MinTTY") ]]></SetProperty>
     <Property Id="TERMINALSEARCH">
       <RegistrySearch Id="TerminalSearch" Root="HKLM" Key="SOFTWARE\GitForWindows" Name="Terminal" Type="raw" />
     </Property>
-    <SetProperty Id="TERMINAL" Value="[TERMINALSEARCH]" Action="GetUpgradeTERMINALValue" After="AppSearch" Sequence="first">TERMINALSEARCH</SetProperty>
-    <SetProperty Id="TERMINAL" Value="[CMDLINE_TERMINAL]" After="GetUpgradeTERMINALValue" Sequence="first"><![CDATA[ CMDLINE_TERMINAL <> TERMINAL ]]></SetProperty>
-    <SetProperty Id="TERMINAL" Value="MinTTY" Action="NormalizeMinTTYCasing" After="SetTERMINAL" Sequence="first">
-      TERMINAL~="MinTTY"
+    <SetProperty Id="GfwTerminal" Value="[TERMINALSEARCH]" Action="SetGfwTerminalUsingPreviouslyInstalledValue" After="AppSearch" Sequence="first">
+      WIX_UPGRADE_DETECTED AND (TERMINALSEARCH~="MinTTY" OR TERMINALSEARCH~="CmdPrompt")
     </SetProperty>
-    <SetProperty Id="TERMINAL" Value="CmdPrompt" Action="NormalizeCmdPromptCasing" After="SetTERMINAL" Sequence="first">
-      TERMINAL~="CmdPrompt"
+    <SetProperty Id="GfwTerminal" Value="[CONSOLE]" Action="SetGfwTerminalFromCommandLine" After="SetGfwTerminalUsingPreviouslyInstalledValue" Sequence="first">
+      CONSOLE~="MinTTY" OR CONSOLE~="CmdPrompt"
     </SetProperty>
+    <SetProperty Id="GfwTerminal" Value="MinTTY" Action="NormalizeCaseGfwTerminalMinTTY" After="SetGfwTerminalFromCommandLine" Sequence="first">GfwTerminal~="MinTTY"</SetProperty>
+    <SetProperty Id="GfwTerminal" Value="CmdPrompt" Action="NormalizeCaseGfwTerminalCmdPrompt" After="SetGfwTerminalFromCommandLine" Sequence="first">GfwTerminal~="CmdPrompt"</SetProperty>
+    <SetProperty Id="TERMINAL" Value="[GfwTerminal]" Before="CostFinalize" Sequence="first" />
 
     <SetProperty Id="CMDLINE_ENABLEFSCACHE" Value="false" Before="AppSearch" Sequence="first">
       ENABLEFSCACHE~="false" OR ENABLEFSCACHE=0
@@ -373,9 +374,9 @@
     <CustomAction Id="ExecConfigureFsCache" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="ignore" Impersonate="no" />
     <SetProperty Id="ExecConfigureGcm" Value='"[#GitExe]" config --system credential.helper manager' Sequence="execute" Before="ExecConfigureGcm"><![CDATA[ REMOVE <> "ALL" AND ENABLEGCM=1 ]]></SetProperty>
     <CustomAction Id="ExecConfigureGcm" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="ignore" Impersonate="no" />
-    <SetProperty Id="ExecEditGitBash" Value='"[#EditGitBash]" "[#GitBash]" "SHOW_CONSOLE=1 APPEND_QUOTE=1 @@COMSPEC@@ /S /C \"\"@@EXEPATH@@\usr\bin\bash.exe\" --login -i"' Sequence="execute" Before="ExecEditGitBash"><![CDATA[ REMOVE <> "ALL" AND TERMINAL = "CmdPrompt" ]]></SetProperty>
+    <SetProperty Id="ExecEditGitBash" Value='"[#EditGitBash]" "[#GitBash]" "SHOW_CONSOLE=1 APPEND_QUOTE=1 @@COMSPEC@@ /S /C \"\"@@EXEPATH@@\usr\bin\bash.exe\" --login -i"' Sequence="execute" Before="ExecEditGitBash"><![CDATA[ (REMOVE <> "ALL" OR NOT REINSTALL) AND TERMINAL = "CmdPrompt" ]]></SetProperty>
     <CustomAction Id="ExecEditGitBash" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="check" Impersonate="no" />
-    <SetProperty Id="DeleteEditGitBash" Value='"[System$(var.SixtyFourBit)Folder]cmd.exe" /S /C del "[#EditGitBash]"' Sequence="execute" Before="DeleteEditGitBash"><![CDATA[ REMOVE <> "ALL" AND TERMINAL = "CmdPrompt" ]]></SetProperty>
+    <SetProperty Id="DeleteEditGitBash" Value='"[System$(var.SixtyFourBit)Folder]cmd.exe" /S /C del "[#EditGitBash]"' Sequence="execute" Before="DeleteEditGitBash"><![CDATA[ (REMOVE <> "ALL" OR NOT REINSTALL) AND TERMINAL = "CmdPrompt" ]]></SetProperty>
     <CustomAction Id="DeleteEditGitBash" BinaryKey="WixCA" DllEntry="WixQuietExec$(var.SixtyFourBit)" Execute="deferred" Return="ignore" Impersonate="no" />
     <!-- Schedule two "best effort" actions:
           1. Write the command to run the post-install.bat to the transaction log
@@ -392,8 +393,8 @@
       <Custom Action="ExecConfigureCoreAutoCrlf" Before="ExecConfigureFsCache"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
       <Custom Action="ExecConfigureFsCache" Before="ExecConfigureGcm"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
       <Custom Action="ExecConfigureGcm" Before="ExecEditGitBash"><![CDATA[ REMOVE <> "ALL" AND ENABLEGCM=1 ]]></Custom>
-      <Custom Action="ExecEditGitBash" Before="DeleteEditGitBash"><![CDATA[ TERMINAL = "CmdPrompt" AND REMOVE <> "ALL" ]]></Custom>
-      <Custom Action="DeleteEditGitBash" Before="ExecPostInstallBat"><![CDATA[ TERMINAL = "CmdPrompt" AND REMOVE <> "ALL" ]]></Custom>
+      <Custom Action="ExecEditGitBash" Before="DeleteEditGitBash"><![CDATA[ TERMINAL = "CmdPrompt" AND (REMOVE <> "ALL" OR NOT REINSTALL) ]]></Custom>
+      <Custom Action="DeleteEditGitBash" Before="ExecPostInstallBat"><![CDATA[ TERMINAL = "CmdPrompt" AND (REMOVE <> "ALL" OR NOT REINSTALL) ]]></Custom>
       <!-- Execute the post-install.bat at the end of the installation transaction on install and repair but not removal. -->
       <Custom Action="ExecPostInstallBat" Before="InstallFinalize"><![CDATA[ REMOVE <> "ALL" ]]></Custom>
     </InstallExecuteSequence>


### PR DESCRIPTION
This pull request updates the implementation of all the MSI properties that have been implemented to date, which record the user's selected configuration options during installation.

Previously, the properties associated with tracking a user's installation configuration choices used the "Remember Property" pattern that @robmen wrote up a long time ago. It's a great pattern, but unfortunately, it doesn't work with properties which have a default value, especially when you need to know from where a property value originated in order to make some determinations about installer data and/or UI flow.

This pull request also contains a refinement to the flow of UI dialogs when it comes to choosing the line-ending setting during installation for Git for Windows. The previous flow was a bit unintuitive, and in some situations, could also lead the user to believing that a default configuration setting was being used when, in fact, a customized setting would be used. This was a bug--and this PR includes a commit to fix that bug.

Lastly, I found and corrected a mis-spelled property name that would've caused the user's `PATH` system environment variable to be modified even if the user selected to only use Git from the Bash shell.
