### PR TITLE
git-prompt: source generic bash completion scripts from the user's home

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -1,3 +1,8 @@
+for c in $(find "$HOME/bash_completion.d" -name "*-completion.bash" -type f 2> /dev/null)
+do
+	. $c
+done
+
 if test -f /etc/profile.d/git-sdk.sh
 then
 	TITLEPREFIX=SDK-${MSYSTEM#MINGW}


### PR DESCRIPTION
This allows e.g.

https://github.com/gradle/gradle-completion#install-manually-1

to work.

Signed-off-by: Sebastian Schuberth <sschuberth@gmail.com>