### PR TITLE
Fixed explanation of --cd-to-home

### DIFF
--- a/portable/root/README.portable
+++ b/portable/root/README.portable
@@ -62,10 +62,10 @@ to them, which will set the user's home directory as the working directory (as
 if Git for Windows was installed).
 
 In addition, if you set the HOME environment variable (either permanently or
-for the current session only) you can make Git store the configuration files
-and the cloned repositories in the directory specified in that variable. And if
-you specify --cd-to-home, git-bash and git-cmd will use that as the
-working directory, too. For example:
+for the current session only) you can make Git store and  use the configuration
+files in the directory specified in that variable. And if you specify
+--cd-to-home, git-bash and git-cmd will use that as the working directory when
+launched, too. For example:
 
         set HOME=%cd%/home
         git --cd-to-home


### PR DESCRIPTION
Almost three years ago, I edited `readme.portable` to document a command line switch. I made a mistake which I have discovered today. This pr fixes it. What can I say, sorry for the delay...