### PR TITLE
notepad: don't break comments in COMMIT_EDITMSG

### DIFF
--- a/git-extra/notepad
+++ b/git-extra/notepad
@@ -25,7 +25,8 @@ dos2unix.exe "$1" &&
 case "$1" in
 */COMMIT_EDITMSG|*\\COMMIT_EDITMSG)
 	! columns="$(git config format.commitmessagecolumns)" || {
-		msg="$(fmt.exe -s -w "$columns" "$1")" &&
+		msg="$(fmt.exe -s -w "$columns" "$1" -p '#' | \
+			fmt.exe -s -w "$columns" -)" &&
 		printf "%s" "$msg" >"$1"
 	}
 	;;


### PR DESCRIPTION
Wrapping lines with fmt could cause comments in COMMIT_EDITMSG to turn into a
comment line and one or more non-comment lines. Wrapping just the comments with
the -p option before wrapping the other lines prevents this from happening.

This fixes git-for-windows/git#1967

I've marked this as "don't merge yet", because I haven't tested it yet. Will update this PR soon.
