### PR TITLE
rename "git update" to "git update-git-for-windows"

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -41,7 +41,7 @@ source=('inputrc'
         'gitattributes'
         'astextplain'
         'git-sdk.sh'
-        'git-update'
+        'git-update-git-for-windows'
         'blocked-file-util.c'
         'zzz_rm_stackdumps.sh'
         'proxy-lookup.c')
@@ -115,6 +115,6 @@ package() {
   install -m644 msys2-32.ico $pkgdir/usr/share/git
   install -m644 99-post-install-cleanup.post $pkgdir/etc/post-install
   install -m755 astextplain $pkgdir/usr/bin
-  install -m755 git-update $pkgdir${MINGW_PREFIX}/libexec/git-core
+  install -m755 git-update-git-for-windows $pkgdir${MINGW_PREFIX}/libexec/git-core
   install -m755 zzz_rm_stackdumps.sh $pkgdir/usr/share/makepkg/lint_package
 }

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -42,6 +42,7 @@ source=('inputrc'
         'astextplain'
         'git-sdk.sh'
         'git-update-git-for-windows'
+        'git-update'
         'blocked-file-util.c'
         'zzz_rm_stackdumps.sh'
         'proxy-lookup.c')
@@ -116,5 +117,6 @@ package() {
   install -m644 99-post-install-cleanup.post $pkgdir/etc/post-install
   install -m755 astextplain $pkgdir/usr/bin
   install -m755 git-update-git-for-windows $pkgdir${MINGW_PREFIX}/libexec/git-core
+  install -m755 git-update $pkgdir${MINGW_PREFIX}/libexec/git-core
   install -m755 zzz_rm_stackdumps.sh $pkgdir/usr/share/makepkg/lint_package
 }

--- a/git-extra/git-update
+++ b/git-extra/git-update
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+# Placeholder for the deprecated `git update` command
+
+echo 'Warning! `git update` has been deprecated;' >&2
+echo 'Please use `git update-git-for-windows instead.' >&2
+
+exec git update-git-for-windows "$@"

--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -50,8 +50,8 @@ version_compare () {
 }
 
 # Counts how many Bash instances are running, apart from the current one (if
-# any: `git update` might have been called from a CMD window, in which case no
-# Git Bash might be running at all).
+# any: `git update-git-for-windows` might have been called from a CMD window,
+# in which case no Git Bash might be running at all).
 #
 # This is a little tricky, as the /usr/bin/sh process (as which `ps` reports the
 # process running this script) is an MSYS2 one, but the calling `git.exe`
@@ -92,7 +92,7 @@ count_other_bashes () {
 
 # The main function of this script
 
-git_update () {
+update_git_for_windows () {
 	proxy=$(git config --get http.proxy)
 	if test -n "$proxy"
 	then
@@ -115,7 +115,7 @@ git_update () {
 		*) echo "Unknown option: $1" >&2;;
 		esac
 		printf >&2 '%s\n%s\n\t%s\n\t%s\n' \
-			"Usage: git-update [options]" \
+			"Usage: git update-git-for-windows [options]" \
 			"Options:" \
 			"-g, --gui Use GUI instead of terminal to prompt" \
 			"-y, --yes Automatic yes to download and install prompt"
@@ -268,4 +268,4 @@ git_update () {
 	ps | grep ' /usr/bin/bash$' | awk '{print "kill -9 " $1 ";" }' | sh
 }
 
-git_update "$@"
+update_git_for_windows "$@"

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1730,7 +1730,7 @@ begin
         '  <Actions Context="Author">'+
         '    <Exec>'+
         '      <Command>"'+AppPath+'\git-bash.exe"</Command>'+
-        '      <Arguments>--hide --no-needs-console --command=cmd\git.exe update --quiet --gui</Arguments>'+
+        '      <Arguments>--hide --no-needs-console --command=cmd\git.exe update-git-for-windows --quiet --gui</Arguments>'+
         '    </Exec>'+
         '  </Actions>'+
         '</Task>',False);

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -39,7 +39,7 @@ fi
 if test -z "$INCLUDE_GIT_UPDATE"
 then
 	EXTRA_FILE_EXCLUDES="$EXTRA_FILE_EXCLUDES
-		/mingw$BITNESS/libexec/git-core/git-update"
+		/mingw$BITNESS/libexec/git-core/git-update-git-for-windows"
 	GIT_UPDATE_EXTRA_PACKAGES=
 else
 	GIT_UPDATE_EXTRA_PACKAGES=mingw-w64-$ARCH-wintoast


### PR DESCRIPTION
In 1da13c5 (Keep Git for Windows up to date via the command-line,
2017-08-11) we added a command to download and install the latest
Git for Windows version. We called this command "git update".

Users, especially Git novices, could easily view the verb "update" as
Git version control operation. Fix the ambiguity by renaming it to
"self-upgrade".