### PR TITLE
Restore post-install script execution for portable installer

### DIFF
--- a/portable/release.sh
+++ b/portable/release.sh
@@ -142,7 +142,7 @@ echo "Creating archive" &&
  echo 'GUIMode="1"' &&
  echo 'InstallPath="%%S\\PortableGit"' &&
  echo 'OverwriteMode="0"' &&
- echo "RunProgram=\"git-bash.exe --no-needs-console --hide --no-cd --command=post-install.bat\"" &&
+ echo "RunProgram=\"git-bash.exe --needs-console --hide --no-cd --command=post-install.bat\"" &&
  echo ';!@InstallEnd@!' &&
  cat "$TMPPACK") > "$TARGET" &&
 echo "Success! You will find the new installer at \"$TARGET\"." &&


### PR DESCRIPTION
The argument --no-needs-console prevents the git-bash.exe to run the script at the end of the extraction process. Moreover, the --hide argument is ineffective in hiding the console windows.

This fixes git-for-windows/git#1896
