### PR TITLE
Update installer/portable/mingit for the new system config location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ edit-git-bash.exe
 /git-for-windows-keyring/git-for-windows-keyring-*.src.tar.gz
 /installer/ReleaseNotes.html
 /installer/config.iss
-/installer/gitconfig.system
 /installer/install.log
 /installer/is-unicode.exe
 /installer/file-list.iss

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ edit-git-bash.exe
 /installer/is-unicode.exe
 /installer/file-list.iss
 /installer/package-versions.txt
-/installer/programdata-config.template
 /installer/root/
 /mingit/exclude-list
 /mingit/root/

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -35,6 +35,8 @@ This package contains software from a number of other projects including Bash, z
 
 ## Changes since Git for Windows v2.23.0 (August 17th 2019)
 
+Note! As a consequence of making `git config --system` work as expected, the location of the system config is now `C:\Program Files\Git\etc\gitconfig` (no longer split between `C:\Program Files\Git\mingw64\etc\gitconfig` and `C:\ProgramData\Git\config`), and likewise the location of the system gitattributes is now `C:\Program Files\Git\etc\gitattributes` (no longer `C:\Program Files\Git\mingw64\etc\gitattributes`). Any manual modifications to `C:\ProgramData\Git\config` need to be ported manually.
+
 ### New Features
 
 * Comes with [cURL v7.66.0](https://curl.haxx.se/changes.html#7_66_0).
@@ -48,6 +50,7 @@ This package contains software from a number of other projects including Bash, z
 * The default config [no longer skips `git-lfs` downloads](https://github.com/git-for-windows/build-extra/pull/256).
 * Starting with cURL v7.66.0, [`$HOME/.netrc` can be used](https://github.com/curl/curl/commit/f9c7ba9096ec29db2536481d8e9ebe314e007f0c) instead of `$HOME/_netrc` (but it will still fall back to looking for the latter).
 * The installer's "ProductVersion" [is now consistent with older Git for Windows versions'](https://github.com/git-for-windows/build-extra/pull/257).
+* [Makes `git config --system` work like you think it should](https://github.com/git-for-windows/git/pull/2358).
 
 ## Changes since Git for Windows v2.22.0 (June 8th 2019)
 

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -1,25 +1,25 @@
 export LC_ALL=C
 
 post_install () {
-	for dir in mingw32 mingw64
-	do
-		test ! -d /$dir ||
-		test -f /$dir/etc/gitconfig ||
-		cat > /$dir/etc/gitconfig <<\GITCONFIG
+	ETC_GITCONFIG="$(git -c core.editor=echo config --system -e 2>/dev/null)"
+	test -f "$ETC_GITCONFIG" ||
+	cat > "$ETC_GITCONFIG" <<\GITCONFIG
 @@GITCONFIG@@
 GITCONFIG
-		test ! -d /$dir ||
-		test -f /$dir/etc/gitattributes ||
-		cat > /$dir/etc/gitattributes <<\GITATTRIBUTES
+	ETC_GITATTRIBUTES="${ETC_GITCONFIG%/*}/gitattributes"
+	test -f "$ETC_GITATTRIBUTES" ||
+	cat > "$ETC_GITATTRIBUTES" <<\GITATTRIBUTES
 @@GITATTRIBUTES@@
 
 GITATTRIBUTES
 
-		grep -q '^\*\.docm' /$dir/etc/gitattributes ||
-		sed -i -e 's/^\*\.DOCX\(.*\)/&\n*.docm\1\n*.DOCM\1/' \
-			-e 's/^\*\.DOT\(.*\)/&\n*.dotm\1\n*.DOTM\1/' \
-			/$dir/etc/gitattributes
+	grep -q '^\*\.docm' "$ETC_GITATTRIBUTES" ||
+	sed -i -e 's/^\*\.DOCX\(.*\)/&\n*.docm\1\n*.DOCM\1/' \
+		-e 's/^\*\.DOT\(.*\)/&\n*.dotm\1\n*.DOTM\1/' \
+		"$ETC_GITATTRIBUTES"
 
+	for dir in mingw32 mingw64
+	do
 		# Drop git-wrapper in place of builtins "to save space"
 		git_wrapper=/$dir/share/git/git-wrapper.exe
 		if test -f $git_wrapper &&

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2188,8 +2188,12 @@ var
 begin
     if UninstallAppPath<>'' then begin
         // Save a copy of the system config so that we can copy it back later
-        if FileExists(UninstallAppPath+'\{#MINGW_BITNESS}\etc\gitconfig') and
-            (not FileCopy(UninstallAppPath+'\{#MINGW_BITNESS}\etc\gitconfig',ExpandConstant('{tmp}\gitconfig.system'),True)) then
+        if FileExists(UninstallAppPath+'\{#MINGW_BITNESS}\etc\gitconfig') then begin
+            if (not FileCopy(UninstallAppPath+'\{#MINGW_BITNESS}\etc\gitconfig',ExpandConstant('{tmp}\gitconfig.system'),True)) then
+                LogError('Could not save system config; continuing anyway');
+        // Save a copy of the system config so that we can copy it back later
+        end else if FileExists(UninstallAppPath+'\etc\gitconfig') and
+            (not FileCopy(UninstallAppPath+'\etc\gitconfig',ExpandConstant('{tmp}\gitconfig.system'),True)) then
             LogError('Could not save system config; continuing anyway');
 
         ProgramData:=ExpandConstant('{commonappdata}');
@@ -2483,10 +2487,10 @@ begin
 
     // Copy previous system wide git config file, if any
     if FileExists(ExpandConstant('{tmp}\gitconfig.system')) then begin
-        if (not ForceDirectories(AppDir+'\{#MINGW_BITNESS}\etc')) then
-            LogError('Failed to create \{#MINGW_BITNESS}\etc; continuing anyway')
+        if (not ForceDirectories(AppDir+'\{#ETC_GITCONFIG_DIR}')) then
+            LogError('Failed to create \{#ETC_GITCONFIG_DIR}; continuing anyway')
         else
-            FileCopy(ExpandConstant('{tmp}\gitconfig.system'),AppDir+'\{#MINGW_BITNESS}\etc\gitconfig',True)
+            FileCopy(ExpandConstant('{tmp}\gitconfig.system'),AppDir+'\{#ETC_GITCONFIG_DIR}\gitconfig',True)
     end;
 
     {

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2184,7 +2184,6 @@ end;
 procedure CleanupWhenUpgrading;
 var
     ErrorCode:Integer;
-    ProgramData:String;
 begin
     if UninstallAppPath<>'' then begin
         // Save a copy of the system config so that we can copy it back later
@@ -2195,15 +2194,6 @@ begin
         end else if FileExists(UninstallAppPath+'\etc\gitconfig') and
             (not FileCopy(UninstallAppPath+'\etc\gitconfig',ExpandConstant('{tmp}\gitconfig.system'),True)) then
             LogError('Could not save system config; continuing anyway');
-
-        ProgramData:=ExpandConstant('{commonappdata}');
-        if FileExists(UninstallAppPath+'\etc\gitconfig') and not FileExists(ProgramData+'\Git\config') then begin
-            if not ForceDirectories(ProgramData+'\Git') then
-                LogError('Could not initialize Windows-wide Git config.')
-            else if not FileCopy(UninstallAppPath+'\etc\gitconfig',ProgramData+'\Git\config',False) then
-                LogError('Could not copy old Git config to Windows-wide location.');
-        end;
-
     end;
 
     if UninstallString<>'' then begin
@@ -2371,7 +2361,7 @@ end;
 
 procedure CurStepChanged(CurStep:TSetupStep);
 var
-    ProgramData,DllPath,FileName,Cmd,Msg,Ico:String;
+    DllPath,FileName,Cmd,Msg,Ico:String;
     BuiltIns,ImageNames,EnvPath:TArrayOfString;
     Count,i:Longint;
     RootKey:Integer;
@@ -2398,7 +2388,6 @@ begin
     end;
 
     AppDir:=ExpandConstant('{app}');
-    ProgramData:=ExpandConstant('{commonappdata}');
 
     {
         Copy dlls from "/mingw64/bin" to "/mingw64/libexec/git-core" if they are
@@ -2471,20 +2460,6 @@ begin
     end else
         LogError('Line {#__LINE__}: Unable to read file "{#MINGW_BITNESS}\{#APP_BUILTINS}".');
 
-    // Create default ProgramData git config file
-    if not FileExists(ProgramData + '\Git\config') then begin
-        if not DirExists(ProgramData + '\Git') then begin
-            if not CreateDir(ProgramData + '\Git') then begin
-                Log('Line {#__LINE__}: Creating directory "' + ProgramData + '\Git" failed.');
-            end;
-        end;
-        if not FileExists(ExpandConstant('{tmp}\programdata-config.template')) then
-            ExtractTemporaryFile('programdata-config.template');
-        if not FileCopy(ExpandConstant('{tmp}\programdata-config.template'), ProgramData + '\Git\config', True) then begin
-            Log('Line {#__LINE__}: Creating initial "' + ProgramData + '\Git\config" failed.');
-        end;
-    end;
-
     // Copy previous system wide git config file, if any
     if FileExists(ExpandConstant('{tmp}\gitconfig.system')) then begin
         if (not ForceDirectories(AppDir+'\{#ETC_GITCONFIG_DIR}')) then
@@ -2509,35 +2484,25 @@ begin
     else
         GitSystemConfigSet('http.sslBackend','openssl');
 
-    if FileExists(ProgramData+'\Git\config') then begin
-        if not Exec(AppDir+'\bin\bash.exe','-c "value=\"$(git config -f config pack.packsizelimit)\" && if test 2g = \"$value\"; then git config -f config --unset pack.packsizelimit; fi"',ProgramData+'\Git',SW_HIDE,ewWaitUntilTerminated,i) then
-            LogError('Unable to remove packsize limit from ProgramData config');
-        Cmd:=AppDir+'/';
+    if not RdbCurlVariant[GC_WinSSL].Checked then begin
+        Cmd:=AppDir+'/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt';
         StringChangeEx(Cmd,'\','/',True);
-        if not Exec(AppDir+'\bin\bash.exe','-c "value=\"$(git config -f config http.sslcainfo)\" && case \"$value\" in \"'+Cmd+'\"/*|\"C:/Program Files/Git/\"*|\"c:/Program Files/Git/\"*) git config -f config --unset http.sslcainfo;; esac"',ProgramData+'\Git',SW_HIDE,ewWaitUntilTerminated,i) then
-            LogError('Unable to delete http.sslCAInfo from ProgramData config');
-        if not RdbCurlVariant[GC_WinSSL].Checked then begin
-            Cmd:=AppDir+'/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt';
-            StringChangeEx(Cmd,'\','/',True);
-            GitSystemConfigSet('http.sslCAInfo',Cmd);
-         end else
-            GitSystemConfigSet('http.sslCAInfo',#0);
-    end;
+        GitSystemConfigSet('http.sslCAInfo',Cmd);
+    end else
+        GitSystemConfigSet('http.sslCAInfo',#0);
 
     {
         Adapt core.autocrlf
     }
 
     if RdbCRLF[GC_LFOnly].checked then begin
-        Cmd:='core.autocrlf input';
+        Cmd:='input';
     end else if RdbCRLF[GC_CRLFAlways].checked then begin
-        Cmd:='core.autocrlf true';
+        Cmd:='true';
     end else begin
-        Cmd:='core.autocrlf false';
+        Cmd:='false';
     end;
-    if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f config ' + Cmd,
-                ProgramData + '\Git', SW_HIDE, ewWaitUntilTerminated, i) then
-        LogError('Unable to configure the line ending conversion: ' + Cmd);
+    GitSystemConfigSet('core.autocrlf',Cmd);
 
     {
         Configure the terminal window for Git Bash
@@ -2551,24 +2516,17 @@ begin
         Configure extra options
     }
 
-    if RdbExtraOptions[GP_FSCache].checked then begin
-        Cmd:='core.fscache true';
-
-        if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f config ' + Cmd,
-                    ProgramData + '\Git', SW_HIDE, ewWaitUntilTerminated, i) then
-            LogError('Unable to enable the extra option: ' + Cmd);
-    end;
+    if RdbExtraOptions[GP_FSCache].checked then
+        GitSystemConfigSet('core.fscache','true');
 
     if RdbExtraOptions[GP_GCM].checked then
         GitSystemConfigSet('credential.helper','manager');
 
     if RdbExtraOptions[GP_Symlinks].checked then
-        Cmd:='core.symlinks true'
+        Cmd:='true'
     else
-        Cmd:='core.symlinks false';
-    if not Exec(AppDir + '\{#MINGW_BITNESS}\bin\git.exe', 'config -f config ' + Cmd,
-                ProgramData + '\Git', SW_HIDE, ewWaitUntilTerminated, i) then
-        LogError('Unable to enable the extra option: ' + Cmd);
+        Cmd:='false';
+    GitSystemConfigSet('core.symlinks',Cmd);
 
     {
         Configure experimental options

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -112,6 +112,7 @@ then
 else
 	echo "Generating file list to be included in the installer ..."
 	LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
+		ETC_GITCONFIG="$etc_gitconfig" \
 		PACKAGE_VERSIONS_FILE=package-versions.txt \
 		INCLUDE_GIT_UPDATE=1 \
 		sh ../make-file-list.sh)" ||
@@ -161,7 +162,7 @@ then
 	inno_defines="$inno_defines$LF#define WITH_EXPERIMENTAL_BUILTIN_ADD_I 1"
 fi
 
-GITCONFIG_PATH="$(echo "$LIST" | grep "^mingw$BITNESS/etc/gitconfig\$")"
+GITCONFIG_PATH="$(echo "$LIST" | grep "^$etc_gitconfig\$")"
 test -z "$GITCONFIG_PATH" || {
 	keys="$(git config -f "/$GITCONFIG_PATH" -l --name-only)" &&
 	gitconfig="$LF[Code]${LF}function GitSystemConfigSet(Key,Value:String):Boolean; forward;$LF" &&
@@ -175,7 +176,7 @@ test -z "$GITCONFIG_PATH" || {
 			case "$key$value" in *"'"*) die "Cannot handle $key=$value because of the single quote";; esac &&
 			case "$key" in
 			filter.lfs.*) extra=" IsComponentSelected('gitlfs') And";;
-			pack.packsizelimit) test $BITNESS = 32 || continue; value=2g;;
+			pack.packsizelimit) test $BITNESS = 32 || continue; value=2g; extra=;;
 			*) extra=;;
 			esac &&
 			gitconfig="$gitconfig$LF    if$extra not GitSystemConfigSet('$key','$value') then$LF        Result:=False;" ||

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -99,6 +99,11 @@ echo "Compiling edit-git-bash.exe ..."
 make -C ../ edit-git-bash.exe ||
 die "Could not build edit-git-bash.exe"
 
+etc_gitconfig="$(git -c core.editor=echo config --system -e 2>/dev/null)" &&
+etc_gitconfig="$(cygpath -au "$etc_gitconfig")" &&
+etc_gitconfig="${etc_gitconfig#/}" ||
+die "Could not determine the path of the system config"
+
 if test t = "$skip_files"
 then
 	# make sure the file exists, as the installer wants it
@@ -215,11 +220,13 @@ test -z "$include_pdbs" || {
 } ||
 die "Could not include .pdb files"
 
-printf "%s\n%s\n%s\n%s%s" \
+etc_gitconfig_dir="${etc_gitconfig%/gitconfig}"
+printf "%s\n%s\n%s\n%s\n%s%s" \
 	"#define APP_VERSION '$displayver'" \
 	"#define FILENAME_VERSION '$version'" \
 	"#define BITNESS '$BITNESS'" \
 	"#define SOURCE_DIR '$(cygpath -aw /)'" \
+	"#define ETC_GITCONFIG_DIR '${etc_gitconfig_dir//\//\\}'" \
 	"$inno_defines" \
 	>config.iss
 

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -253,10 +253,13 @@ pacman -Q filesystem $SH_FOR_REBASE rebase \
 		mingw-w64-$ARCH-xpdf-tools) \
 	>>"$PACKAGE_VERSIONS_FILE"
 
+test -n "$ETC_GITCONFIG" ||
+ETC_GITCONFIG=etc/gitconfig
+
 cat <<EOF
 etc/fstab
 etc/nsswitch.conf
-mingw$BITNESS/etc/gitconfig
+$ETC_GITCONFIG
 usr/bin/rebase.exe
 usr/bin/rebaseall
 EOF

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -256,9 +256,13 @@ pacman -Q filesystem $SH_FOR_REBASE rebase \
 test -n "$ETC_GITCONFIG" ||
 ETC_GITCONFIG=etc/gitconfig
 
+test -n "$ETC_GITATTRIBUTES" ||
+ETC_GITATTRIBUTES="${ETC_GITCONFIG%/*}/gitattributes"
+
 cat <<EOF
 etc/fstab
 etc/nsswitch.conf
+$ETC_GITATTRIBUTES
 usr/bin/rebase.exe
 usr/bin/rebaseall
 EOF
@@ -274,7 +278,6 @@ etc/bash.bashrc
 etc/msystem
 usr/bin/dash.exe
 usr/bin/getopt.exe
-mingw$BITNESS/etc/gitattributes
 EOF
 
 test -n "$MINIMAL_GIT" || cat <<EOF

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -259,7 +259,6 @@ ETC_GITCONFIG=etc/gitconfig
 cat <<EOF
 etc/fstab
 etc/nsswitch.conf
-$ETC_GITCONFIG
 usr/bin/rebase.exe
 usr/bin/rebaseall
 EOF
@@ -279,6 +278,7 @@ mingw$BITNESS/etc/gitattributes
 EOF
 
 test -n "$MINIMAL_GIT" || cat <<EOF
+$ETC_GITCONFIG
 etc/post-install/01-devices.post
 etc/post-install/03-mtab.post
 etc/post-install/06-windows-files.post

--- a/mingit/release.sh
+++ b/mingit/release.sh
@@ -69,6 +69,16 @@ die "Could not copy license file"
 mkdir -p "$SCRIPT_PATH"/root/etc ||
 die "Could not make etc/"
 
+cat >"$SCRIPT_PATH"/root/"$etc_gitconfig" <<EOF ||
+[include]
+	; include Git for Windows' system config in order
+	; to inherit settings like `core.autocrlf`
+	path = C:\Program Files (x86)\Git\etc\gitconfig
+	path = C:\Program Files\Git\etc\gitconfig
+$(cat "/$etc_gitconfig")
+EOF
+die "Could not generate system config"
+
 test -z "$include_pdbs" || {
 	find "$SCRIPT_PATH/root" -name \*.pdb -exec rm {} \; &&
 	"$SCRIPT_PATH"/../please.sh bundle-pdbs \

--- a/mingit/release.sh
+++ b/mingit/release.sh
@@ -54,6 +54,11 @@ case "$SCRIPT_PATH" in
 	;;
 esac
 
+etc_gitconfig="$(git -c core.editor=echo config --system -e 2>/dev/null)" &&
+etc_gitconfig="$(cygpath -au "$etc_gitconfig")" &&
+etc_gitconfig="${etc_gitconfig#/}" ||
+die "Could not determine the path of the system config"
+
 rm -rf "$SCRIPT_PATH"/root &&
 mkdir -p "$SCRIPT_PATH"/root ||
 die "Could not create overlay directory"
@@ -72,7 +77,7 @@ test -z "$include_pdbs" || {
 die "Could not unpack .pdb files"
 
 # Make a list of files to include
-LIST="$(ARCH=$ARCH BITNESS=$BITNESS MINIMAL_GIT=1 \
+LIST="$(ARCH=$ARCH BITNESS=$BITNESS MINIMAL_GIT=1 ETC_GITCONFIG="$etc_gitconfig" \
 	PACKAGE_VERSIONS_FILE="$SCRIPT_PATH"/root/etc/package-versions.txt \
 	sh "$SCRIPT_PATH"/../make-file-list.sh "$@")" ||
 die "Could not generate file list"

--- a/mingw-w64-git-lfs/git-lfs.install
+++ b/mingw-w64-git-lfs/git-lfs.install
@@ -1,12 +1,8 @@
 post_install() {
-  for arch in mingw32 mingw64; do
-    if [ -f "${arch}/bin/git-lfs.exe" ]; then
-      git config -f "${arch}/etc/gitconfig" filter.lfs.clean "git-lfs clean -- %f"
-      git config -f "${arch}/etc/gitconfig" filter.lfs.smudge "git-lfs smudge -- %f"
-      git config -f "${arch}/etc/gitconfig" filter.lfs.process "git-lfs filter-process"
-      git config -f "${arch}/etc/gitconfig" filter.lfs.required true
-    fi
-  done
+  git config --system filter.lfs.clean "git-lfs clean -- %f"
+  git config --system filter.lfs.smudge "git-lfs smudge -- %f"
+  git config --system filter.lfs.process "git-lfs filter-process"
+  git config --system filter.lfs.required true
 }
 
 post_upgrade() {
@@ -14,9 +10,5 @@ post_upgrade() {
 }
 
 pre_remove() {
-  for arch in mingw32 mingw64; do
-    if [ -f "${arch}/bin/git-lfs.exe" ]; then
-       git config -f "${arch}/etc/gitconfig" --remove-section filter.lfs
-    fi
-  done
+  git config --system --remove-section filter.lfs
 }

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -93,25 +93,29 @@ die "Could not install bin/ redirectors"
 cp "$SCRIPT_PATH/../post-install.bat" "$SCRIPT_PATH/root/" ||
 die "Could not copy post-install script"
 
-mkdir -p "$SCRIPT_PATH/root/mingw$BITNESS/etc" &&
-cp /mingw$BITNESS/etc/gitconfig \
-	"$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" &&
-git config -f "$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" \
+etc_gitconfig="$(git -c core.editor=echo config --system -e 2>/dev/null)" &&
+etc_gitconfig="$(cygpath -au "$etc_gitconfig")" &&
+etc_gitconfig="${etc_gitconfig#/}" ||
+die "Could not determine the path of the system config"
+
+mkdir -p "$SCRIPT_PATH/root/${etc_gitconfig%/*}" &&
+cp /"$etc_gitconfig" "$SCRIPT_PATH/root/$etc_gitconfig" &&
+git config -f "$SCRIPT_PATH/root/$etc_gitconfig" \
 	credential.helper manager ||
 die "Could not configure Git-Credential-Manager as default"
 test 64 != $BITNESS ||
-git config -f "$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" --unset pack.packSizeLimit
+git config -f "$SCRIPT_PATH/root/$etc_gitconfig" --unset pack.packSizeLimit
 
 # Make a list of files to include
-LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
+LIST="$(ARCH=$ARCH BITNESS=$BITNESS ETC_GITCONFIG="$etc_gitconfig" \
 	PACKAGE_VERSIONS_FILE="$SCRIPT_PATH"/root/etc/package-versions.txt \
 	sh "$SCRIPT_PATH"/../make-file-list.sh "$@" |
-	grep -v "^mingw$BITNESS/etc/gitconfig$")" ||
+	grep -v "^$etc_gitconfig$")" ||
 die "Could not generate file list"
 
 case "$LIST" in
 */git-credential-helper-selector.exe*)
-	git config -f "$SCRIPT_PATH/root/mingw$BITNESS/etc/gitconfig" \
+	git config -f "$SCRIPT_PATH/root/$etc_gitconfig" \
 		credential.helper helper-selector
 	;;
 esac


### PR DESCRIPTION
This is a follow-up PR for https://github.com/git-for-windows/git/pull/2358, and it will need to be merged _before_ that one, so that the next snapshot won't be broken.

The idea is to prepare the scripts that generate the Git for Windows installer, the Portable Git and the MinGit versions to accommodate for Git versions that have only one system config: Instead of reading `C:\ProgramData\Git\config` and then `C:\Program Files\Git\mingw64\etc\gitconfig` (or for 32-bit Git on 64-bit Windows, `C:\Program Files (x86)\Git\mingw32\etc\gitconfig`), we now only read from the quite intuitive location `C:\Program Files\Git\etc\gitconfig`, i.e. without the `mingw64` part.

This also addresses the issue raised many times that the Portable Git relied on settings configured _outside_ of the Portable Git (`C:\ProgramData\Git\config`), in addition to squelching complaints that there is no equivalent to the `--system` option for writing to the ProgramData config.

Finally, the ProgramData config was meant to be a truly Windows-wide config, but it lacked buy-in. For example, JGit (which is implicitly used by pretty much every Android Studio/Eclipse user) does not support it. At the same time, libgit2 seems to never have stopped looking for `C:\Program Files\Git\etc\gitconfig`. In short: the ProgramData config failed to serve its purpose, anyway.