### PR TITLE
Exclude xsltproc.exe from installer/portable Git/etc

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -104,6 +104,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/etc/skel/' -e '^/mingw../etc/skel/' \
 	-e '^/usr/bin/svn' \
 	-e '^/usr/bin/xml.*exe$' \
+	-e '^/usr/bin/xslt.*$' \
 	-e '^/mingw../share/doc/gettext/' \
 	-e '^/mingw../share/doc/lib' \
 	-e '^/mingw../share/doc/pcre2\?/' \


### PR DESCRIPTION
It was reported in https://github.com/git-for-windows/git/issues/1775 that xsltproc does not work due to a missing .dll. Keeping in mind that xsltproc is not at all required for Git to work, let's exclude that executable.
