### PR TITLE
git-extra: added support for dotx diffs

### DIFF
--- a/git-extra/astextplain
+++ b/git-extra/astextplain
@@ -14,7 +14,7 @@ case "$1" in
 	*.doc | *.DOC | *.dot | *.DOT)
 		antiword -m UTF-8 "$1" | sed "s/\^M$//" || cat "$1"
 		;;
-	*.docx | *.DOCX | *.docm | *.DOCM | *.dotm | *.DOTM)
+	*.docx | *.DOCX | *.dotx | *.DOTX | *.docm | *.DOCM | *.dotm | *.DOTM)
 		docx2txt.pl "$1" -
 		;;
 	*.pdf | *.PDF)

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -36,6 +36,8 @@ GITCONFIG
 *.DOCM	diff=astextplain
 *.dot	diff=astextplain
 *.DOT	diff=astextplain
+*.dotx	diff=astextplain
+*.DOTX	diff=astextplain
 *.dotm	diff=astextplain
 *.DOTM	diff=astextplain
 *.pdf	diff=astextplain

--- a/git-extra/gitattributes
+++ b/git-extra/gitattributes
@@ -6,6 +6,8 @@
 *.DOCM	diff=astextplain
 *.dot	diff=astextplain
 *.DOT	diff=astextplain
+*.dotx	diff=astextplain
+*.DOTX	diff=astextplain
 *.dotm	diff=astextplain
 *.DOTM	diff=astextplain
 *.pdf	diff=astextplain


### PR DESCRIPTION
dotx is the file format for Word templates which is already supported by
docx2txt.pl

This pull request was based on pull request #128 and issue #900
(git-for-windows/git). They added compatibility with docm and dotm files