### PR TITLE
Set ssh.variant for plink or tortoise plink

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1694,7 +1694,7 @@ begin
             'variables will be adjusted to point to the following executable:',TabOrder,Top,Left);
         EdtPlink:=TEdit.Create(PuTTYPage);
         EdtPlink.Left:=ScaleX(Left+24);
-        EdtPlink.Top:=ScaleY(Top+9);
+        EdtPlink.Top:=ScaleY(Top);
         with EdtPlink do begin
             Parent:=PuTTYPage.Surface;
 
@@ -1717,7 +1717,7 @@ begin
         end;
         BtnPlink:=TButton.Create(PuTTYPage);
         BtnPlink.Left:=ScaleX(Left+344);
-        BtnPlink.Top:=ScaleY(Top+9);
+        BtnPlink.Top:=ScaleY(Top);
         with BtnPlink do begin
             Parent:=PuTTYPage.Surface;
             Caption:='...';

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1687,7 +1687,11 @@ begin
         RdbSSH[GS_OpenSSH]:=CreateRadioButton(PuTTYPage,'Use OpenSSH','This uses ssh.exe that comes with Git. The GIT_SSH and SVN_SSH'+#13+'environment variables will not be modified.',TabOrder,Top,Left);
 
         // 2nd choice
-        RdbSSH[GS_Plink]:=CreateRadioButton(PuTTYPage,'Use (Tortoise)Plink','PuTTY sessions were found in your Registry. You may specify the path'+#13+'to an existing copy of (Tortoise)Plink.exe from the TortoiseGit/SVN/CVS'+#13+'or PuTTY applications. The GIT_SSH and SVN_SSH environment'+#13+'variables will be adjusted to point to the following executable:',TabOrder,Top,Left);
+        RdbSSH[GS_Plink]:=CreateRadioButton(PuTTYPage,'Use (Tortoise)Plink',
+            'PuTTY sessions were found in your Registry. You may specify the path'+#13+
+            'to an existing copy of (Tortoise)Plink.exe from the TortoiseGit/SVN/CVS'+#13+
+            'or PuTTY applications. The GIT_SSH and SVN_SSH environment'+#13+
+            'variables will be adjusted to point to the following executable:',TabOrder,Top,Left);
         EdtPlink:=TEdit.Create(PuTTYPage);
         EdtPlink.Left:=ScaleX(Left+24);
         EdtPlink.Top:=ScaleY(Top+9);


### PR DESCRIPTION
git-for-windows/git issue #2018 suggests ssh.variant should be set if the user selects plink for ssh.  This change expands on that requirement.  
- adds some text to indicate ssh.variant will be set
- adds a checkbox to select if tortoise plink is being used.  This affects the command parameters when running plink
- sets ssh.variant to putty or tortoiseshell if needed
- unset ssh.variant if it was set in a previous install
- track previous selection of the checkbox

Installer git configuration settings are not always removed during uninstall and this update does not change current behavior.