### PR TITLE
Fire EditorSelectionChanged on next button click

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1193,7 +1193,6 @@ begin
     else
         CbbEditor.ItemIndex:=GE_VIM;
     end;
-    EditorSelectionChanged(NIL);
 
     (*
      * Create a custom page for modifying the environment.
@@ -1529,7 +1528,9 @@ begin
         end;
     end;
 
-    if (PuTTYPage<>NIL) and (CurPageID=PuTTYPage.ID) then begin
+    if (EditorPage<>NIL) and (CurPageID=EditorPage.ID) then begin
+        EditorSelectionChanged(NIL);
+    end else if (PuTTYPage<>NIL) and (CurPageID=PuTTYPage.ID) then begin
         Result:=RdbSSH[GS_OpenSSH].Checked or
             (RdbSSH[GS_Plink].Checked and FileExists(EdtPlink.Text));
         if not Result then begin


### PR DESCRIPTION
This is a solution that I propose for [#1690](https://github.com/git-for-windows/git/issues/1690). I consider it to be a suggestion, as building an installer was beyond me, thus I'm not sure if it would fix the issue.

As far as my comprehension goes, an [EditorSelectionChanged](https://github.com/izdwuut/build-extra/blob/1d9630e321351b5ecd1609a3effd8df34cd948a1/installer/install.iss#L1084) procedure is responsible for toggling the "next" button. I noticed that it gets invoked in at least 2 situations:
  - when an user picks a text editor ([an OnChange event](https://github.com/izdwuut/build-extra/blob/1d9630e321351b5ecd1609a3effd8df34cd948a1/installer/install.iss#L1119))
  - once the custom page for configuring the default Git editor is initialized (the InitializeWizard procedure. I have just removed it, as I see it as redundant now)

My reasoning tells me that it would be applicable in the [NextButtonClick](https://github.com/izdwuut/build-extra/blob/1d9630e321351b5ecd1609a3effd8df34cd948a1/installer/install.iss#L1507) procedure as well. I added an appropriate code snippet to it.