### PR TITLE
please.sh: print action description to console

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -767,6 +767,7 @@ build_and_test_64 () {
 		: make sure that the .dll files are correctly resolved: &&
 		cd $PWD &&
 		rm -f t/test-results/*.{counts,tee} &&
+		printf "\nBuilding Git...\n" >&2 &&
 		if ! make -j5 -k DEVELOPER=1
 		then
 			echo "Re-running build (to show failures)" >&2
@@ -775,6 +776,7 @@ build_and_test_64 () {
 				exit 1
 			}
 		fi &&
+		printf "\nTesting Git...\n" >&2 &&
 		if '"$(if test -z "$skip_tests"
 			then
 				echo "! ${make_t_prefix}make -C t -j5 -k"
@@ -1057,6 +1059,7 @@ test_remote_branch () { # [--worktree=<dir>] [--skip-tests] [--bisect-and-commen
 	 then
 		exit 1
 	 else
+		printf "\nBisecting broken Git tests...\n" >&2 &&
 		case "$branch" in
 		upstream/pu) good=upstream/next;;
 		upstream/next) good=upstream/master;;


### PR DESCRIPTION
These descriptions markers make it possible to cut the
"test_remote_branch" log into "build", "test", and "after failed test"
sections. This is useful to print the sections in the appropriate steps
in the TravisCI run.

**Attention:**
I haven't tested this as I don't have the setup. But it should work 😄 

/cc @dscho 