### PR TITLE
git-lfs: add config for more efficent filter-process protocol

### DIFF
--- a/mingw-w64-git-lfs/git-lfs.install
+++ b/mingw-w64-git-lfs/git-lfs.install
@@ -3,6 +3,7 @@ post_install() {
     if [ -f "${arch}/bin/git-lfs.exe" ]; then
       git config -f "${arch}/etc/gitconfig" filter.lfs.clean "git-lfs clean -- %f"
       git config -f "${arch}/etc/gitconfig" filter.lfs.smudge "git-lfs smudge -- %f"
+      git config -f "${arch}/etc/gitconfig" filter.lfs.process "git-lfs filter-process"
       git config -f "${arch}/etc/gitconfig" filter.lfs.required true
     fi
   done


### PR DESCRIPTION
The same config is set via the `git lfs install` command:
https://github.com/git-lfs/git-lfs/blob/e029224251e2d8b134ee92f3cc00e001fdcbfb40/lfs/setup.go#L32-L35

However, I wonder if should rather use [`git lfs install --system`](https://github.com/git-lfs/git-lfs/blob/e029224251e2d8b134ee92f3cc00e001fdcbfb40/commands/command_install.go#L56) ?

--

This change is not tested. I just noticed the file and thought I could update it. I am pretty sure it works, though...

/cc @shiftkey 