### PR TITLE
Make it a lot easier to start hacking on the installer

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -89,7 +89,7 @@ sdk () {
 		;;
 	valid_projects)
 		printf "%s " build-extra git git-extra MINGW-packages \
-			MSYS2-packages msys2-runtime
+			MSYS2-packages msys2-runtime installer
 		;;
 	valid_build_targets)
 		printf "%s " git-and-installer $(sdk valid_projects | tr ' ' '\n' |
@@ -109,7 +109,7 @@ sdk () {
 				https://github.com/git-for-windows/"$2" ||
 			sdk die "Could not initialize $src_dir"
 			;;
-		git-extra)
+		git-extra|installer)
 			sdk init-lazy build-extra &&
 			src_dir="$src_dir/$2" ||
 			return 1
@@ -203,8 +203,8 @@ sdk () {
 			make -C "$src_dir" -j$(nproc) DEVELOPER=1
 			;;
 		installer)
-			sdk init build-extra &&
-			"$src_dir"/installer/release.sh "${3:-0-test}"
+			sdk init "$2" &&
+			"$src_dir"/release.sh "${3:-0-test}"
 			;;
 		git-and-installer)
 			sdk build git &&

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -252,7 +252,24 @@ EOF
 		esac
 		;;
 	reload)
-		. "$GIT_SDK_SH_PATH"
+		shift
+		case "$*" in
+		--experimental)
+			sdk init git-extra &&
+			. "$src_dir"/sdk.completion &&
+			. "$src_dir"/git-sdk.sh
+			;;
+		--system)
+			. /usr/share/bash-completion/completions/sdk &&
+			. /etc/profile.d/git-sdk.sh
+			;;
+		'')
+			. "$GIT_SDK_SH_PATH"
+			;;
+		*)
+			sdk die "Unhandled option: '$*'"
+			;;
+		esac
 		return $?
 		;;
 	*)

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -29,13 +29,14 @@ sdk () {
 		create-desktop-icon: install a desktop icon that starts the Git for
 		    Windows SDK Bash.
 
-		cd <project>: initialize/update a worktree and cd into it. Known projects
-		    are: git, git-extra, build-extra, MINGW-packages, MSYS2-packages.
+		cd <project>: initialize/update a worktree and cd into it. Known projects:
+		$(sdk valid_projects | sdk fmt_list)
 
 		init <project>: initialize and/or update a worktree. Known projects
 		    are the same as for the 'cd' command.
 
-		build <project>: builds one of the following: git, git-and-installer.
+		build <project>: builds one of the following:
+		$(sdk valid_build_targets | sdk fmt_list)
 
 		reload: reload the 'sdk' function.
 		EOF
@@ -78,6 +79,9 @@ sdk () {
 		shift
 		echo "$*" >&2
 		return 1
+		;;
+	fmt_list)
+		fmt -w 64 | sed 's/^/\t/'
 		;;
 	# for completion
 	valid_commands)

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -87,6 +87,10 @@ sdk () {
 		printf "%s " build-extra git git-extra MINGW-packages \
 			MSYS2-packages msys2-runtime
 		;;
+	valid_build_targets)
+		printf "%s " git-and-installer $(sdk valid_projects | tr ' ' '\n' |
+			grep -v '^\(build-extra\|\(MINGW\|MSYS2\)-packages\)')
+		;;
 	# here start the commands
 	init-lazy)
 		case "$2" in

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -38,6 +38,9 @@ sdk () {
 		build <project>: builds one of the following:
 		$(sdk valid_build_targets | sdk fmt_list)
 
+		edit <file>: edit a well-known file. Well-known files are:
+		$(sdk valid_edit_targets | sdk fmt_list)
+
 		reload: reload the 'sdk' function.
 		EOF
 		;;
@@ -85,7 +88,7 @@ sdk () {
 		;;
 	# for completion
 	valid_commands)
-		echo "build cd create-desktop-icon init reload"
+		echo "build cd create-desktop-icon init edit reload"
 		;;
 	valid_projects)
 		printf "%s " build-extra git git-extra MINGW-packages \
@@ -94,6 +97,9 @@ sdk () {
 	valid_build_targets)
 		printf "%s " git-and-installer $(sdk valid_projects | tr ' ' '\n' |
 			grep -v '^\(build-extra\|\(MINGW\|MSYS2\)-packages\)')
