### PR TITLE
feat(installer): Git for Windows Updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.swp
 /ReleaseNotes.html
 edit-git-bash.exe
+proxy-lookup.exe
 /cached-source-packages/
 /download-stats.ids
 /git-extra/pkg/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 CFLAGS=-O2 -Wall
 
-all: edit-git-bash.exe
+all: edit-git-bash.exe proxy-lookup.exe
 
 edit-git-bash.exe: edit-git-bash.c
 	gcc -DSTANDALONE_EXE $(CFLAGS) -o $@ $^
+
+proxy-lookup.exe: proxy-lookup.c
+	gcc $(CFLAGS) -Werror -o $@ $^ -lshell32 -lwinhttp

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -60,7 +60,7 @@ sha256sums=('e6a17a669fe8282792b3d98a2c47718425364a0ca9a456bdbad4a69c57ec6978'
             '2dba0f5f8133b8e8d1da8291efec140cd516e385f04b33b95e4f97fc40f628b3'
             'f4e310c00721f8834949268167b0584b7c9323775a318574dbca960af10d7998'
             '89b4d784e1c07d67c11a35abc7094709c216372e2099b2eb7abbc6eb7c34861f'
-            '33a49036a52442a9754240e67abeb9dc2f686e8e25e5f70d522d78a150085e0a')
+            '5887f1f22a1b898072decd954ab3b3bfbb79b013f14c2cc4139a878d33d70e62')
 
 prepare() {
   test $startdir/$pkgname.install -nt $startdir/$pkgname.install.in &&

--- a/git-extra/git-update
+++ b/git-extra/git-update
@@ -5,6 +5,13 @@
 # when confirmation to do so is given.
 
 git_update () {
+	proxy=$(proxy-lookup https://api.github.com | grep URL | awk '{ print $4}' | awk -F";" '{print $1}')
+	if test "$proxy" != ""
+	then
+		export https_proxy="http://$proxy"
+		echo "Using proxy server $https_proxy detected from Internet Explorer settings"
+	fi
+
 	yn=
 	while test $# -gt 0
 	do

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -102,6 +102,14 @@ Name: consolefont; Description: Use a TrueType font in all console windows
 [Run]
 Filename: {app}\git-bash.exe; Parameters: --cd-to-home; Description: Launch Git Bash; Flags: nowait postinstall skipifsilent runasoriginaluser unchecked
 Filename: {app}\ReleaseNotes.html; Description: View Release Notes; Flags: shellexec skipifdoesntexist postinstall skipifsilent
+Filename: "schtasks"; \
+    Description: Daily check for available update; \
+    Parameters: "/Create /F /SC DAILY /TN ""Git for Windows Updater"" /TR ""'{app}\bin\git.exe' update"""; \
+    Flags: runhidden postinstall
+
+[UninstallRun]
+Filename: "schtasks"; \
+    Parameters: "/Delete /F /TN ""Git for Windows Updater"""; \
 
 [Files]
 ; Install files that might be in use during setup under a different name.

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -118,6 +118,7 @@ Source: {#SourcePath}\ReleaseNotes.html; DestDir: {app}; Flags: replacesameversi
 Source: {#SourcePath}\..\LICENSE.txt; DestDir: {app}; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore
 Source: {#SourcePath}\NOTICE.txt; DestDir: {app}; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore; Check: ParamIsSet('VSNOTICE')
 Source: {#SourcePath}\..\edit-git-bash.exe; Flags: dontcopy
+Source: {#SourcePath}\..\proxy-lookup.exe; DestDir: {app}\{#MINGW_BITNESS}\bin; Flags: replacesameversion
 
 [Dirs]
 Name: "{app}\tmp"

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -96,6 +96,10 @@ echo "Compiling edit-git-bash.exe ..."
 make -C ../ edit-git-bash.exe ||
 die "Could not build edit-git-bash.exe"
 
+# Compile proxy-lookup.exe
+make -C ../ proxy-lookup.exe ||
+die "Could not build proxy-lookup.exe."
+
 if test t = "$skip_files"
 then
 	LIST=

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -124,6 +124,10 @@ die "Could not generate ReleaseNotes.html."
 make -C ../ edit-git-bash.exe ||
 die "Could not build edit-git-bash.exe."
 
+# Compile proxy-lookup.exe
+make -C ../ proxy-lookup.exe ||
+die "Could not build proxy-lookup.exe."
+
 # Make a list of files to include
 LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
 	PACKAGE_VERSIONS_FILE="$SCRIPT_PATH"/package-versions.txt \

--- a/proxy-lookup.c
+++ b/proxy-lookup.c
@@ -1,0 +1,67 @@
+// based on the sample provided here: https://github.com/git-for-windows/git/issues/387
+// probably inspired by https://msdn.microsoft.com/en-us/library/aa384122(v=vs.85).aspx
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winhttp.h>
+#include <shellapi.h>
+
+LPCWSTR get_proxy_for_url(LPCWSTR url)
+{
+    WINHTTP_CURRENT_USER_IE_PROXY_CONFIG config;
+    WINHTTP_AUTOPROXY_OPTIONS options;
+    WINHTTP_PROXY_INFO info;
+
+    memset(&config, 0, sizeof(config));
+
+    if (!WinHttpGetIEProxyConfigForCurrentUser(&config))
+        config.fAutoDetect = FALSE;
+    else if (config.lpszAutoConfigUrl)
+        config.fAutoDetect = TRUE;
+
+    if (config.fAutoDetect) {
+        HINTERNET handle = WinHttpOpen(L"Proxy Lookup/1.0",
+                WINHTTP_ACCESS_TYPE_NO_PROXY,
+                WINHTTP_NO_PROXY_NAME,
+                WINHTTP_NO_PROXY_BYPASS, 0);
+
+        memset(&options, 0, sizeof(options));
+
+        // use pac file URL from IE proxy configuration
+        options.lpszAutoConfigUrl = config.lpszAutoConfigUrl;
+
+        options.fAutoLogonIfChallenged = TRUE;
+        options.dwFlags = options.lpszAutoConfigUrl ?
+            WINHTTP_AUTOPROXY_CONFIG_URL :
+            WINHTTP_AUTOPROXY_AUTO_DETECT;
+        if (!options.lpszAutoConfigUrl)
+            options.dwAutoDetectFlags =
+                WINHTTP_AUTO_DETECT_TYPE_DHCP |
+                WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+
+        config.fAutoDetect = WinHttpGetProxyForUrl(handle, url,
+                &options, &info );
+
+        WinHttpCloseHandle(handle);
+    }
+
+    if (config.fAutoDetect)
+        return info.lpszProxy;
+    return config.lpszProxy;
+}
+
+int main(int argc, char **argv)
+{
+    LPWSTR *wargv;
+    int i, wargc;
+
+    wargv = CommandLineToArgvW(GetCommandLineW(), &wargc);
+    wprintf(L"Proxy lookup\n");
+
+    for (i = 1; i < wargc; i++)
+        wprintf(L"URL: %s, proxy: %s\n",
+                wargv[i], get_proxy_for_url(wargv[i]));
+
+    return 0;
+}


### PR DESCRIPTION
This is a followup on https://github.com/git-for-windows/git/issues/1256 adding git-update created via https://github.com/git-for-windows/build-extra/pull/151 to the installer with a task that is scheduled daily.

Installer looks like this:
![2017-08-23 21_08_20-git 2 14 2 setup](https://user-images.githubusercontent.com/378909/29633832-e2b1f18e-8847-11e7-9ebe-21fd36bc24ca.png)

This dialog appears if some updates are available:
![2017-08-24 09_24_09-taskeng exe](https://user-images.githubusercontent.com/378909/29654582-0c113ec0-88ae-11e7-9d19-ef2da399692e.png)

Tested with the following settings:
![2017-08-25 12_15_44-local area network lan settings](https://user-images.githubusercontent.com/378909/29712198-e522fe84-8998-11e7-8630-f59c52cd1b47.png)

Todo:
* verification within multiple environments