### PR TITLE
help Docker and Vault work more seamlessly by adding winpty

### DIFF
--- a/git-extra/aliases.sh
+++ b/git-extra/aliases.sh
@@ -10,7 +10,7 @@ xterm*)
 	# The following programs are known to require a Win32 Console
 	# for interactive usage, therefore let's launch them through winpty
 	# when run inside `mintty`.
-	for name in node ipython php php5 psql python2.7
+	for name in node ipython php php5 psql python2.7 docker vault ${GITBASH_WINPTY}
 	do
 		case "$(type -p "$name".exe 2>/dev/null)" in
 		''|/usr/bin/*) continue;;


### PR DESCRIPTION
Both Docker and Vault have weird surprises for most users, where either the cli doesn't work, or in Docker's case, it tells them no, on this shell, you need to do something different.

for eg:
https://github.com/hashicorp/vault/issues/4946

I don't know if the `GITBASH_WINPTY` env is ok, or if there's a better name - but as someone that was working on docker so very many years ago, it would have been useful at least for development.