### PR TITLE
Deprecate Git CMD

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -35,6 +35,8 @@ This package contains software from a number of other projects including Bash, z
 
 ## Changes since Git for Windows v2.19.1 (Oct 5th 2018)
 
+Please note: _Git CMD_ is deprecated as of this Git for Windows version. The default is to have `git.exe` in the `PATH` anyway, so there is no noticeable difference between CMD and Git CMD. It is impossible to turn off CMD's behavior where it picks up any `git.exe` in the current directory, so let's discourage the use of Git CMD. Users who dislike Git Bash should switch to Powershell instead.
+
 ### New Features
 
 * Comes with [OpenSSH v7.9p1](https://www.openssh.com/txt/release-7.9).

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -122,7 +122,7 @@ Name: "{app}\tmp"
 [Icons]
 Name: {group}\Git GUI; Filename: {app}\cmd\git-gui.exe; Parameters: ""; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 Name: {group}\Git Bash; Filename: {app}\git-bash.exe; Parameters: "--cd-to-home"; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
-Name: {group}\Git CMD; Filename: {app}\git-cmd.exe; Parameters: "--cd-to-home"; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
+Name: {group}\Git CMD (Deprecated); Filename: {app}\git-cmd.exe; Parameters: "--cd-to-home"; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 
 [Messages]
 BeveledLabel={#APP_URL}
@@ -154,10 +154,10 @@ Root: HKCU; Subkey: Console\Git Bash; ValueType: dword; ValueName: FontFamily; V
 Root: HKCU; Subkey: Console\Git Bash; ValueType: dword; ValueName: FontSize; ValueData: $000e0000; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
 Root: HKCU; Subkey: Console\Git Bash; ValueType: dword; ValueName: FontWeight; ValueData: $00000190; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
 
-Root: HKCU; Subkey: Console\Git CMD; ValueType: string; ValueName: FaceName; ValueData: Lucida Console; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
-Root: HKCU; Subkey: Console\Git CMD; ValueType: dword; ValueName: FontFamily; ValueData: $00000036; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
-Root: HKCU; Subkey: Console\Git CMD; ValueType: dword; ValueName: FontSize; ValueData: $000e0000; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
-Root: HKCU; Subkey: Console\Git CMD; ValueType: dword; ValueName: FontWeight; ValueData: $00000190; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
+Root: HKCU; Subkey: Console\Git CMD (Deprecated); ValueType: string; ValueName: FaceName; ValueData: Lucida Console; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
+Root: HKCU; Subkey: Console\Git CMD (Deprecated); ValueType: dword; ValueName: FontFamily; ValueData: $00000036; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
+Root: HKCU; Subkey: Console\Git CMD (Deprecated); ValueType: dword; ValueName: FontSize; ValueData: $000e0000; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
+Root: HKCU; Subkey: Console\Git CMD (Deprecated); ValueType: dword; ValueName: FontWeight; ValueData: $00000190; Flags: createvalueifdoesntexist uninsdeletevalue uninsdeletekeyifempty
 
 ; Note that we write the Registry values below either to HKLM or to HKCU depending on whether the user running the installer
 ; is a member of the local Administrators group or not (see the "Check" argument).

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -177,7 +177,7 @@ sed -e 's/\(.*\)\\\(.*\)/            <Component Directory="INSTALLFOLDER:\\\1\\"
             <\/Component>/' \
 	-e "s/<File Source=\"\(mingw$BITNESS.*\(ca\)-\(bundle\.crt\)\)\" \/>/<File Id=\"\2_\3\" Source=\"\1\" \/>/"\
 	-e 's/\(<File Source="git-bash.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git Bash" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
-	-e 's/\(<File Source="git-cmd.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git CMD" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
+	-e 's/\(<File Source="git-cmd.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git CMD (Deprecated)" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
 	-e 's/\(<File Source="cmd\\git-gui.exe"[^>]*\) \/>/\1 \/><Shortcut Name="Git GUI" Icon="git.ico" Directory="GitProgramMenuFolder" WorkingDirectory="INSTALLFOLDER" Arguments="--cd-to-home" Advertise="yes" \/>/' \
 	-e 's/\(Source="git-bash.exe" \)\([^>]\)*/Id="GitBash" \1\2/' \
 	-e 's/\(<Component Directory="INSTALLFOLDER:\\etc\\post-install\\"\)>/\1 Guid="" >/' \


### PR DESCRIPTION
We talked about this recently, and I think it is time. There is one particular issue with CMD that opens a particular attack vector that is unavailable for Git Bash and Powershell users: when calling `git log` in a directory in which there is a `git.exe`, that executable is used, no matter how you configure `PATH` or CMD. So if some creative user talks another user into cloning a repository with `git.exe` in the top-level directory, and that other user is unsuspecting of this behavior, they might be talked into calling `git log` and actually run untrusted code.

To raise awareness of this issue, and at the same time to diminish chances of such social-engineering attacks, let's deprecate Git CMD.

Note: this behavior is neither new, nor limited to Git. It just so happens that we can at least deprecate Git CMD, and that's what we should do.