### PR TITLE
diffutils dep for git-extra

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -9,7 +9,7 @@ arch=('i686' 'x86_64')
 url="https://github.com/git-for-windows/build-extra"
 license=('GPL')
 groups=('VCS')
-depends=('git-for-windows-keyring')
+depends=('git-for-windows-keyring' 'diffutils')
 optdepends=('vim' 'filesystem')
 install='git-extra.install'
 pkgver() {


### PR DESCRIPTION
There's a call to `cmp ` in the .install script.