### PR TITLE
git-update - Keep Git for Windows up to date via the command-line

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -39,7 +39,8 @@ source=('inputrc'
         '99-post-install-cleanup.post'
         'gitattributes'
         'astextplain'
-        'git-sdk.sh')
+        'git-sdk.sh'
+        'git-update')
 md5sums=('3fab57079f0322efe256e95fe29d516f'
          'a2d3b63eb1c88c2a2b011ccf0b219d60'
          'bfb591886b2a28af3334521e71198b74'
@@ -58,7 +59,8 @@ md5sums=('3fab57079f0322efe256e95fe29d516f'
          'bdeb6046510aa1a6cd76e7f86673aa3f'
          '52c242d0c84d6934ec6a94766f8a70f0'
          'e87a5075629b58fe329094b92c1d13db'
-         '593dbce30c442529b4351650f4422b6e')
+         '593dbce30c442529b4351650f4422b6e'
+         'da5db7644f0aff6567185a5495435415')
 
 prepare() {
   test $startdir/$pkgname.install -nt $startdir/$pkgname.install.in &&
@@ -102,4 +104,5 @@ package() {
   install -m644 msys2-32.ico $pkgdir/usr/share/git
   install -m644 99-post-install-cleanup.post $pkgdir/etc/post-install
   install -m755 astextplain $pkgdir/usr/bin
+  install -m755 git-update $pkgdir/${MINGW_PREFIX}/libexec/git-core
 }

--- a/git-extra/git-update
+++ b/git-extra/git-update
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+# Compares the currently installed Git for Windows against latest available release.
+# If versions differ, the bit matched installer is downloaded and run when confirmation
+# to do so is given.
+
+git_update () {
+    yn="$1"
+    case $yn in
+        -\? | --?\?) echo "Usage: git-update [options]";
+        echo "Options:";
+        echo "  -y, --yes       Automatic yes to download and install prompt";
+        return;;
+    esac
+    bit=$(ls --color=never -d /mingw* | sed 's/\/mingw//')
+    releases=$(curl --silent https://api.github.com/repos/git-for-windows/git/releases/latest)
+    latest=$(echo "$releases" | grep '"tag_name": "v' | sed -E 's/.*"tag_name": "v([^"]*).*/\1/')
+    version=$(git --version | sed "s/git version //")
+    echo "Git for Windows $version (${bit}bit)"
+    if [ "$latest" != "$version" ]
+    then
+        echo "Update $latest is available"
+        download=$(echo "$releases" | grep '"browser_download_url": "' | grep "$bit\-bit\.exe" | sed -E 's/.*": "([^"]*).*/\1/')
+        filename=$(echo "$download" | sed -E 's/.*\/([^\/]*)$/\1/')
+        installer=$(mktemp -t gfw-install-XXXXXXXX.exe)
+        case $yn in
+            -[Yy]* | --[Yy]*) yn="y"; echo "Downloading $filename";;
+            *) read -p "Download $filename and install [N/y]? " yn;;
+        esac
+        case $yn in
+            [Yy]* ) curl -# -L -o $installer $download; start "" "$installer" /SILENT; ps | grep bash | awk '{print "kill -9 " $2 ";" }' | sh;;
+        esac
+        return
+    fi
+    echo "Up to date"
+}
+
+git_update $*
+


### PR DESCRIPTION
A shell script that makes keeping Git for Windows up to date as simply as # git-update --yes

Compares what version is currently installed against the latest available release.

If versions differ, the bit matched installer is downloaded and run when confirmation to do so is given.

Discussed in Git issue https://github.com/git-for-windows/git/issues/1256