### PR TITLE
Add a meta credential helper

### DIFF
--- a/git-extra/Makefile
+++ b/git-extra/Makefile
@@ -1,5 +1,6 @@
 BUILDDIR ?= .
 SRCDIR ?= .
+WINDRES ?= windres
 CFLAGS ?= -Wall
 CXXFLAGS ?= -Wall
 
@@ -13,6 +14,9 @@ $(BUILDDIR)/create-shortcut.exe: $(BUILDDIR)/create-shortcut.o
 
 $(BUILDDIR)/%.o: $(SRCDIR)/%.c
 	$(CC) -c $(CFLAGS) $< -o $@
+
+$(BUILDDIR)/%.res: $(SRCDIR)/%.rc
+	$(WINDRES) --input $< --output $@ --output-format coff
 
 $(BUILDDIR)/WhoUses.exe: $(BUILDDIR)/WhoUses.o $(BUILDDIR)/SystemInfo.o
 	$(CXX) $(CXXFLAGS) -o $@ $^
@@ -37,7 +41,8 @@ $(BUILDDIR)/git-askyesno.exe: $(BUILDDIR)/git-askyesno.o
 $(BUILDDIR)/git-credential-helper-selector.o: CFLAGS += -DUNICODE
 
 $(BUILDDIR)/git-credential-helper-selector.exe: \
-	$(BUILDDIR)/git-credential-helper-selector.o
+	$(BUILDDIR)/git-credential-helper-selector.o \
+	$(BUILDDIR)/git-credential-helper-selector.res
 	$(CC) -municode $(CFLAGS) -o $@ $^ -lgdi32 -lcomctl32
 clean:
 	$(RM) $(BUILDDIR)/create-shortcut.exe $(BUILDDIR)/create-shortcut.o

--- a/git-extra/Makefile
+++ b/git-extra/Makefile
@@ -5,7 +5,8 @@ CXXFLAGS ?= -Wall
 
 all: $(BUILDDIR)/create-shortcut.exe $(BUILDDIR)/WhoUses.exe \
 	$(BUILDDIR)/blocked-file-util.exe $(BUILDDIR)/proxy-lookup.exe \
-	$(BUILDDIR)/git-askyesno.exe
+	$(BUILDDIR)/git-askyesno.exe \
+	$(BUILDDIR)/git-credential-helper-selector.exe
 
 $(BUILDDIR)/create-shortcut.exe: $(BUILDDIR)/create-shortcut.o
 	$(CC) $(CFLAGS) -o $@ $^ -luuid -lole32
@@ -33,9 +34,16 @@ $(BUILDDIR)/git-askyesno.o: CFLAGS += -DUNICODE
 $(BUILDDIR)/git-askyesno.exe: $(BUILDDIR)/git-askyesno.o
 	$(CC) -municode $(CFLAGS) -o $@ $^
 
+$(BUILDDIR)/git-credential-helper-selector.o: CFLAGS += -DUNICODE
+
+$(BUILDDIR)/git-credential-helper-selector.exe: \
+	$(BUILDDIR)/git-credential-helper-selector.o
+	$(CC) -municode $(CFLAGS) -o $@ $^ -lgdi32 -lcomctl32
 clean:
 	$(RM) $(BUILDDIR)/create-shortcut.exe $(BUILDDIR)/create-shortcut.o
 	$(RM) $(BUILDDIR)/WhoUses.exe $(BUILDDIR)/WhoUses.o \
 		$(BUILDDIR)/SystemInfo.o
 	$(RM) $(BUILDDIR)/blocked-file-util.exe $(BUILDDIR)/blocked-file-util.o
 	$(RM) $(BUILDDIR)/proxy-lookup.exe $(BUILDDIR)/proxy-lookup.o
