### PR TITLE
git-sdk fixes

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -1,5 +1,3 @@
-#!/bin/sh
-
 # This profile.d script configures a few things for the Git SDK (but is
 # excluded from the end user-facing Git for Windows).
 

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -72,6 +72,7 @@ sdk () {
 	init-lazy)
 		case "$2" in
 		build-extra|git|MINGW-packages|MSYS2-packages)
+			test -d /usr/src/"$2"/.git && return
 			mkdir -p /usr/src/"$2" &&
 			git -C /usr/src/"$2" init &&
 			git -C /usr/src/"$2" config core.autocrlf false &&
@@ -132,7 +133,6 @@ case $- in
 	test -n "$JENKINS_URL" || {
 		for project in git build-extra MINGW-packages MSYS2-packages
 		do
-			test -d /usr/src/$project/.git ||
 			sdk init-lazy $project
 		done
 


### PR DESCRIPTION
* git-sdk: if a repo already exists, don't try to reinitialize it
* git-sdk: remove the shebang line

With these changes, I was able to actually build a new Git with `sdk build git`.