### PR TITLE
git-extra: only edit vim 8.0's defaults file when it exists

### DIFF
--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -154,6 +154,7 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	sed -i -e '/^ *autocmd BufReadPost \*/,/\\ \(| \)\?endif$/s/^/"/' \
 		/usr/share/vim/vim81/defaults.vim
 
+	test ! -f /usr/share/vim/vim80/defaults.vim ||
 	! grep -q '^"  augroup END$' /usr/share/vim/vim80/defaults.vim ||
 	sed -i -e '/^"  augroup END$/,$s/^"//' \
 		/usr/share/vim/vim80/defaults.vim


### PR DESCRIPTION
Because otherwise, we're probably on vim 8.1 or later.

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>