### PR TITLE
Fix astextplain for pdf files

### DIFF
--- a/git-extra/astextplain
+++ b/git-extra/astextplain
@@ -18,7 +18,7 @@ case "$1" in
 		docx2txt.pl "$1" -
 		;;
 	*.pdf | *.PDF)
-		pdftotext -layout "$1" -enc UTF-8 - | sed "s/(\^M$)|(^\^L)//"
+		pdftotext -layout -enc UTF-8 "$1" - | sed "s/(\^M$)|(^\^L)//"
 		;;
 	# TODO add rtf support
 	*.rtf | *.RTF)


### PR DESCRIPTION
Fixed order of command line arguments for pdftotext.
With current order it prints help message to stderr.