### PR TITLE
Don't set http.sslCAInfo for schannel

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1853,6 +1853,20 @@ begin
             Log('Line {#__LINE__}: Creating initial "' + ProgramData + '\Git\config" failed.');
         end;
     end;
+
+    {
+        Configure http.sslBackend according to the user's choice.
+    }
+
+    if RdbCurlVariant[GC_WinSSL].Checked then begin
+        Cmd:='schannel';
+    end else begin
+        Cmd:='openssl';
+    end;
+    if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config --system http.sslBackend '+Cmd,
+                AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
+        LogError('Unable to configure the HTTPS backend: '+Cmd);
+
     if FileExists(ProgramData+'\Git\config') then begin
         if not Exec(AppDir+'\bin\bash.exe','-c "value=\"$(git config -f config pack.packsizelimit)\" && if test 2g = \"$value\"; then git config -f config --unset pack.packsizelimit; fi"',ProgramData+'\Git',SW_HIDE,ewWaitUntilTerminated,i) then
             LogError('Unable to remove packsize limit from ProgramData config');
@@ -1870,19 +1884,6 @@ begin
                 AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
             LogError('Unable to configure SSL CA info: ' + Cmd);
     end;
-
-    {
-        Configure http.sslBackend according to the user's choice.
-    }
-
-    if RdbCurlVariant[GC_WinSSL].Checked then begin
-        Cmd:='schannel';
-    end else begin
-        Cmd:='openssl';
-    end;
-    if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config --system http.sslBackend '+Cmd,
-                AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
-        LogError('Unable to configure the HTTPS backend: '+Cmd);
 
     {
         Adapt core.autocrlf

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1878,11 +1878,17 @@ begin
         StringChangeEx(Cmd,'\','/',True);
         if not Exec(AppDir+'\bin\bash.exe','-c "value=\"$(git config -f config http.sslcainfo)\" && case \"$value\" in \"'+Cmd+'\"/*|\"C:/Program Files/Git/\"*|\"c:/Program Files/Git/\"*) git config -f config --unset http.sslcainfo;; esac"',ProgramData+'\Git',SW_HIDE,ewWaitUntilTerminated,i) then
             LogError('Unable to delete http.sslCAInfo from ProgramData config');
-        Cmd:='http.sslCAInfo "'+AppDir+'/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt"';
-        StringChangeEx(Cmd,'\','/',True);
-        if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config --system '+Cmd,
-                AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
-            LogError('Unable to configure SSL CA info: ' + Cmd);
+        if not RdbCurlVariant[GC_WinSSL].Checked then begin
+            Cmd:='http.sslCAInfo "'+AppDir+'/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt"';
+            StringChangeEx(Cmd,'\','/',True);
+            if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config --system '+Cmd,
+                    AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
+                LogError('Unable to configure SSL CA info: ' + Cmd);
+         end else begin
+            if not Exec(AppDir+'\{#MINGW_BITNESS}\bin\git.exe','config --system --unset http.sslCAInfo',
+                    AppDir,SW_HIDE,ewWaitUntilTerminated,i) then
+                LogError('Unable to unset SSL CA info');
+         end;
     end;
 
     {


### PR DESCRIPTION
This addresses #1409

One strange thing in my fix may be the setting and unsetting of http.dummy variable. This is a work-around for Git config problem described here:
https://stackoverflow.com/questions/37147475/gitconfig-section-duplicates-everytime-i-set-a-preference
Without this trick the installer was leaving one empty [http] section. Everything else was working fine, but system config file looked ugly.

This is my first contribution to Git for Windows, please be forgiving :)