### PR TITLE
git-extra: Install nanorc and git.nanorc file

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -25,6 +25,8 @@ pkgver() {
 source=('inputrc'
         'vimrc'
         'vi'
+        'nanorc'
+        'git.nanorc'
         'notepad'
         'wordpad'
         'create-shortcut.c'
@@ -48,6 +50,8 @@ source=('inputrc'
 sha256sums=('9efaf8dccc08c7cddc58cb589bab5aac5c0894661175a344ca02b2aa849382bd'
             '36e0b6ae5fcf6361b5dad8bac815603d9211b38dfd8fdad89c01c34412529959'
             '640d04d2a2da709419188a986d5e5550ad30df23c7ea9be1a389c37a6b917994'
+            'd69fd1e1c6477743b0155dd23e033f8f49915f3016a1419b24a309f2f4afd52f'
+            '17c90698d4dd52dd9f383e72aee54ecea0f62520baf56722de5c83285507c0d9'
             '694b07404618d616aa316a632090ce64f2f89df3cc62b9d949efc0c2569b016e'
             'a9ada325a279ce460aeb663a715e4c335d8972f497d48d97ff5524053b1fb43a'
             '197791d75a7f7e18c19e3673266d4d8a9f2620e0d046f6478cb94ad422fb21c4'
@@ -100,6 +104,8 @@ package() {
   install -d -m755 $pkgdir/usr/share/makepkg/lint_package
   install -m644 inputrc $pkgdir/etc
   install -m644 vimrc $pkgdir/etc
+  install -m644 nanorc $pkgdir/etc
+  install -m644 git.nanorc $pkgdir/usr/share/nano
   install -m755 vi $pkgdir/usr/bin
   install -m755 notepad $pkgdir/usr/bin
   install -m755 wordpad $pkgdir/usr/bin

--- a/git-extra/git.nanorc
+++ b/git-extra/git.nanorc
@@ -1,0 +1,80 @@
+syntax "git-config" "git(config|modules)$|\.git/config$"
+
+color brightcyan "\<(true|false)\>"
+color cyan "^[[:space:]]*[^=]*="
+color brightmagenta "^[[:space:]]*\[.*\]$"
+color yellow ""(\\.|[^"])*"|'(\\.|[^'])*'"
+color brightblack "(^|[[:space:]])#([^{].*)?$"
+color ,green "[[:space:]]+$"
+color ,red "	+"
+
+# This code is free software; you can redistribute it and/or modify it under
+# the terms of the new BSD License.
+#
+# Copyright (c) 2010, Sebastian Staudt
+
+# A nano configuration file to enable syntax highlighting of some Git specific
+# files with the GNU nano text editor (http://www.nano-editor.org)
+#
+syntax "git-commit" "COMMIT_EDITMSG|TAG_EDITMSG"
+
+# Commit message
+color yellow ".*"
+
+# Comments
+color brightblack "^#.*"
+
+# Files changes
+color white       "#[[:space:]](deleted|modified|new file|renamed):[[:space:]].*"
+color red         "#[[:space:]]deleted:"
+color green       "#[[:space:]]modified:"
+color brightgreen "#[[:space:]]new file:"
+color brightblue  "#[[:space:]]renamed:"
+
+# Untracked filenames
+color black "^#	[^/?*:;{}\\]+\.[^/?*:;{}\\]+$"
+
+color brightmagenta "^#[[:space:]]Changes.*[:]"
+color brightred "^#[[:space:]]Your branch and '[^']+"
+color brightblack "^#[[:space:]]Your branch and '"
+color brightwhite "^#[[:space:]]On branch [^ ]+"
+color brightblack "^#[[:space:]]On branch"
+
+# Recolor hash symbols
+
+# Recolor hash symbols
+color brightblack "#"
+
+# Trailing spaces (+LINT is not ok, git uses tabs)
+color ,green "[[:space:]]+$"
+
+
+# This syntax format is used for interactive rebasing
+syntax "git-rebase-todo" "git-rebase-todo"
+
+# Default
+color yellow ".*"
+
+# Comments
+color brightblack "^#.*"
+
+# Rebase commands
+color green       "^(e|edit) [0-9a-f]{7,40}"
+color green       "^#  (e, edit)"
+color brightgreen "^(f|fixup) [0-9a-f]{7,40}"
+color brightgreen "^#  (f, fixup)"
+color brightwhite "^(p|pick) [0-9a-f]{7,40}"
+color brightwhite "^#  (p, pick)"
+color blue        "^(r|reword) [0-9a-f]{7,40}"
+color blue        "^#  (r, reword)"
+color brightred   "^(s|squash) [0-9a-f]{7,40}"
+color brightred   "^#  (s, squash)"
+color yellow      "^(x|exec) [^ ]+ [0-9a-f]{7,40}"
+color yellow      "^#  (x, exec)"
+
+# Recolor hash symbols
+color brightblack "#"
+
+# Commit IDs
+color brightblue "[0-9a-f]{7,40}"
+

--- a/git-extra/nanorc
+++ b/git-extra/nanorc
@@ -1,0 +1,279 @@
+## Sample initialization file for GNU nano.
+##
+## Please note that you must have configured nano with --enable-nanorc
+## for this file to be read!  Also note that this file should not be in
+## DOS or Mac format, and that characters specially interpreted by the
+## shell should not be escaped here.
+##
+## To make sure an option is disabled, use "unset <option>".
+##
+## For the options that take parameters, the default value is given.
+## Other options are unset by default.
+##
+## Quotes inside string parameters don't have to be escaped with
+## backslashes.  The last double quote in the string will be treated as
+## its end.  For example, for the "brackets" option, ""')>]}" will match
+## ", ', ), >, ], and }.
+
+## Silently ignore problems with unknown directives in the nanorc file.
+## Useful when your nanorc file might be read on systems with multiple
+## versions of nano installed (e.g. your home directory is on NFS).
+# set quiet
+
+## When soft line wrapping is enabled, make it wrap lines at blanks
+## (tabs and spaces) instead of always at the edge of the screen.
+# set atblanks
+
+## Use auto-indentation.
+# set autoindent
+
+## Back up files to the current filename plus a tilde.
+# set backup
+
+## The directory to put unique backup files in.
+# set backupdir ""
+
+## Do backwards searches by default.
+# set backwards
+
+## Use bold text instead of reverse video text.
+# set boldtext
+
+## The characters treated as closing brackets when justifying
+## paragraphs.  They cannot contain blank characters.  Only closing
+## punctuation, optionally followed by closing brackets, can end
+## sentences.
+# set brackets ""')>]}"
+
+## Do case-sensitive searches by default.
+# set casesensitive
+
+## Constantly display the cursor position in the status bar.  Note that
+## this overrides "quickblank".
+# set constantshow
+## (The old form, 'const', is deprecated.)
+
+## Use cut-from-cursor-to-end-of-line by default.
+# set cutfromcursor
+## (The old form, 'cut', is deprecated.)
+
+## Set the line length for wrapping text and justifying paragraphs.
+## If the value is 0 or less, the wrapping point will be the screen
+## width less this number.
+# set fill -8
+
+## Remember the used search/replace strings for the next session.
+# set historylog
+
+## Make the justify command kill whitespace at the end of lines.
+# set justifytrim
+
+## Display line numbers to the left of the text.
+# set linenumbers
+
+## Enable vim-style lock-files.  This is just to let a vim user know you
+## are editing a file [s]he is trying to edit and vice versa.  There are
+## no plans to implement vim-style undo state in these files.
+# set locking
+
+## The opening and closing brackets that can be found by bracket
+## searches.  They cannot contain blank characters.  The former set must
+## come before the latter set, and both must be in the same order.
+# set matchbrackets "(<[{)>]}"
+
+## Use the blank line below the title bar as extra editing space.
+# set morespace
+
+## Enable mouse support, if available for your system.  When enabled,
+## mouse clicks can be used to place the cursor, set the mark (with a
+## double click), and execute shortcuts.  The mouse will work in the X
+## Window System, and on the console when gpm is running.
+# set mouse
+
+## Switch on multiple file buffers (inserting a file will put it into
+## a separate buffer).
+# set multibuffer
+
+## Don't convert files from DOS/Mac format.
+# set noconvert
+
+## Don't display the helpful shortcut lists at the bottom of the screen.
+# set nohelp
+
+## Don't pause between warnings at startup.  Which means that only the
+## last one will be readable (when there are multiple ones).
+# set nopauses
+
+## Don't add newlines to the ends of files.
+# set nonewlines
+
+## Don't wrap text at all.
+# set nowrap
+
+## Set operating directory.  nano will not read or write files outside
+## this directory and its subdirectories.  Also, the current directory
+## is changed to here, so any files are inserted from this dir.  A blank
+## string means the operating-directory feature is turned off.
+# set operatingdir ""
+
+## Remember the cursor position in each file for the next editing session.
+# set positionlog
+## (The old form, 'poslog', is deprecated.)
+
+## Preserve the XON and XOFF keys (^Q and ^S).
+# set preserve
+
+## The characters treated as closing punctuation when justifying
+## paragraphs.  They cannot contain blank characters.  Only closing
+## punctuation, optionally followed by closing brackets, can end
+## sentences.
+# set punct "!.?"
+
+## Do quick status-bar blanking.  Status-bar messages will disappear after
+## 1 keystroke instead of 26.  Note that "constantshow" overrides this.
+# set quickblank
+
+## The email-quote string, used to justify email-quoted paragraphs.
+## This is an extended regular expression if your system supports them,
+## otherwise a literal string.
+## If you have extended regular expression support, the default is:
+# set quotestr "^([ 	]*[#:>\|}])+"
+## Otherwise:
+# set quotestr "> "
+
+## Fix Backspace/Delete confusion problem.
+# set rebinddelete
+
+## Fix numeric keypad key confusion problem.
+# set rebindkeypad
+
+## Do extended regular expression searches by default.
+# set regexp
+
+## Put the cursor on the highlighted item in the file browser;
+## useful for people who use a braille display.
+# set showcursor
+
+## Make the Home key smarter.  When Home is pressed anywhere but at the
+## very beginning of non-whitespace characters on a line, the cursor
+## will jump to that beginning (either forwards or backwards).  If the
+## cursor is already at that position, it will jump to the true
+## beginning of the line.
+# set smarthome
+
+## Use smooth scrolling as the default.
+# set smooth
+
+## Enable soft line wrapping (AKA full-line display).
+# set softwrap
+
+## Use this spelling checker instead of the internal one.  This option
+## does not have a default value.
+# set speller "aspell -x -c"
+
+## Allow nano to be suspended.
+# set suspend
+
+## Use this tab size instead of the default; it must be greater than 0.
+# set tabsize 8
+
+## Convert typed tabs to spaces.
+# set tabstospaces
+
+## Save automatically on exit; don't prompt.
+# set tempfile
+
+## Disallow file modification.  Why would you want this in an rcfile? ;)
+# set view
+
+## The two single-column characters used to display the first characters
+## of tabs and spaces.  187 in ISO 8859-1 (0000BB in Unicode) and 183 in
+## ISO-8859-1 (0000B7 in Unicode) seem to be good values for these.
+## The default when in a UTF-8 locale:
+# set whitespace "»·"
+## The default otherwise:
+# set whitespace ">."
+
+## Detect word boundaries differently by treating punctuation
+## characters as parts of words.
+# set wordbounds
+
+## The characters (besides alphanumeric ones) that should be considered
+## as parts of words.  This option does not have a default value.  When
+## set, it overrides option 'set wordbounds'.
+# set wordchars "<_>."
+
+
+## Paint the interface elements of nano.
+## These are examples; by default there are no colors.
+set titlecolor brightwhite,blue
+set statuscolor brightwhite,green
+set selectedcolor brightwhite,magenta
+set numbercolor cyan
+set keycolor cyan
+set functioncolor green
+## In root's .nanorc you might want to use:
+# set titlecolor brightwhite,red
+# set statuscolor brightwhite,red
+# set selectedcolor brightwhite,cyan
+# set numbercolor magenta
+# set keycolor brightmagenta
+# set functioncolor magenta
+
+
+## Setup of syntax coloring.
+##
+## Format:
+##
+## syntax "short description" ["filename regex" ...]
+##
+## The "none" syntax is reserved; specifying it on the command line is
+## the same as not having a syntax at all.  The "default" syntax is
+## special: it takes no filename regexes, and applies to files that
+## don't match any other syntax's filename regexes.
+##
+## color foreground,background "regex" ["regex"...]
+## or
+## icolor foreground,background "regex" ["regex"...]
+##
+## "color" will do case-sensitive matches, while "icolor" will do
+## case-insensitive matches.
+##
+## Valid colors: white, black, red, blue, green, yellow, magenta, cyan.
+## For foreground colors, you may use the prefix "bright" to get a
+## stronger highlight.
+##
+## To use multi-line regexes, use the start="regex" end="regex"
+## [start="regex" end="regex"...] format.
+##
+## If your system supports transparency, not specifying a background
+## color will use a transparent color.  If you don't want this, be sure
+## to set the background color to black or white.
+##
+## All regexes should be extended regular expressions.
+##
+## If you wish, you may put your syntax definitions in separate files.
+## You can make use of such files as follows:
+##
+## include "/path/to/syntax_file.nanorc"
+##
+## Unless otherwise noted, the name of the syntax file (without the
+## ".nanorc" extension) should be the same as the "short description"
+## name inside that file.  These names are kept fairly short to make
+## them easier to remember and faster to type using nano's -Y option.
+##
+## To include all existing syntax definitions, you can do:
+include "/usr/share/nano/*.nanorc"
+
+
+## Key bindings.
+## See nanorc(5) (section REBINDING KEYS) for more details on this.
+##
+## The following three functions are not bound to any key by default.
+## You may wish to choose different keys than the ones suggested here.
+# bind ^S savefile main
+# bind M-B cutwordleft main
+# bind M-N cutwordright main
+
+## Set this if your Backspace key sends Del most of the time.
+# bind Del backspace all


### PR DESCRIPTION
Quite a while now _Git for Windows_ is given the users a choice to
select the `nano` editor over `vim` as the default one. So it should
feel natural to us to improve the user experience with this new default
editor.

This commit will add the `git.nanorc` file that is available on github
(https://github.com/scopatz/nanorc/blob/master/git.nanorc) to the
git-extra package. git-extra will install that syntax-highlighting file
to `/usr/share/nano` so that it will be globally available.

This leads us to the second improvement. `nano` comes with quite a lot
syntax-highlighting files already. But they are not enabled by default.
So this commit also adds a slightly modifed `nanorc` file to the
git-extra package. The file will be installed into the `/etc` folder
just like the `vimrc` file. The following list shows all settings
that will be uncommented in this file. The default `nanorc` has no
settings enabled.

    set titlecolor brightwhite,blue
    set statuscolor brightwhite,green
    set selectedcolor brightwhite,magenta
    set numbercolor cyan
    set keycolor cyan
    set functioncolor green
    include "/usr/share/nano/*.nanorc"

This first group of settings will enable the default nano ui colors.
The last one will enable all those pretty syntax-highlighting files (
including the git based one).