### PR TITLE
Change to git-update behaviour when Git is up-to-date

### DIFF
--- a/git-extra/git-update
+++ b/git-extra/git-update
@@ -102,6 +102,7 @@ git_update () {
 
 	yn=
 	use_gui=
+	quiet=
 	testing=
 	while test $# -gt 0
 	do
@@ -109,6 +110,7 @@ git_update () {
 		-\?|--?\?|-h|--help) ;;
 		-y|--yes) yn=y; shift; continue;;
 		-g|--gui) use_gui=t; shift; continue;;
+		--quiet) quiet=t; shift; continue;;
 		--testing) testing=t; shift; continue;;
 		*) echo "Unknown option: $1" >&2;;
 		esac
@@ -157,7 +159,7 @@ git_update () {
 		sed -E 's/.*"tag_name": "v([^"]*).*/\1/')
 	# Did we ask about this version already?
 	recently_seen="$(git config --global winUpdater.recentlySeenVersion)"
-	test -n "$testing" || test "x$recently_seen" != "x$latest" || return
+	test -n "$quiet" && test "x$recently_seen" = "x$latest" && return
 
 	version=$(git --version | sed "s/git version //")
 	echo "Git for Windows $version (${bit}bit)" >&2

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1730,7 +1730,7 @@ begin
         '  <Actions Context="Author">'+
         '    <Exec>'+
         '      <Command>"'+AppPath+'\git-bash.exe"</Command>'+
-        '      <Arguments>--hide --no-needs-console --command=cmd\git.exe update --gui</Arguments>'+
+        '      <Arguments>--hide --no-needs-console --command=cmd\git.exe update --quiet --gui</Arguments>'+
         '    </Exec>'+
         '  </Actions>'+
         '</Task>',False);


### PR DESCRIPTION
As discussed in [Issue #1363](https://github.com/git-for-windows/git/issues/1363#issuecomment-356616531): the existing `git-update` behaviour, where no response is given if Git has already been validated as up-to-date in a previous check, has been moved behind a "--quiet" flag and added to the auto-update process.