### PR TITLE
Remove getent calls from /etc/bash.bashrc

### DIFF
--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -146,6 +146,9 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	! grep -q '^# Define default printer' /etc/profile ||
 	sed -i -e '/^# Define default printer/,/^$/d' \
 		-e 's/^\(export .* \)PRINTER /\1/' /etc/profile
+
+	! grep -q '^if .*command -v getent' /etc/bash.bashrc ||
+	sed -i '/^if .*command -v getent/,/^fi/s/^/#/' /etc/bash.bashrc
 }
 
 post_upgrade () {

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -122,6 +122,9 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	grep -q ' exe "normal! g`\\""' ||
 	sed -i -e '/^ *autocmd BufReadPost \*/,/\\ endif$/s/^/"/' \
 		/usr/share/vim/vim80/defaults.vim
+
+	! grep -q '^if .*command -v getent' /etc/bash.bashrc ||
+	sed -i '/^if .*command -v getent/,/^fi/s/^/#/' /etc/bash.bashrc
 }
 
 post_upgrade () {


### PR DESCRIPTION
This is my initial attempt to add `getent` to the Git for Windows package, in order to address [issue #1226](https://github.com/git-for-windows/git/issues/1226). It seems to work exactly as expected for the 64-bit release on Windows 10, but I want to do some additional validation (portable and SDK installers, as well as the 32-bit variants) before considering it ready to merge... I probably won't have an opportunity to do this until Sunday.

The only downside I see thus far is that it increased the size of the installer binary by approximately 10 MB, which is roughly 20 percent. This might be enough of a jump to be problematic for folks with less-than-ideal connectivity speeds.

An alternate, potential fix would be to include just */usr/bin/getent* (along with any hard dependencies) instead of the full *getent* package. That will of course require more effort to implement and validate, and I don't know if GfW already has a precedent for that. So I'm currently unsure if this would be a good idea to pursue.

A simpler alternate fix would be to remove the `getent` calls from */etc/bash.bashrc*. That would remove the ability to customize the prompt based on admin/non-admin user status (see [this commit](https://github.com/Alexpux/MSYS2-packages/commit/ae10fd86dd82faccc965a27ecb5c75ca6dc04082)), when that status can actually be determined... it apparently requires `group: db` to be enabled, which is disabled by default in GfW. I assume this would require in-place editing of *bash.bashrc* during either the installer build or installation, however, since it's part of **MSYS2-packages** rather than being directly owned by GfW.

@dscho Do you have any preference as to the possible approaches?

---
Add `getent` to the list of pacman MSYS2 packages to be included in the
build. This utility is used, if available, by /etc/bash.bashrc in order
to customize the shell prompt to distinguish between admin and non-admin
users. It is not currently included in Git for Windows, however.

Normally its omission is not a problem, but when Cygwin is installed
and also in the PATH -- even if Git appears first -- then Git Bash will
encounter the following error during startup (from issue #1226).

   1 [main] getent (14752) C:\cygwin\bin\getent.exe: *** fatal error - cygheap base mismatch detected - 0x1802FF408/0x180304408.

During test builds, this increased the size of the 64-bit installer by
approximately 10 MB (47,154 vs 37,848 MB).

Signed-off-by: Adric Norris <landstander668@gmail.com>