+		;;
+	valid_edit_targets)
+		printf "%s " git-sdk.sh sdk.completion ReleaseNotes.md
 		;;
 	# here start the commands
 	init-lazy)
@@ -258,6 +264,27 @@ EOF
 			return 1
 			;;
 		esac
+		;;
+	git-editor)
+		# Cannot use `git config -e -f "$2", as that would cd up to the
+		# top-level if the file is in a subdirectory of a Git worktree
+		eval "$(git var GIT_EDITOR)" "$2"
+		;;
+	edit)
+		case "$2" in
+		git-sdk.sh|sdk.completion)
+			sdk cd git-extra &&
+			sdk git-editor "$2" &&
+			. "$2"
+			;;
+		ReleaseNotes.md)
+			sdk cd build-extra &&
+			sdk git-editor "$2"
+			;;
+		*)
+			sdk die "Not a valid edit target: $2"
+			;;
+		esac || return $?
 		;;
 	reload)
 		shift

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -142,7 +142,7 @@ sdk () {
 
 		second_path=/usr/bin
 		case "$PWD" in
-		*/MSYS2-packages/*)
+		*/MSYS2-packages|*/MSYS2-packages/*)
 			MSYSTEM=MSYS
 			second_path=$first_path
 			first_path=/usr/bin:/opt/bin

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -99,7 +99,8 @@ sdk () {
 			grep -v '^\(build-extra\|\(MINGW\|MSYS2\)-packages\)')
 		;;
 	valid_edit_targets)
-		printf "%s " git-sdk.sh sdk.completion ReleaseNotes.md
+		printf "%s " git-sdk.sh sdk.completion ReleaseNotes.md \
+			install.iss
 		;;
 	# here start the commands
 	init-lazy)
@@ -279,6 +280,10 @@ EOF
 			;;
 		ReleaseNotes.md)
 			sdk cd build-extra &&
+			sdk git-editor "$2"
+			;;
+		install.iss)
+			sdk cd installer &&
 			sdk git-editor "$2"
 			;;
 		*)

--- a/git-extra/sdk.completion
+++ b/git-extra/sdk.completion
@@ -6,8 +6,13 @@ _sdk()
 	prev="${COMP_WORDS[COMP_CWORD-1]}"
 
 	case "$prev" in
-	build|cd|init)
+	cd|init)
 		local projects=$(sdk valid_projects)
+		COMPREPLY=($(compgen -W "$projects" -- $cur))
+		return 0
+		;;
+	build)
+		local projects=$(sdk valid_build_targets)
 		COMPREPLY=($(compgen -W "$projects" -- $cur))
 		return 0
 		;;

--- a/git-extra/sdk.completion
+++ b/git-extra/sdk.completion
@@ -11,6 +11,11 @@ _sdk()
 		COMPREPLY=($(compgen -W "$projects" -- $cur))
 		return 0
 		;;
+	reload)
+		local reload_opts="--experimental --system"
+		COMPREPLY=($(compgen -W "$reload_opts" -- $cur))
+		return 0
+		;;
 	create-desktop-icon)
 		return 1
 		;;

--- a/git-extra/sdk.completion
+++ b/git-extra/sdk.completion
@@ -16,6 +16,11 @@ _sdk()
 		COMPREPLY=($(compgen -W "$projects" -- $cur))
 		return 0
 		;;
+	edit)
+		local targets=$(sdk valid_edit_targets)
+		COMPREPLY=($(compgen -W "$targets" -- $cur))
+		return 0
+		;;
 	reload)
 		local reload_opts="--experimental --system"
 		COMPREPLY=($(compgen -W "$reload_opts" -- $cur))


### PR DESCRIPTION
One of the central missions of Git for Windows' SDK is to make it as easy as humanly possible for Git for Windows users to work on their own feature requests. Yes, it is a complex system, but that does not mean that everybody who wants to contribute as little as an enhanced description of an installer options needs to understand all that.

With this change, we can start to recommend to users to "just download the SDK and then call `sdk edit install.iss` followed by `sdk build installer`".

This PR also brings a couple of other touch-ups to the `sdk` function, more or less because I either needed them to develop this PR (such as `sdk reload --experimental` and `sdk edit git-sdk.sh`) or because I just saw those issues nearby and thought I'd just quickly fix them.