### PR TITLE
Enable Ctrl-Arrow backward forward words

### DIFF
--- a/git-extra/inputrc
+++ b/git-extra/inputrc
@@ -62,6 +62,8 @@ $if mode=emacs
     "\e[1~": beginning-of-line      # Home Key
     "\e[4~": end-of-line            # End Key
     "\e[3~": delete-char            # Delete Key
+    "\e[1;5D": backward-word        # Ctrl-Left
+    "\e[1;5C": forward-word         # Ctrl-Right
     "\e\e[C": forward-word          # Alt-Right
     "\e\e[D": backward-word         # Alt-Left
     "\e[17~": "Function Key 6"


### PR DESCRIPTION
Provide the same command-line experience as in Linux
Ctrl+Left moves cursor a word backward
Ctrl+Right moves cursor a word forward