### PR TITLE
please.sh: script to fix duplicate relnote entry

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3453,6 +3453,7 @@ mention () { # <what, e.g. bug-fix, new-feature> <release-notes-item>
 		sed -i -e "/^## Changes since/{s/^/$quoted\n\n/;:1;n;b1}" \
 			"$relnotes"
 	else
+		search=$(echo $quoted | sed -r -e 's#.*Comes with \[(.* v|patch level).*#\1#')
 		sed -i -e '/^## Changes since/{
 			:1;n;
 			/^### '"$what"'/b3;
@@ -3460,12 +3461,15 @@ mention () { # <what, e.g. bug-fix, new-feature> <release-notes-item>
 			/^## Changes since/b2;
 			b1;
 
-			:2;s/^/### '"$what"'\n\n'"$quoted"'\n\n/;b5;
+			:2;s/^/### '"$what"'\n\n'"$quoted"'\n\n/;b7;
 
-			:3;/^\*/b4;n;b3;:4;n;/^\*/b4;
-			s/^/'"$quoted"'\n/;b5;
+			:3;/^\*/b4;n;b3;
 
-			:5;n;b5}' "$relnotes"
+			:4;/'"$search"'/b5;n;b6;:5;N;s/^.*\n//;:6;/^\*/b4;
+
+			s/^/'"$quoted"'\n/;
+
+			:7;n;b7}' "$relnotes"
 	fi ||
 	die "Could not edit release notes\n"
 


### PR DESCRIPTION
when packages (like 'Git Credential Manager') are upgraded twice (or
more times) between Git for Windows releases, duplicate entries are
created in 'ReleaseNotes.md'.

Subcommand `mention` writes/edits the 'ReleaseNotes.md'.

Added script to delete every match for 'Comes with [<package> v' before
appending new entry 'Comes with [<package> <version>](<url>)'.

this closes issue https://github.com/git-for-windows/git/issues/1898