### PR TITLE
Exclude git-archimport from installer/portable Git/etc

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -123,6 +123,8 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../.*/git-cvsserver.*$' \
 	-e '^/mingw../.*/gitweb/' \
 	-e '^/mingw../lib/tdbc' \
+	-e '^/mingw../libexec/git-core/git-archimport$' \
+	-e '^/mingw../share/doc/git-doc/git-archimport' \
 	-e '^/mingw../share/git\(k\|-gui\)/lib/msgs/' \
 	-e '^/mingw../share/nghttp2/' \
 	-e '^/usr/bin/msys-\(db\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \


### PR DESCRIPTION
This is a component that we expect does not get much use. Instead of distributing this component with Git for Windows, remove it. Removing this component will reduce the work associated the release process.

Signed-off-by: Jameson Miller <jamill@microsoft.com>

