### PR TITLE
sdk create-desktop-icon: use $USERPROFILE instead of $HOME

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -59,7 +59,7 @@ sdk () {
 		x86_64) bitness=" 64-bit";;
 		*) bitness=;;
 		esac &&
-		desktop_icon_path="$HOME/Desktop/Git SDK$bitness.lnk" &&
+		desktop_icon_path="$USERPROFILE/Desktop/Git SDK$bitness.lnk" &&
 		if test -n "$force" || test ! -f "$desktop_icon_path"
 		then
 			create-shortcut.exe --icon-file /msys2.ico --work-dir \


### PR DESCRIPTION
As per git-for-windows/git#1660 - In non-standard environments the $HOME environment variable may not point to the folder containing the Desktop folder, so use the "Known Folder" $USERPROFILE.

I'm not sure this 100% correct - Windows [has a whole API](https://msdn.microsoft.com/en-us/library/windows/desktop/bb776911(v=vs.85).aspx) for discovering the correct location of the desktop folder, maybe the right way would be modifying the create-shortcut helper to find out the Desktop folder location by itself.