### PR TITLE
git-extra: add support for docm and dotm diffs

### DIFF
--- a/git-extra/astextplain
+++ b/git-extra/astextplain
@@ -11,7 +11,7 @@ case "$1" in
 	*.doc | *.DOC | *.dot | *.DOT)
 		antiword -m UTF-8 "$1" | sed "s/\^M$//" || cat "$1"
 		;;
-	*.docx | *.DOCX)
+	*.docx | *.DOCX | *.docm | *.DOCM | *.dotm | *.DOTM)
 		docx2txt.pl "$1" -
 		;;
 	*.pdf | *.PDF)

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -32,8 +32,12 @@ GITCONFIG
 *.DOC	diff=astextplain
 *.docx	diff=astextplain
 *.DOCX	diff=astextplain
+*.docm	diff=astextplain
+*.DOCM	diff=astextplain
 *.dot	diff=astextplain
 *.DOT	diff=astextplain
+*.dotm	diff=astextplain
+*.DOTM	diff=astextplain
 *.pdf	diff=astextplain
 *.PDF	diff=astextplain
 *.rtf	diff=astextplain

--- a/git-extra/gitattributes
+++ b/git-extra/gitattributes
@@ -2,8 +2,12 @@
 *.DOC	diff=astextplain
 *.docx	diff=astextplain
 *.DOCX	diff=astextplain
+*.docm	diff=astextplain
+*.DOCM	diff=astextplain
 *.dot	diff=astextplain
 *.DOT	diff=astextplain
+*.dotm	diff=astextplain
+*.DOTM	diff=astextplain
 *.pdf	diff=astextplain
 *.PDF	diff=astextplain
 *.rtf	diff=astextplain


### PR DESCRIPTION
The above file-types were added alongside the existing .doc/docx/dot
Word formats.