### PR TITLE
git-extra: Allow non-ASCII characters from $PWD in window title

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -9,7 +9,7 @@ if test -f ~/.config/git/git-prompt.sh
 then
 	. ~/.config/git/git-prompt.sh
 else
-	PS1='\[\033]0;$TITLEPREFIX:${PWD//[^[:ascii:]]/?}\007\]' # set window title
+	PS1='\[\033]0;$TITLEPREFIX:$PWD\007\]' # set window title
 	PS1="$PS1"'\n'                 # new line
 	PS1="$PS1"'\[\033[32m\]'       # change to green
 	PS1="$PS1"'\u@\h '             # user@host<space>


### PR DESCRIPTION
Seems like this limitation is artificial at this point (it's been there since the beginning of the repository).

![image](https://user-images.githubusercontent.com/1399406/29305522-70eadf98-8199-11e7-9d4c-6f788bd88b9b.png)

Not updating `PKGBUILD` since `updpkgsums` showed other changes and I guess there's a different process to it.