### PR TITLE
Update 2.19.1 release notes for clearer cmd.exe deprecation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -50,7 +50,7 @@ This package contains software from a number of other projects including Bash, z
 
 ## Changes since Git for Windows v2.19.1 (Oct 5th 2018)
 
-Please note: _Git CMD_ is deprecated as of this Git for Windows version. The default is to have `git.exe` in the `PATH` anyway, so there is no noticeable difference between CMD and Git CMD. It is impossible to turn off CMD's behavior where it picks up any `git.exe` in the current directory, so let's discourage the use of Git CMD. Users who dislike Git Bash should switch to Powershell instead.
+Please note: Using Git from Command Prompt (cmd.exe, Git CMD) is deprecated as of this Git for Windows version. The default is to have `git.exe` in the `PATH`, so there is no noticeable difference between cmd.exe and using the _Git CMD_ start menu shortcut. It is impossible to turn off Command Prompt's behavior where it picks up any `git.exe` in the current directory, so let's discourage the use of _Git CMD_. Users who dislike Git Bash should switch to PowerShell instead.
 
 ### New Features
 


### PR DESCRIPTION
Some people may be confused about the meaning of deprecation
of "Git CMD". Rewording the release notes to call out that:

- using _Command Prompt (cmd.exe)_ is deprecated,
- the _Git CMD_ start menu shortcut (which configures a cmd.exe
  instance) is really the same as a vanilla cmd.exe instance.

Signed-off-by: Matthew John Cheetham <mjcheetham@outlook.com>