### PR TITLE
Move git-lfs binary back out of git-core

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2053,7 +2053,7 @@ begin
     if not IsComponentSelected('gitlfs') then begin
         if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe','config --system --remove-section filter.lfs','',SW_HIDE,ewWaitUntilTerminated, i) then
             LogError('Could not disable Git LFS in the gitconfig.');
-        if not DeleteFile(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-lfs.exe') and not DeleteFile(AppDir+'\{#MINGW_BITNESS}\bin\git-lfs.exe') then
+        if not DeleteFile(AppDir+'\{#MINGW_BITNESS}\bin\git-lfs.exe') and not DeleteFile(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-lfs.exe') then
             LogError('Line {#__LINE__}: Unable to delete "git-lfs.exe".');
     end;
 

--- a/mingw-w64-git-lfs/PKGBUILD
+++ b/mingw-w64-git-lfs/PKGBUILD
@@ -4,7 +4,7 @@ _realname="git-lfs"
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
 pkgver=2.0.2
-pkgrel=2
+pkgrel=3
 pkgdesc="An open source Git extension for versioning large files"
 install=git-lfs.install
 arch=('any')
@@ -34,6 +34,6 @@ sha256sums=("$sha256sum" SKIP)
 options=('!strip')
 
 package() {
-  install -d -m755 $pkgdir/$MINGW_PREFIX/libexec/git-core
-  install -m755 $srcdir/$folder/git-lfs.exe $pkgdir/$MINGW_PREFIX/libexec/git-core/git-lfs.exe
+  install -d -m755 $pkgdir/$MINGW_PREFIX/bin
+  install -m755 $srcdir/$folder/git-lfs.exe $pkgdir/$MINGW_PREFIX/bin/git-lfs.exe
 }


### PR DESCRIPTION
Because git-lfs is intended to run both through git.exe (e.g. 'git lfs',
generally when the user executes an LFS command manually) and as a
standalone executable (e.g. 'git-lfs', as run by the filters), git-lfs.exe
should reside as a top-level executable.

This prevents an issue where the user may have an older version of LFS
installed by itself and 'git-lfs' finds that version while 'git lfs' finds
the bundled version.