### PR TITLE
Revert "Add perl JSON module"

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -90,7 +90,7 @@ git-extra openssh $UTIL_PACKAGES"
 if test -z "$MINIMAL_GIT"
 then
 	packages="$packages mingw-w64-$ARCH-git-doc-html ncurses mintty vim nano
-		winpty less gnupg tar diffutils patch dos2unix which subversion perl-JSON
+		winpty less gnupg tar diffutils patch dos2unix which subversion
 		mingw-w64-$ARCH-tk mingw-w64-$ARCH-connect git-flow docx2txt
 		mingw-w64-$ARCH-antiword mingw-w64-$ARCH-odt2txt ssh-pageant
 		mingw-w64-$ARCH-git-lfs mingw-w64-$ARCH-xz tig $GIT_UPDATE_EXTRA_PACKAGES"


### PR DESCRIPTION
Sadly, this fails to build an installer:

```
[...]
Generating file list to be included in the installer ...
error: package 'perl-JSON' not found
```

Reverts git-for-windows/build-extra#209

Signed-off-by: Johannes Schindelin <johannes.schindelin@gmx.de>