### PR TITLE
Fix vars in bat files

### DIFF
--- a/post-install.bat
+++ b/post-install.bat
@@ -18,7 +18,7 @@
 	@REM We need to rebase just to make sure that it still works even with
 	@REM 32-bit Windows 10
 	@FOR /F "tokens=4 delims=.[XP " %%i IN ('ver') DO @SET ver=%%i
-	@IF 10 LEQ %ver @(
+	@IF 10 LEQ %ver% @(
 		@REM We copy `rebase.exe` because it links to `msys-2.0.dll`
 		@REM (and @REM thus prevents modifying it). It is okay to
 		@REM execute `rebase.exe`, though, because the DLL base address

--- a/sdk-installer/setup-git-sdk.bat
+++ b/sdk-installer/setup-git-sdk.bat
@@ -16,7 +16,7 @@
 @REM need to rebase just to make sure that it still works even with Windows 10
 @SET initialrebase=false
 @FOR /F "tokens=4 delims=.[XP " %%i IN ('ver') DO @SET ver=%%i
-@IF 10 LEQ %ver @(
+@IF 10 LEQ %ver% @(
 	@SET initialrebase=false
 )
 

--- a/sdk-installer/setup-git-sdk.bat
+++ b/sdk-installer/setup-git-sdk.bat
@@ -17,7 +17,7 @@
 @SET initialrebase=false
 @FOR /F "tokens=4 delims=.[XP " %%i IN ('ver') DO @SET ver=%%i
 @IF 10 LEQ %ver% @(
-	@SET initialrebase=false
+	@SET initialrebase=true
 )
 
 @IF %initialrebase% == true @(


### PR DESCRIPTION
A couple commits fixing 32-bit Windows msys-2.0.dll address range workarounds. Please read commit messages for more details.