### PR TITLE
fix installer's Product Version inconsistency with older versions

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -50,8 +50,6 @@ SignTool=signtool
 #endif
 
 #define FILE_VERSION GetFileVersion(SOURCE_DIR+'\'+MINGW_BITNESS+'\bin\git.exe')
-#define PROD_VERSION GetStringFileInfo(SOURCE_DIR+'\'+MINGW_BITNESS \
-				+'\bin\git.exe', 'ProductVersion')
 
 ; Installer-related
 AllowNoIcons=yes
@@ -59,7 +57,7 @@ AppName={#APP_NAME}
 AppPublisher=The Git Development Community
 AppPublisherURL={#APP_URL}
 AppSupportURL={#APP_CONTACT_URL}
-AppVersion={#PROD_VERSION}
+AppVersion={#APP_VERSION}
 ChangesAssociations=yes
 ChangesEnvironment=yes
 CloseApplications=no


### PR DESCRIPTION
Why: Third-party applications or IT tools must be able to know
if the latest Git version is installed on the system
by means of version number comparisons.

How: Remove platform identifier from the Product Version.

Product Version now displays x.x.x.x instead of x.x.x.windows.x

See https://github.com/git-for-windows/git/issues/2223

Signed-off-by: Audric Guerin <49029709+AudricGuerin@users.noreply.github.com>