### PR TITLE
Fix the SDK installer so it respects target directories with spaces in their path

### DIFF
--- a/sdk-installer/release.sh
+++ b/sdk-installer/release.sh
@@ -48,10 +48,13 @@ do
 	exes_and_dlls="$exes_and_dlls$file "
 
         for dll in $(ldd "$BIN_DIR/$file" |
-		sed -n "s|.*> $BIN_DIR/\\([^ ]*\\).*|\\1|p")
+		sed -ne "s|.*> $BIN_DIR/\\([^ ]*\\).*|\\1|p" \
+			-e "s|.*> ${BIN_DIR%bin}\\(libexec/git-core/[^ ]*\\).*|../\\1|p")
         do
                 case " $exes_and_dlls $todo " in
                 *" $dll "*) ;; # already found/queued
+                *" ${dll#../libexec/git-core/} "*) ;; # already found/queued
+                *" ../libexec/git-core/$dll "*) ;; # already found/queued
                 *) test ! -f "$BIN_DIR/$dll" || todo="$todo$dll ";;
                 esac
         done

--- a/sdk-installer/setup-git-sdk.bat
+++ b/sdk-installer/setup-git-sdk.bat
@@ -7,6 +7,9 @@
 @REM <percent>~fI Expands <percent>I to a fully qualified path name.
 @FOR /F "delims=" %%D in ("%~dp0") do @set cwd=%%~fD
 
+@CD "%cwd%"
+@IF ERRORLEVEL 1 GOTO DIE
+
 @REM set PATH
 @set PATH=%cwd%\mini\mingw@@BITNESS@@\bin;%PATH%
 
@@ -23,21 +26,21 @@
 @IF ERRORLEVEL 1 GOTO DIE
 
 @REM Cleaning up temporary git.exe
-@RMDIR /Q /S %cwd%\mini
+@RMDIR /Q /S mini
 @IF ERRORLEVEL 1 GOTO DIE
 
 @REM Avoid overlapping address ranges
 @IF 32 == @@BITNESS@@ @(
 	ECHO Auto-rebasing .dll files
-	CALL "%cwd%"\autorebase.bat
+	CALL autorebase.bat
 )
 
 @REM Before running a shell, let's prevent complaints about "permission denied"
 @REM from MSYS2's /etc/post-install/01-devices.post
-@MKDIR "%cwd%"\dev\shm 2> NUL
-@MKDIR "%cwd%"\dev\mqueue 2> NUL
+@MKDIR dev\shm 2> NUL
+@MKDIR dev\mqueue 2> NUL
 
-@START /B %cwd%\git-bash.exe
+@START /B git-bash.exe
 @EXIT /B 0
 
 :DIE

--- a/sdk-installer/setup-git-sdk.bat
+++ b/sdk-installer/setup-git-sdk.bat
@@ -22,7 +22,7 @@
 @IF ERRORLEVEL 1 GOTO DIE
 @git fetch --depth 1 origin
 @IF ERRORLEVEL 1 GOTO DIE
-@git checkout -t origin/master
+@git -c core.fscache=true checkout -t origin/master
 @IF ERRORLEVEL 1 GOTO DIE
 
 @REM Cleaning up temporary git.exe


### PR DESCRIPTION
It was reported in https://github.com/git-for-windows/git-sdk-64/issues/6 that installing into a directory whose path contains a space does not work.

While at it, I had to fix the problem where `.dll` files required by `git-remote-https.exe` were not picked up if they existed in `libexec/git-core/`, and I also activated the FSCache for the checkout.