+	$(RM) $(BUILDDIR)/git-credential-helper-selector.exe \
+		$(BUILDDIR)/git-credential-helper-selector.o

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -49,7 +49,8 @@ source=('inputrc'
         'zzz_rm_stackdumps.sh'
         'proxy-lookup.c'
         'git-askyesno.c'
-        'update-via-pacman.bat')
+        'update-via-pacman.bat'
+        'git-credential-helper-selector.c')
 sha256sums=('9efaf8dccc08c7cddc58cb589bab5aac5c0894661175a344ca02b2aa849382bd'
             'c26d22aaa1d3dc615d474e0d60c5c0f19598d61d9205e19ec87aac1b28bb07c1'
             '640d04d2a2da709419188a986d5e5550ad30df23c7ea9be1a389c37a6b917994'
@@ -121,6 +122,7 @@ package() {
   install -m755 $builddir/blocked-file-util.exe $pkgdir${MINGW_PREFIX}/bin
   install -m755 $builddir/proxy-lookup.exe $pkgdir${MINGW_PREFIX}/bin
   install -m755 $builddir/git-askyesno.exe $pkgdir${MINGW_PREFIX}/bin
+  install -m755 $builddir/git-credential-helper-selector.exe $pkgdir${MINGW_PREFIX}/bin
   install -m755 git-prompt.sh $pkgdir/etc/profile.d
   install -m755 aliases.sh $pkgdir/etc/profile.d
   install -m755 env.sh $pkgdir/etc/profile.d

--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -605,7 +605,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 		for (i = 0; i < helper_nr; i++) {
 			HWND hwnd2 = CreateWindowW(L"Button", helper_name[i],
 						   WS_CHILD | WS_VISIBLE |
-						   BS_AUTORADIOBUTTON,
+						   BS_AUTORADIOBUTTON | BS_NOTIFY,
 						   2 * offset_x,
 						   3 * offset_y + line_height * i,
 						   width - 4 * offset_x,
@@ -659,6 +659,10 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 				SendMessage(hwnd, WM_CLOSE, 0, 0);
 		} else if (HIWORD(wParam) == BN_CLICKED && LOWORD(wParam) >= ID_USER) {
 			selected_helper = LOWORD(wParam) - ID_USER;
+		} else if (HIWORD(wParam) == BN_DBLCLK && LOWORD(wParam) >= ID_USER) {
+			aborted = 0;
+			selected_helper = LOWORD(wParam) - ID_USER;
+			SendMessage(main_window, WM_CLOSE, 0, 0);
 		} else if (wParam == ID_PERSIST) {
 			persist = !IsDlgButtonChecked(hwnd, ID_PERSIST);
 			CheckDlgButton(hwnd, ID_PERSIST, persist ? BST_CHECKED : BST_UNCHECKED);

--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -1,7 +1,32 @@
 #include <windows.h>
 
+static HINSTANCE instance;
+static LPWSTR *helper_name, *helper_path;
+static size_t helper_nr, selected_helper;
+
 #define ID_ENTER   IDOK
 #define ID_ABORT   IDCANCEL
+#define ID_USER    2000
+
+static int discover_helpers(void)
+{
+	/* TODO: walk `PATH` to populate these */
+	helper_nr = 2;
+	helper_name = malloc(helper_nr * sizeof(*helper_name));
+	helper_path = malloc(helper_nr * sizeof(*helper_path));
+	if (!helper_name || !helper_path) {
+		MessageBoxW(NULL, L"Out of memory!", L"Error", MB_OK);
+		return -1;
+	}
+	helper_name[0] = L"<no helper>";
+	helper_path[0] = L"<none>";
+	helper_name[1] = L"manager";
+	helper_path[1] = L"C:\\Program Files\\Git\\mingw64\\libexec\\git-core\\git-credential-manager.exe";
+
+	selected_helper = 1;
+
+	return 0;
+}
 
 static int aborted = 1;
 
@@ -16,14 +41,35 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 	case WM_CREATE: {
 		RECT rect;
 		int width;
+		size_t i;
 
 		GetClientRect(hwnd, &rect);
 		width = rect.right - rect.left;
+		CreateWindowW(L"Button", L"Select a credential helper",
+			      WS_CHILD | WS_VISIBLE | BS_GROUPBOX,
+			      offset_x, offset_y,
+			      width - 2 * offset_x,
+			      line_height * helper_nr + 3 * offset_y,
+			      hwnd, (HMENU) 0, instance, NULL);
+		for (i = 0; i < helper_nr; i++) {
+			HWND hwnd2 = CreateWindowW(L"Button", helper_name[i],
+						   WS_CHILD | WS_VISIBLE |
+						   BS_AUTORADIOBUTTON,
+						   2 * offset_x,
+						   3 * offset_y + line_height * i,
+						   width - 4 * offset_x,
+						   line_height + line_offset_y,
+						   hwnd, (HMENU)(ID_USER + i), instance, NULL);
+			if (i == selected_helper) {
+				SendMessage(hwnd2, BM_SETCHECK, BST_CHECKED, 1);
+				SetFocus(hwnd2);
+			}
+		}
 
 		CreateWindowW(L"Button", L"Select",
 			      WS_VISIBLE | WS_CHILD,
 			      width - 2 * (button_width + offset_x),
-			      offset_y,
+			      5 * offset_y + line_height * helper_nr,
 			      button_width,
 			      line_height + line_offset_y,
 			      hwnd, (HMENU) ID_ENTER, NULL, NULL);
@@ -31,7 +77,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 		CreateWindowW(L"Button", L"Cancel",
 			      WS_VISIBLE | WS_CHILD,
 			      width - (button_width + offset_x),
-			      offset_y,
+			      5 * offset_y + line_height * helper_nr,
 			      button_width,
 			      line_height + line_offset_y,
 			      hwnd, (HMENU) ID_ABORT, NULL, NULL);
@@ -44,6 +90,8 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 			SendMessage(hwnd, WM_CLOSE, 0, 0);
 		} else if (wParam == ID_ABORT) {
 			SendMessage(hwnd, WM_CLOSE, 0, 0);
+		} else if (HIWORD(wParam) == BN_CLICKED && LOWORD(wParam) >= ID_USER) {
+			selected_helper = LOWORD(wParam) - ID_USER;
 		}
 		break;
 
@@ -67,6 +115,12 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	window_class.hbrBackground = GetSysColorBrush(COLOR_3DFACE);
 	window_class.hCursor = LoadCursor(0, IDC_ARROW);
 
+	if (discover_helpers() < 0) {
+		MessageBoxW(NULL, L"Could not discover credential helpers", L"Error", MB_OK);
+		return 1;
+	}
+
+	instance = hInstance;
 	RegisterClassW(&window_class);
 	CreateWindowW(window_class.lpszClassName, L"CredentialHelperSelector",
 		      WS_OVERLAPPEDWINDOW | WS_VISIBLE,

--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -1,0 +1,82 @@
+#include <windows.h>
+
+#define ID_ENTER   IDOK
+#define ID_ABORT   IDCANCEL
+
+static int aborted = 1;
+
+static int width = 400, height = 300;
+static int offset_x = 10, offset_y = 10;
+static int line_height = 25, line_offset_y = 5, button_width = 75;
+
+static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
+				    LPARAM lParam)
+{
+	switch (message) {
+	case WM_CREATE: {
+		RECT rect;
+		int width;
+
+		GetClientRect(hwnd, &rect);
+		width = rect.right - rect.left;
+
+		CreateWindowW(L"Button", L"Select",
+			      WS_VISIBLE | WS_CHILD,
+			      width - 2 * (button_width + offset_x),
+			      offset_y,
+			      button_width,
+			      line_height + line_offset_y,
+			      hwnd, (HMENU) ID_ENTER, NULL, NULL);
+
+		CreateWindowW(L"Button", L"Cancel",
+			      WS_VISIBLE | WS_CHILD,
+			      width - (button_width + offset_x),
+			      offset_y,
+			      button_width,
+			      line_height + line_offset_y,
+			      hwnd, (HMENU) ID_ABORT, NULL, NULL);
+		break;
+	}
+
+	case WM_COMMAND:
+		if (LOWORD(wParam) == ID_ENTER) {
+			aborted = 0;
+			SendMessage(hwnd, WM_CLOSE, 0, 0);
+		} else if (wParam == ID_ABORT) {
+			SendMessage(hwnd, WM_CLOSE, 0, 0);
+		}
+		break;
+
+	case WM_DESTROY:
+		PostQuitMessage(0);
+		break;
+	}
+
+	return DefWindowProcW(hwnd, message, wParam, lParam);
+}
+
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
+		    PWSTR lpCmdLine, int nCmdShow)
+{
+	WNDCLASSW window_class = { 0 };
+	MSG message;
+
+	window_class.lpszClassName = L"CredentialHelperSelector";
+	window_class.hInstance = hInstance;
+	window_class.lpfnWndProc = window_proc;
+	window_class.hbrBackground = GetSysColorBrush(COLOR_3DFACE);
+	window_class.hCursor = LoadCursor(0, IDC_ARROW);
+
+	RegisterClassW(&window_class);
+	CreateWindowW(window_class.lpszClassName, L"CredentialHelperSelector",
+		      WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+		      CW_USEDEFAULT, CW_USEDEFAULT,
+		      width, height, 0, 0, hInstance, 0);
+
+	while (GetMessage(&message, NULL, 0, 0)) {
+		TranslateMessage(&message);
+		DispatchMessage(&message);
+	}
+
+	return aborted;
+}

--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -3,6 +3,7 @@
 #include <wchar.h>
 
 static HINSTANCE instance;
+static HWND main_window;
 static LPWSTR *helper_name, *helper_path, previously_selected_helper;
 static size_t helper_nr, selected_helper;
 static int persist;
@@ -589,7 +590,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 			      hwnd, (HMENU) ID_PERSIST, NULL, NULL);
 
 		CreateWindowW(L"Button", L"Select",
-			      WS_VISIBLE | WS_CHILD,
+			      WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
 			      width - 2 * (button_width + offset_x),
 			      5 * offset_y + line_height * (helper_nr + 1),
 			      button_width,
@@ -657,12 +658,14 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 
 	instance = hInstance;
 	RegisterClassW(&window_class);
-	CreateWindowW(window_class.lpszClassName, L"CredentialHelperSelector",
-		      WS_OVERLAPPEDWINDOW | WS_VISIBLE,
-		      CW_USEDEFAULT, CW_USEDEFAULT,
-		      width, height, 0, 0, hInstance, 0);
+	main_window = CreateWindowW(window_class.lpszClassName, L"CredentialHelperSelector",
+				    WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+				    CW_USEDEFAULT, CW_USEDEFAULT,
+				    width, height, 0, 0, hInstance, 0);
 
 	while (GetMessage(&message, NULL, 0, 0)) {
+		if (IsDialogMessage(main_window, &message))
+			continue;
 		TranslateMessage(&message);
 		DispatchMessage(&message);
 	}

--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -562,7 +562,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 		GetClientRect(hwnd, &rect);
 		width = rect.right - rect.left;
 		CreateWindowW(L"Button", L"Select a credential helper",
-			      WS_CHILD | WS_VISIBLE | BS_GROUPBOX,
+			      WS_TABSTOP | WS_CHILD | WS_VISIBLE | BS_GROUPBOX,
 			      offset_x, offset_y,
 			      width - 2 * offset_x,
 			      line_height * helper_nr + 3 * offset_y,
@@ -583,7 +583,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 		}
 
 		CreateWindowW(L"Button", L"Always use this from now on",
-			      WS_VISIBLE | WS_CHILD | BS_CHECKBOX,
+			      WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_CHECKBOX,
 			      2 * offset_x,
 			      4 * offset_y + line_height * helper_nr,
 			      width - 2 * offset_x,
@@ -591,7 +591,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 			      hwnd, (HMENU) ID_PERSIST, NULL, NULL);
 
 		CreateWindowW(L"Button", L"Select",
-			      WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
+			      WS_TABSTOP | WS_VISIBLE | WS_CHILD | BS_DEFPUSHBUTTON,
 			      width - 2 * (button_width + offset_x),
 			      5 * offset_y + line_height * (helper_nr + 1),
 			      button_width,
@@ -599,7 +599,7 @@ static LRESULT CALLBACK window_proc(HWND hwnd, UINT message, WPARAM wParam,
 			      hwnd, (HMENU) ID_ENTER, NULL, NULL);
 
 		CreateWindowW(L"Button", L"Cancel",
-			      WS_VISIBLE | WS_CHILD,
+			      WS_TABSTOP | WS_VISIBLE | WS_CHILD,
 			      width - (button_width + offset_x),
 			      5 * offset_y + line_height * (helper_nr + 1),
 			      button_width,

--- a/git-extra/git-credential-helper-selector.manifest
+++ b/git-extra/git-credential-helper-selector.manifest
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
+<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type='win32'
+        name='Microsoft.Windows.Common-Controls'
+        version='6.0.0.0'
+        publicKeyToken='6595b64144ccf1df'
+        language='*'
+        processorArchitecture='*'
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/git-extra/git-credential-helper-selector.rc
+++ b/git-extra/git-credential-helper-selector.rc
@@ -1,0 +1,3 @@
+#include <winuser.h>
+
+1 RT_MANIFEST git-credential-helper-selector.manifest


### PR DESCRIPTION
The idea is to have a credential helper that discovers all other credential helpers on the `PATH` and lets the user choose one (or none).

This meta helper will come in handy to avoid surprises where users run a portable Git on someone else's computer and expect no credentials to be stored there.

This addresses https://github.com/git-for-windows/git/issues/2116.