### PR TITLE
installer: Change app url used by installer

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -14,7 +14,7 @@
 #endif
 #define MINGW_BITNESS 'mingw'+BITNESS
 #define APP_CONTACT_URL 'https://github.com/git-for-windows/git/wiki/Contact'
-#define APP_URL       'https://git-for-windows.github.io/'
+#define APP_URL       'https://gitforwindows.org/'
 #define APP_BUILTINS  'share\git\builtins.txt'
 
 #define PLINK_PATH_ERROR_MSG 'Please enter a valid path to a Plink executable.'


### PR DESCRIPTION
Since _Git for Windows_ propagated the new url
`https://gitforwindows.org/` with the last release we sould also use that
new url inside the installer.