### PR TITLE
Support the `msys2-runtime` better in the `sdk` function

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -206,13 +206,15 @@ sdk () {
 			"$src_dir"/installer/release.sh "${3:-0-test}"
 			;;
 		*)
+			sdk cd "$2" ||
+			return $?
 			if test -f PKGBUILD
 			then
 				case "$MSYSTEM" in
 				MSYS) makepkg --syncdeps --noconfirm;;
 				MINGW*) makepkg-mingw --syncdeps --noconfirm;;
 				esac
-				return #?
+				return $?
 			fi
 
 			cat >&2 <<EOF

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -205,6 +205,27 @@ sdk () {
 			sdk init build-extra &&
 			"$src_dir"/installer/release.sh "${3:-0-test}"
 			;;
+		msys2-runtime)
+			sdk cd "$2" ||
+			return $?
+
+			if test refs/heads/makepkg = "$(git symbolic-ref HEAD)" &&
+				{ git -C diff-files --quiet &&
+				  git -C diff-index --quiet HEAD ||
+				  test ! -s .git/index; }
+			then
+				# no local changes
+				cd "$src_cdup_dir" &&
+				makepkg --syncdeps --noconfirm
+				return $?
+			fi
+
+			# Build the current branch
+			uname_m="$(uname -m)" &&
+			cd "../build-$uname_m-pc-msys/$uname_m-pc-msys/winsup/cygwin" &&
+			make -j$(nproc)
+			return $?
+			;;
 		*)
 			sdk cd "$2" ||
 			return $?

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -81,7 +81,7 @@ sdk () {
 		;;
 	# for completion
 	valid_commands)
-		echo "build cd create-desktop-icon init"
+		echo "build cd create-desktop-icon init reload"
 		;;
 	valid_projects)
 		printf "%s " build-extra git git-extra MINGW-packages \

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -222,6 +222,7 @@ Supported projects:
 	git
 	installer [<version>]
 	git-and-installer [<version>]
+	msys2-runtime
 EOF
 			return 1
 			;;


### PR DESCRIPTION
With this change, a developer can do this:

```sh
sdk cd msys2-runtime # (with tab-completion now!)
<modify the source files>
sdk build msys2-runtime
```

to build `msys0.dll` (which really is a `msys-2.0.dll`, with a safe name to avoid interfering with the currently-used `msys-2.0.dll`) with local modifications.