### PR TITLE
Enable support for gawk in-place editing

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -112,7 +112,7 @@ pacman_list $packages "$@" |
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '/man/' -e '/pkgconfig/' -e '/emacs/' \
 	-e '^/usr/lib/python' -e '^/usr/lib/ruby' \
-	-e '^/usr/share/awk' -e '^/usr/share/subversion' \
+	-e '^/usr/share/subversion' \
 	-e '^/etc/skel/' -e '^/mingw../etc/skel/' \
 	-e '^/usr/bin/svn' \
 	-e '^/usr/bin/xml.*exe$' \


### PR DESCRIPTION
 Update the excluded file patterns, so the contents of "/usr/share/awk" will be present in the installer and portable builds. This does not significantly impact the size of the installer, with the full contents of the directory being approximately 50 KB in size.

This fixes git-for-windows/git#1972.
