### PR TITLE
Add dev directory during setup

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -117,6 +117,7 @@ Source: {#SourcePath}\NOTICE.txt; DestDir: {app}; Flags: replacesameversion; Aft
 Source: {#SourcePath}\..\edit-git-bash.exe; Flags: dontcopy
 
 [Dirs]
+Name: "{app}\dev"
 Name: "{app}\tmp"
 
 [Icons]

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -118,6 +118,8 @@ Source: {#SourcePath}\..\edit-git-bash.exe; Flags: dontcopy
 
 [Dirs]
 Name: "{app}\dev"
+Name: "{app}\dev\mqueue"
+Name: "{app}\dev\shm"
 Name: "{app}\tmp"
 
 [Icons]

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -39,6 +39,7 @@ do
 			exit 1
 		fi
 		inno_defines="$inno_defines$LF#define DEBUG_WIZARD_PAGE '$page'$LF#define OUTPUT_TO_TEMP ''"
+		inno_defines="$inno_defines$LF[Code]${LF}function SetSystemConfigDefaults():Boolean;${LF}begin${LF}    Result:=True;${LF}end;${LF}${LF}"
 		skip_files=t
 		;;
 	--output=*)

--- a/nuget/GitForWindows.nuspec.in
+++ b/nuget/GitForWindows.nuspec.in
@@ -24,6 +24,8 @@
     <file src="$buildextra$\nuget\Install.ps1" target="tools" />
     <file src="$buildextra$\post-install.bat" target="tools" />
     <file src="$buildextra$\emptydir" target="tools\dev" />
+    <file src="$buildextra$\emptydir" target="tools\dev\mqueue" />
+    <file src="$buildextra$\emptydir" target="tools\dev\shm" />
     <file src="$buildextra$\nuget\package-versions.txt" target="tools\etc" />
     @@FILELIST@@
   </files>

--- a/nuget/GitForWindows.nuspec.in
+++ b/nuget/GitForWindows.nuspec.in
@@ -23,6 +23,7 @@
     <file src="$buildextra$\ReleaseNotes.css" target="content" />
     <file src="$buildextra$\nuget\Install.ps1" target="tools" />
     <file src="$buildextra$\post-install.bat" target="tools" />
+    <file src="$buildextra$\emptydir" target="tools\dev" />
     <file src="$buildextra$\nuget\package-versions.txt" target="tools\etc" />
     @@FILELIST@@
   </files>

--- a/nuget/release.sh
+++ b/nuget/release.sh
@@ -91,6 +91,9 @@ sed -e "s/@@VERSION@@/$VERSION/g" -e "s/@@AUTHOR@@/$AUTHOR/g" \
 	-e "s/@@VERSIONTAG@@/$VERSIONTAG/g" \
 	-e "s/@@ID@@/$ID/g" -e '/@@FILELIST@@/,$d' <"$SPECIN" >"$SPEC"
 
+mkdir -p "$BUILDEXTRA/emptydir" ||
+die "Could not generate empty directory."
+
 # Make a list of files to include
 LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
 	PACKAGE_VERSIONS_FILE="$BUILDEXTRA"/nuget/package-versions.txt \

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -70,8 +70,11 @@ esac
 cp "$SCRIPT_PATH/../LICENSE.txt" "$SCRIPT_PATH/root/" ||
 die "Could not copy license file"
 
-mkdir -p "$SCRIPT_PATH/root/dev" ||
-die "Could not make dev/ directory"
+mkdir -p "$SCRIPT_PATH/root/dev/mqueue" ||
+die "Could not make /dev/mqueue directory"
+
+mkdir -p "$SCRIPT_PATH/root/dev/shm" ||
+die "Could not make /dev/shm/ directory"
 
 mkdir -p "$SCRIPT_PATH/root/etc" ||
 die "Could not make etc/ directory"

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -70,6 +70,9 @@ esac
 cp "$SCRIPT_PATH/../LICENSE.txt" "$SCRIPT_PATH/root/" ||
 die "Could not copy license file"
 
+mkdir -p "$SCRIPT_PATH/root/dev" ||
+die "Could not make dev/ directory"
+
 mkdir -p "$SCRIPT_PATH/root/etc" ||
 die "Could not make etc/ directory"
 


### PR DESCRIPTION
A minimal fix for git-for-windows/git#2291.

Note no change in mingit because that is just git.exe, and the missing /dev directory is only a problem for bash.exe.

Built and validated the regular installer, NuGet package and portable installers.