### PR TITLE
Exclude PCRE2 documentation from releases

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -106,7 +106,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/xml.*exe$' \
 	-e '^/mingw../share/doc/gettext/' \
 	-e '^/mingw../share/doc/lib' \
-	-e '^/mingw../share/doc/pcre/' \
+	-e '^/mingw../share/doc/pcre2\?/' \
 	-e '^/mingw../share/doc/git-doc/.*\.txt$' \
 	-e '^/mingw../lib/gettext/' -e '^/mingw../share/gettext/' \
 	-e '^/usr/include/' -e '^/mingw../include/' \


### PR DESCRIPTION
As Git for Windows did not ship PCRE documentation before switching to the PCRE2 dependency, there
should be no need too start shipping PCRE2 documentation now.