### PR TITLE
git-sdk: Mount other SDK with noacl flag

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -14,7 +14,7 @@ case "$rootdir" in
 	then
 		othersdk="${rootdir%??}$otherarch"
 		test ! -d "$othersdk" ||
-		mount "$othersdk" /sdk$otherarch 2>/dev/null
+		mount -o noacl "$othersdk" /sdk$otherarch 2>/dev/null
 	fi
 	;;
 esac


### PR DESCRIPTION
Without it, chmod fails for files on this mount