### PR TITLE
installer: offer the builtin stash/rebase as experimental options

### DIFF
--- a/installer/release.sh
+++ b/installer/release.sh
@@ -130,6 +130,20 @@ case "$LIST" in
 	;;
 esac
 
+case "$LIST" in
+*/libexec/git-core/git-legacy-rebase*)
+	inno_defines="$(printf "%s\n%s" "$inno_defines" \
+		"#define WITH_EXPERIMENTAL_BUILTIN_REBASE 1")"
+	;;
+esac
+
+case "$LIST" in
+*/libexec/git-core/git-legacy-stash*)
+	inno_defines="$(printf "%s\n%s" "$inno_defines" \
+		"#define WITH_EXPERIMENTAL_BUILTIN_STASH 1")"
+	;;
+esac
+
 GITCONFIG_PATH="$(echo "$LIST" | grep "^mingw$BITNESS/etc/gitconfig\$")"
 printf '' >programdata-config.template
 test -z "$GITCONFIG_PATH" || {


### PR DESCRIPTION
As nice as the speed-ups are, the patches in question are still in flux, and they are not battle-tested at all.

Let's use the scripted commands by default, and offer the new, fast, experimental builtins as options.

This gives us the best of both worlds: users who want the raw speed improvement we got through three Google Summer of Code projects working in parallel can have that, while others who are reluctant to play guinea pig by running only well-tested code can stay on the safe side.

Plus, it gives us a chance of battle-testing those patches :-)

Note: the code added in this PR will only kick in if bundling a Git built including the latest patches of https://github.com/git-for-windows/git/pull/1800.