### PR TITLE
ReleaseNotes: duplicated files are hard links

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -23,6 +23,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
 *   Some commands are not yet supported on Windows and excluded from the installation.
 *   As Git for Windows is shipped without Python support, all Git commands requiring Python are not yet supported; e.g. `git p4`.
 *   The Quick Launch icon will only be installed for the user running setup (typically the Administrator). This is a technical restriction and will not change.
+*   The git-core executable file(s) are typically double-counted by Windows Explorer. In fact, repeated files are hard linked, so do not take up the space indicated (#1977).
 
 Should you encounter other problems, please search [the bug tracker](https://github.com/git-for-windows/git/issues) and [the mailing list](http://groups.google.com/group/git-for-windows), chances are that the problem was reported already. If it has not been reported, please follow [our bug reporting guidelines](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) and [report the bug](https://github.com/git-for-windows/git/issues/new).
 


### PR DESCRIPTION
Inform users that Windows Explorer double counts file sizes for
hard links.

fixes: #1977 (https://github.com/git-for-windows/git/issues/1997)

Signed-off-by: Philip Oakley <philipoakley@iee.org>
---
I haven't tested this with a full build and install yet, but it looked simple enough, apart from a minor concern about the '#' in the updated markdown text.

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
