### PR TITLE
Make `sdk build` less cumbersome to use

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -147,7 +147,7 @@ sdk () {
 			sdk init MSYS2-packages &&
 			(cd "$src_dir/$2" &&
 			 test -d src/msys2-runtime ||
-			 makepkg --nobuild --syncdeps --noconfirm) &&
+			 makepkg --nobuild --syncdeps --noconfirm --skipchecksums --skippgpcheck) &&
 			src_dir="$src_dir/msys2-runtime/src/msys2-runtime" &&
 			src_cdup_dir="$src_dir" ||
 			return 1
@@ -286,7 +286,7 @@ sdk () {
 			then
 				# no local changes
 				cd "$src_cdup_dir" &&
-				makepkg --syncdeps --noconfirm
+				makepkg --syncdeps --noconfirm --skipchecksums --skippgpcheck
 				return $?
 			fi
 
@@ -302,8 +302,8 @@ sdk () {
 			if test -f PKGBUILD
 			then
 				case "$MSYSTEM" in
-				MSYS) makepkg --syncdeps --noconfirm;;
-				MINGW*) makepkg-mingw --syncdeps --noconfirm;;
+				MSYS) makepkg --syncdeps --noconfirm --skipchecksums --skippgpcheck;;
+				MINGW*) makepkg-mingw --syncdeps --noconfirm --skipchecksums --skippgpcheck;;
 				esac
 				return $?
 			fi


### PR DESCRIPTION
The recommended way in the Git for Windows SDK to start developing patches for any package is to run something like this:

```sh
sdk cd <package-name>
sdk build
```

However, this is not as easy to use as it should: after editing any source file, it would complain about checksum mismatches (which is correct, but not helpful). For other packages, it will complain that it does not find the GPG key with which the upstream sources were signed.

Let's make all of this much more fun by skipping those checks. The checksums will be updated anyway, as part of the semi-automated process to build and upload the package to Git for Windows' Pacman repository. Not anything a contributor should need to worry about.