### PR TITLE
Allow to override the Git prompt (and mintty window title)

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -5,29 +5,35 @@ else
 	TITLEPREFIX=$MSYSTEM
 fi
 
-PS1='\[\033]0;$TITLEPREFIX:${PWD//[^[:ascii:]]/?}\007\]' # set window title
-PS1="$PS1"'\n'                 # new line
-PS1="$PS1"'\[\033[32m\]'       # change to green
-PS1="$PS1"'\u@\h '             # user@host<space>
-PS1="$PS1"'\[\033[35m\]'       # change to purple
-PS1="$PS1"'$MSYSTEM '          # show MSYSTEM
-PS1="$PS1"'\[\033[33m\]'       # change to brownish yellow
-PS1="$PS1"'\w'                 # current working directory
-if test -z "$WINELOADERNOEXEC"
+if test -f ~/.config/git/git-prompt.sh
 then
-	GIT_EXEC_PATH="$(git --exec-path 2>/dev/null)"
-	COMPLETION_PATH="${GIT_EXEC_PATH%/libexec/git-core}"
-	COMPLETION_PATH="${COMPLETION_PATH%/lib/git-core}"
-	COMPLETION_PATH="$COMPLETION_PATH/share/git/completion"
-	if test -f "$COMPLETION_PATH/git-prompt.sh"
+	. ~/.config/git/git-prompt.sh
+else
+	PS1='\[\033]0;$TITLEPREFIX:${PWD//[^[:ascii:]]/?}\007\]' # set window title
+	PS1="$PS1"'\n'                 # new line
+	PS1="$PS1"'\[\033[32m\]'       # change to green
+	PS1="$PS1"'\u@\h '             # user@host<space>
+	PS1="$PS1"'\[\033[35m\]'       # change to purple
+	PS1="$PS1"'$MSYSTEM '          # show MSYSTEM
+	PS1="$PS1"'\[\033[33m\]'       # change to brownish yellow
+	PS1="$PS1"'\w'                 # current working directory
+	if test -z "$WINELOADERNOEXEC"
 	then
-		. "$COMPLETION_PATH/git-completion.bash"
-		. "$COMPLETION_PATH/git-prompt.sh"
-		PS1="$PS1"'\[\033[36m\]'  # change color to cyan
-		PS1="$PS1"'`__git_ps1`'   # bash function
+		GIT_EXEC_PATH="$(git --exec-path 2>/dev/null)"
+		COMPLETION_PATH="${GIT_EXEC_PATH%/libexec/git-core}"
+		COMPLETION_PATH="${COMPLETION_PATH%/lib/git-core}"
+		COMPLETION_PATH="$COMPLETION_PATH/share/git/completion"
+		if test -f "$COMPLETION_PATH/git-prompt.sh"
+		then
+			. "$COMPLETION_PATH/git-completion.bash"
+			. "$COMPLETION_PATH/git-prompt.sh"
+			PS1="$PS1"'\[\033[36m\]'  # change color to cyan
+			PS1="$PS1"'`__git_ps1`'   # bash function
+		fi
 	fi
+	PS1="$PS1"'\[\033[0m\]'        # change color
+	PS1="$PS1"'\n'                 # new line
+	PS1="$PS1"'$ '                 # prompt: always $
 fi
-PS1="$PS1"'\[\033[0m\]'        # change color
-PS1="$PS1"'\n'                 # new line
-PS1="$PS1"'$ '                 # prompt: always $
+
 MSYS2_PS1="$PS1"               # for detection by MSYS2 SDK's bash.basrc


### PR DESCRIPTION
Allow to override the Git prompt by reading in
~/.config/git/git-prompt.sh, if it exists, as part of the default
/etc/profile.d/git-prompt.sh.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>