### PR TITLE
Add Nano editor

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -99,6 +99,7 @@ Name: ext; Description: Windows Explorer integration; Types: default
 Name: ext\shellhere; Description: Git Bash Here; Types: default
 Name: ext\guihere; Description: Git GUI Here; Types: default
 Name: gitlfs; Description: Git LFS (Large File Support); Types: default; Flags: disablenouninstallwarning
+Name: nano; Description: Use nano as default editor for git;
 Name: assoc; Description: Associate .git* configuration files with the default text editor; Types: default
 Name: assoc_sh; Description: Associate .sh files to be run with Bash; Types: default
 Name: consolefont; Description: Use a TrueType font in all console windows
@@ -2159,6 +2160,15 @@ begin
             LogError('Could not disable Git LFS in the gitconfig.');
         if not DeleteFile(AppDir+'\{#MINGW_BITNESS}\bin\git-lfs.exe') and not DeleteFile(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-lfs.exe') then
             LogError('Line {#__LINE__}: Unable to delete "git-lfs.exe".');
+    end;
+
+    {
+        Set nano as default editor
+    }
+
+    if IsComponentSelected('nano') then begin
+        if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe','config --system core.editor nano.exe','',SW_HIDE,ewWaitUntilTerminated, i) then
+            LogError('Could not set nano as core.editor in the gitconfig.');
     end;
 
     {

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -67,7 +67,8 @@ for req in mingw-w64-$ARCH-git-credential-manager $SH_FOR_REBASE \
 	$(test -n "$MINIMAL_GIT" || echo \
 		mingw-w64-$ARCH-connect git-flow unzip docx2txt \
 		mingw-w64-$ARCH-antiword mingw-w64-$ARCH-odt2txt \
-		mingw-w64-$ARCH-xpdf ssh-pageant mingw-w64-$ARCH-git-lfs tig)
+		mingw-w64-$ARCH-xpdf ssh-pageant mingw-w64-$ARCH-git-lfs tig \
+		nano)
 do
 	test -d /var/lib/pacman/local/$req-[0-9]* ||
 	test -d /var/lib/pacman/local/$req-git-[0-9]* ||
@@ -81,7 +82,7 @@ packages="mingw-w64-$ARCH-git mingw-w64-$ARCH-git-credential-manager
 git-extra openssh $UTIL_PACKAGES"
 if test -z "$MINIMAL_GIT"
 then
-	packages="$packages mingw-w64-$ARCH-git-doc-html ncurses mintty vim
+	packages="$packages mingw-w64-$ARCH-git-doc-html ncurses mintty vim nano
 		winpty less gnupg tar diffutils patch dos2unix which subversion
 		mingw-w64-$ARCH-tk mingw-w64-$ARCH-connect git-flow docx2txt
 		mingw-w64-$ARCH-antiword mingw-w64-$ARCH-odt2txt ssh-pageant mingw-w64-$ARCH-git-lfs tig"


### PR DESCRIPTION
Nano is a lightweight text editor that most novices to the bash command line find easier to use than vim.

This PR adds the msys2 package of nano to the Git-for-Windows installer and adds an option
(opt-in) to the install process to set it as core.editor.

Nano has a small footprint (installed 2.28 MiB [1]) and only few dependencies that are already included in Git for Windows. According to my tests the size of the installer is only increased by ca. 100 KiB.

The PR has been created according to what @dscho has outlined in git-for-windows/git#1224

[1]:
```
$ pacman -Qi nano
Name            : nano
Version         : 2.8.7-1
Description     : Pico editor clone with enhancements
Architecture    : x86_64
URL             : https://www.nano-editor.org
Licenses        : GPL
Groups          : editors
Provides        : None
Depends On      : file  libintl  ncurses  sh
Optional Deps   : None
Required By     : None
Optional For    : None
Conflicts With  : None
Replaces        : None
Installed Size  : 2.28 MiB
Packager        : Alexey Pavlov
Build Date      : Thu, Sep 07, 2017 03:46:48
```