### PR TITLE
Reworded release notes for the OpenSSL/git-svn patch

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -56,6 +56,7 @@ This package contains software from a number of other projects including Bash, z
 * Portable Git [can be launched via network paths again](https://github.com/git-for-windows/git/issues/2036).
 * FSCache works again [on network drives](https://github.com/git-for-windows/git/issues/2022), in particular [when Windows 8.1 or older](https://github.com/git-for-windows/git/issues/1989) are involved.
 * Partially hidden text in the `Path` options page in the installer [is no longer hidden](https://github.com/git-for-windows/git/issues/2049).
+* Comes with a version of OpenSSL v1.1.1a that's been [patched to remove a potential infinite loop](https://github.com/git-for-windows/MSYS2-packages/commit/80b90d2fb01834a867f25db89de60fae03f63367). This fixes hanging issues with `git svn` when interacting with repositories via HTTPS.
 
 ## Changes since Git for Windows v2.20.0 (December 10th 2018)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -44,7 +44,6 @@ This package contains software from a number of other projects including Bash, z
 * Comes with MSYS2 runtime (Git for Windows flavor) based on [Cygwin 3.0.1](https://cygwin.com/ml/cygwin-announce/2019-02/msg00014.html) (including the changes of [Cygwin 3.0.0](https://cygwin.com/ml/cygwin-announce/2019-02/msg00010.html) since the previous Git for Windows version).
 * Comes with [git-flow v1.12.0](https://github.com/petervanderdoes/gitflow-avh/releases/tag/1.12.0).
 * `git archive` [no longer requires `gzip` to generate `.tgz` archives](https://github.com/git-for-windows/git/pull/2077) (this means in particular that it works in MinGit).
-* Comes with [OpenSSL v1.1.1a](https://www.openssl.org/news/openssl-1.1.1-notes.html).
 
 ### Bug Fixes
 


### PR DESCRIPTION
> Comes with OpenSSL v1.1.1a

didn't accurately describe this change, even though the build agent tried it's best.