### PR TITLE
Use the Command Prompt as own name

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1436,10 +1436,10 @@ begin
     RdbPath[GP_BashOnly]:=CreateRadioButton(PathPage,'Use Git from Git Bash only','This is the safest choice as your PATH will not be modified at all. You will only be'+#13+'able to use the Git command line tools from Git Bash.',TabOrder,Top,Left);
 
     // 2nd choice
-    RdbPath[GP_Cmd]:=CreateRadioButton(PathPage,'Use Git from the Windows Command Prompt','This option is considered safe as it only adds some minimal Git wrappers to your'+#13+'PATH to avoid cluttering your environment with optional Unix tools. You will be'+#13+'able to use Git from both Git Bash and the Windows Command Prompt.',TabOrder,Top,Left);
+    RdbPath[GP_Cmd]:=CreateRadioButton(PathPage,'Git from the command line and also from 3rd-party software','This option is considered safe as it only adds some minimal Git wrappers to your'+#13+'PATH to avoid cluttering your environment with optional Unix tools.'+#13+'You will be able to use Git from Git Bash, the Command Prompt and the Windows PowerShell as well as any third-party software looking for Git in PATH.',TabOrder,Top,Left);
 
     // 3rd choice
-    RdbPath[GP_CmdTools]:=CreateRadioButton(PathPage,'Use Git and optional Unix tools from the Windows Command Prompt','Both Git and the optional Unix tools will be added to your PATH.'+#13+'<RED>Warning: This will override Windows tools like "find" and "sort". Only'+#13+'use this option if you understand the implications.</RED>',TabOrder,Top,Left);
+    RdbPath[GP_CmdTools]:=CreateRadioButton(PathPage,'Use Git and optional Unix tools from the Command Prompt','Both Git and the optional Unix tools will be added to your PATH.'+#13+'<RED>Warning: This will override Windows tools like "find" and "sort". Only'+#13+'use this option if you understand the implications.</RED>',TabOrder,Top,Left);
 
     // Restore the setting chosen during a previous install.
     case ReplayChoice('Path Option','Cmd') of


### PR DESCRIPTION
Clarifies the Command Prompt is an own name, and qualifying it with Windows, i.e. Windows Command Prompt, is redundant. Similarly, full name of PowerShell on Windows is Windows PowerShell.

Mention the Windows PowerShell in the 2nd choice description for even more clarity.

## References

- Follow-up to the ML thread [Git for Windows v2.20.0-rc0](https://groups.google.com/forum/#!msg/git-for-windows/SFqyASXbGxE/v1nSwrOhCQAJ), where I argued use of the "Windows Command Prompt" in

    > That setting "Use Git from the Windows Command Prompt" affected PowerShell
    > already: by "Windows Command Prompt", I refer to both CMD and PowerShell:
    > both are Windows Command Prompts.

    is confusing, since

    > Shortly, there are two native command prompts in Windows with distinct names:
    > - Command Prompt
    > - Windows PowerShell

    If I'm still trying to be anal about the naming, trying to find a rationale of it, I'd have considered the "Windows Command Prompt" as shortcut of "Windows' Command Prompt", "In Windows, Command Prompt" or "Command Prompt on Windows" :-)

    Possibly, "Windows Command-line" may be better name for all command-line flavours on Windows, than "Windows Command Prompt".

- https://en.wikipedia.org/wiki/PowerShell although now portable, for GfW case, it is clearer to state the old name:

   > Initially a Windows component only, known as Windows PowerShell

- https://en.wikipedia.org/wiki/Cmd.exe uses name "Command Prompt"
    
    > In Windows, Command Prompt

- MSDN and docs.microsoft.com use "The Developer Command Prompt", not "The Developer Windows Command Prompt", to refer to the Command Prompt configured for Visual Studio toolsets.

