### PR TITLE
git-sdk: silence warning when on detached head

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -156,7 +156,7 @@ sdk () {
 	init)
 		sdk init-lazy "$2" &&
 		if test refs/heads/master = \
-				"$(git -C "$src_cdup_dir" symbolic-ref HEAD)" &&
+				"$(git -C "$src_cdup_dir" symbolic-ref HEAD >/dev/null 2>&1)" &&
 			{ git -C "$src_cdup_dir" diff-files --quiet &&
 			  git -C "$src_cdup_dir" diff-index --quiet HEAD ||
 			  test ! -s "$src_cdup_dir"/.git/index; }


### PR DESCRIPTION
This fixes
https://github.com/git-for-windows/git-for-windows.github.io/pull/18#discussion_r261622367
`fatal: ref HEAD is not a symbolic ref`

Signed-off-by: Philip Oakley <philipoakley@iee.org>
