### PR TITLE
enable GCM and Chacha20 ciphers

### DIFF
--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -219,8 +219,8 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	# Re-enable at least AES256-cbc and AES128-cbc, as they are still used
 	# e.g. in VSTS
 	test ! -f /etc/ssh/ssh_config ||
-	grep -q '^Ciphers .*aes256-cbc,aes192-cbc' /etc/ssh/ssh_config ||
-	sed -i -e '/^[# ]*Ciphers /{s/^# *//;s/$/,aes256-cbc,aes192-cbc/}' \
+	grep -q '^Ciphers' /etc/ssh/ssh_config ||
+	sed -i -e '$aCiphers   chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,3des-cbc,aes256-cbc,aes192-cbc' \
 		/etc/ssh/ssh_config
 
 	# Enable color and syntax-highlighting in GNU nano

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -181,8 +181,8 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	# Re-enable at least AES256-cbc and AES128-cbc, as they are still used
 	# e.g. in VSTS
 	test ! -f /etc/ssh/ssh_config ||
-	grep -q '^Ciphers .*aes256-cbc,aes192-cbc' /etc/ssh/ssh_config ||
-	sed -i -e '/^[# ]*Ciphers /{s/^# *//;s/$/,aes256-cbc,aes192-cbc/}' \
+	grep -q '^Ciphers' /etc/ssh/ssh_config ||
+	sed -i -e '$aCiphers   chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,3des-cbc,aes256-cbc,aes192-cbc' \
 		/etc/ssh/ssh_config
 
 	# Enable color and syntax-highlighting in GNU nano


### PR DESCRIPTION
These are offered by ssh by default, but they are not included in the
default list of Ciphers in ssh_config.

Closes https://github.com/git-for-windows/git/issues/1723.