### PR TITLE
Some changes to the vimrc

### DIFF
--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -20,17 +20,15 @@ set statusline=%<%F%h%m%r\ [%{&ff}]\ (%{strftime(\"%H:%M\ %d/%m/%Y\",getftime(ex
 "------------------------------------------------------------------------------
 " Only do this part when compiled with support for autocommands.
 if has("autocmd")
-    "Set UTF-8 as the default encoding for commit messages
+    " Set UTF-8 as the default encoding for commit messages
     autocmd BufReadPre COMMIT_EDITMSG,MERGE_MSG,git-rebase-todo setlocal fileencodings=utf-8
 
-    "Remember the positions in files with some git-specific exceptions"
+    " Remember the positions in files with some git-specific exceptions"
     autocmd BufReadPost *
       \ if line("'\"") > 0 && line("'\"") <= line("$")
-      \           && expand("%") !~ "COMMIT_EDITMSG"
-      \           && expand("%") !~ "MERGE_EDITMSG"
+      \           && &filetype !~# 'commit\|gitrebase'
       \           && expand("%") !~ "ADD_EDIT.patch"
-      \           && expand("%") !~ "addp-hunk-edit.diff"
-      \           && expand("%") !~ "git-rebase-todo" |
+      \           && expand("%") !~ "addp-hunk-edit.diff" |
       \   exe "normal g`\"" |
       \ endif
 

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -4,7 +4,6 @@
 set ai                          " set auto-indenting on for programming
 set showmatch                   " automatically show matching brackets. works like it does in bbedit.
 set vb                          " turn on the "visual bell" - which is much quieter than the "audio blink"
-set ruler                       " show the cursor position all the time
 set laststatus=2                " make the last line where the status is two lines deep so you can see status always
 set backspace=indent,eol,start  " make that backspace key work the way it should
 set nocompatible                " vi compatible is LAME

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -12,6 +12,7 @@ set vb                          " turn on the "visual bell" - which is much quie
 set laststatus=2                " make the last line where the status is two lines deep so you can see status always
 set showmode                    " show the current mode
 set clipboard=unnamed           " set clipboard to unnamed to access the system clipboard under windows
+set wildmode=list:longest,longest:full   " Better command line completion
 
 " Show EOL type and last modified timestamp, right after the filename
 set statusline=%<%F%h%m%r\ [%{&ff}]\ (%{strftime(\"%H:%M\ %d/%m/%Y\",getftime(expand(\"%:p\")))})%=%l,%c%V\ %P

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -26,6 +26,12 @@ set statusline+=%=              " Rest: right align
 set statusline+=%l,%c%V         " Position in buffer: linenumber, column, virtual column
 set statusline+=\ %P            " Position in buffer: Percentage
 
+if &term =~ 'xterm'             " mintty identifies itsself as xterm-compatible
+  if &t_Co == 8
+    set t_Co = 256              " Use at lease 256 colors
+  endif
+  " set termguicolors           " Uncomment, to allow trucolors on mintty
+endif
 "------------------------------------------------------------------------------
 " Only do this part when compiled with support for autocommands.
 if has("autocmd")

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -33,7 +33,6 @@ if has("autocmd")
       \ endif
 
       autocmd BufNewFile,BufRead *.patch set filetype=diff
-      autocmd BufNewFile,BufRead *.diff set filetype=diff
 
       autocmd Syntax diff
       \ highlight WhiteSpaceEOL ctermbg=red |

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -1,16 +1,17 @@
 " Setting some decent VIM settings for programming
 " This source file comes from git-for-windows build-extra repository (git-extra/vimrc)
 
+ru! defaults.vim                " Use Enhanced Vim defaults
+set mouse=                      " Reset the mouse setting from defaults
+aug vimStartup | au! | aug END  " Revert last positioned jump, as it is defined below
+let g:skip_defaults_vim = 1     " Do not source defaults.vim again (after loading this system vimrc)
+
 set ai                          " set auto-indenting on for programming
 set showmatch                   " automatically show matching brackets. works like it does in bbedit.
 set vb                          " turn on the "visual bell" - which is much quieter than the "audio blink"
 set laststatus=2                " make the last line where the status is two lines deep so you can see status always
-set backspace=indent,eol,start  " make that backspace key work the way it should
-set nocompatible                " vi compatible is LAME
-set background=dark             " Use colours that work well on a dark background (Console is usually black)
 set showmode                    " show the current mode
 set clipboard=unnamed           " set clipboard to unnamed to access the system clipboard under windows
-syntax on                       " turn syntax highlighting on by default
 
 " Show EOL type and last modified timestamp, right after the filename
 set statusline=%<%F%h%m%r\ [%{&ff}]\ (%{strftime(\"%H:%M\ %d/%m/%Y\",getftime(expand(\"%:p\")))})%=%l,%c%V\ %P

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -37,6 +37,4 @@ if has("autocmd")
       autocmd Filetype diff
       \ highlight WhiteSpaceEOL ctermbg=red |
       \ match WhiteSpaceEOL /\(^+.*\)\@<=\s\+$/
-
-      autocmd Syntax gitcommit setlocal textwidth=74
 endif " has("autocmd")

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -1,4 +1,5 @@
 " Setting some decent VIM settings for programming
+" This source file comes from git-for-windows build-extra repository (git-extra/vimrc)
 
 set ai                          " set auto-indenting on for programming
 set showmatch                   " automatically show matching brackets. works like it does in bbedit.

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -15,7 +15,16 @@ set clipboard=unnamed           " set clipboard to unnamed to access the system 
 set wildmode=list:longest,longest:full   " Better command line completion
 
 " Show EOL type and last modified timestamp, right after the filename
-set statusline=%<%F%h%m%r\ [%{&ff}]\ (%{strftime(\"%H:%M\ %d/%m/%Y\",getftime(expand(\"%:p\")))})%=%l,%c%V\ %P
+" Set the statusline
+set statusline=%f               " filename relative to current $PWD
+set statusline+=%h              " help file flag
+set statusline+=%m              " modified flag
+set statusline+=%r              " readonly flag
+set statusline+=\ [%{&ff}]      " Fileformat [unix]/[dos] etc...
+set statusline+=\ (%{strftime(\"%H:%M\ %d/%m/%Y\",getftime(expand(\"%:p\")))})  " last modified timestamp
+set statusline+=%=              " Rest: right align
+set statusline+=%l,%c%V         " Position in buffer: linenumber, column, virtual column
+set statusline+=\ %P            " Position in buffer: Percentage
 
 "------------------------------------------------------------------------------
 " Only do this part when compiled with support for autocommands.

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -34,7 +34,7 @@ if has("autocmd")
 
       autocmd BufNewFile,BufRead *.patch set filetype=diff
 
-      autocmd Syntax diff
+      autocmd Filetype diff
       \ highlight WhiteSpaceEOL ctermbg=red |
       \ match WhiteSpaceEOL /\(^+.*\)\@<=\s\+$/
 


### PR DESCRIPTION
Hi this branch changes some of the Vim settings. I tried to make the commits as granular as possible to make reviewing easier.

Currently some settings can be improved a bit, so I slightly changed them. I tried not to change them according to my personal taste and if I did, I mentioned it in the commit message (cursor block style, command line completion, ...) and those could then reverted if needed.

The rest should keep Vim more closely to Vims upstream repository, especially since it sources the defaults.vim file anyhow (currently overwriting some settings). 

Also I found comments beneficial, so I left a couple of more comments. One thing I did not know for sure is the usage of EDIT_MERGEMSG and EDIT_MSG. I am not sure whether both of them are needed or only one of them (and the other one was a typo). For now I left it as is (and added the other one to the settings as well. This can easily be reverted if needed. Also if this is correct, it might be beneficial to add some of this to upstreams filetype detection logic.