### PR TITLE
Remove minor, superfluous text from install.iss.

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1355,7 +1355,7 @@ begin
     RdbExtraOptions[GP_FSCache].Checked:=ReplayChoice('Performance Tweaks FSCache','Enabled')<>'Disabled';
 
     // 2nd option
-    RdbExtraOptions[GP_GCM]:=CreateCheckBox(ExtraOptionsPage,'Enable Git Credential Manager','The <A HREF=https://github.com/Microsoft/Git-Credential-Manager-for-Windows>Git Credential Manager for Windows</A> provides secure Git credential storage'+#13+'for Windows, most notably multi-factor authentication support for Visual Studio'+#13+'Team Services and GitHub. (requires .NET framework v4.5.1 or or later).',TabOrder,Top,Left);
+    RdbExtraOptions[GP_GCM]:=CreateCheckBox(ExtraOptionsPage,'Enable Git Credential Manager','The <A HREF=https://github.com/Microsoft/Git-Credential-Manager-for-Windows>Git Credential Manager for Windows</A> provides secure Git credential storage'+#13+'for Windows, most notably multi-factor authentication support for Visual Studio'+#13+'Team Services and GitHub. (requires .NET framework v4.5.1 or later).',TabOrder,Top,Left);
 
     // Restore the settings chosen during a previous install, if .NET 4.5.1
     // or later is available.


### PR DESCRIPTION
# Repro Steps
0. The superfluous text can be observed in the 2.18.0 release: https://github.com/git-for-windows/git/releases/tag/v2.18.0.windows.1 .
1. Install `Git for Windows SDK`.
2. Run `sdk build git-and-installer` to produce an unsigned installer `Git-0-test-64-bit.exe`.
3. The superfluous text can be observed in the unsigned installer.
4. Apply the code patch.
5. Run `sdk build git-and-installer` to re-build the installer.
6. The superfluous text can no longer be observed in the re-built installer.
