### PR TITLE
remove credential.helper manager

### DIFF
--- a/portable/release.sh
+++ b/portable/release.sh
@@ -89,10 +89,7 @@ die "Could not copy post-install script"
 
 mkdir -p "$SCRIPT_PATH/root/mingw$BITNESS/etc" &&
 cp /mingw$BITNESS/etc/gitconfig \
-	"$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" &&
-git config -f "$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" \
-	credential.helper manager ||
-die "Could not configure Git-Credential-Manager as default"
+	"$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig"
 test 64 != $BITNESS ||
 git config -f "$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" --unset pack.packSizeLimit
 


### PR DESCRIPTION
might fix @git-for-windows/git#2116

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
