### PR TITLE
Fixed the 'sports' typo in the Windows installer

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1004,7 +1004,7 @@ begin
     with LblMinTTY do begin
         Parent:=BashTerminalPage.Surface;
         Caption:=
-            'Git Bash will use MinTTY as terminal emulator, which sports a resizable window,' + #13 +
+            'Git Bash will use MinTTY as terminal emulator, which supports a resizable window,' + #13 +
             'non-rectangular selections and a Unicode font. Windows console programs (such' + #13 +
             'as interactive Python) must be launched via `winpty` to work in MinTTY.';
         Left:=ScaleX(28);


### PR DESCRIPTION
The installer says:

> Git Bash will use MinTTY as terminal emulator, which **sports** a resizable window non-rectangular selections and a Unicode font.

This PR fixes this into "supports".
