### PR TITLE
installer: Drop subversion binaries

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -56,7 +56,7 @@ git-extra openssh sed awk grep findutils coreutils"
 if test -z "$MINIMAL_GIT"
 then
 	packages="$packages mingw-w64-$ARCH-git-doc-html ncurses mintty vim
-		winpty less gnupg tar diffutils patch dos2unix which subversion
+		winpty less gnupg tar diffutils patch dos2unix which
 		mingw-w64-$ARCH-tk mingw-w64-$ARCH-connect git-flow docx2txt
 		mingw-w64-$ARCH-antiword ssh-pageant"
 


### PR DESCRIPTION
Since this developer was pressing in the early days of _Git for Windows 2_ to include the files from `subversion` package in the installer we are shipping those binaries since those days. At least this developer thinks that we can drop those now.

I would appreciate a second set of eyes that looks into http://repo.msys2.org/msys/x86_64/subversion-1.9.5-1-x86_64.pkg.tar.xz to spot files we might actually _need_. I don't think we need the libraries in `bin` because `git-svn` uses the `pearl` bindings.