### PR TITLE
Adding rsync to installer

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -58,7 +58,7 @@ then
 	packages="$packages mingw-w64-$ARCH-git-doc-html ncurses mintty vim
 		winpty less gnupg tar diffutils patch dos2unix which subversion
 		mingw-w64-$ARCH-tk mingw-w64-$ARCH-connect git-flow docx2txt
-		mingw-w64-$ARCH-antiword ssh-pageant"
+		mingw-w64-$ARCH-antiword ssh-pageant rsync"
 
 fi
 pacman_list $packages "$@" |


### PR DESCRIPTION
Solves #347 (closed), uses the same method as pull #57.

Rationale: I am looking to make backups using rsync, and would like to include it in Git Bash, rather than install other software such as Cygwin. Per #347 there is demand for it. As listed below, the file size increase is negligible (<0.4%).

64-bit compiled version sizes (via `wc -c`):

Size (Bytes) | Build | Size (Megabytes)
-----------|-----------|---
43508495 | Standard | 43.51
43678759 | With rsync | 43.68

Installing rsync via pacman was a 0.25MiB download and 0.46MiB installed, so the 0.17MB difference in the installer checks out.
