### PR TITLE
Installer: stop complaining about "downgrading" when upgrading from an rc version

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -869,6 +869,16 @@ begin
     ExitProcess(0);
 end;
 
+function CountDots(S:String):Integer;
+var
+    i:Integer;
+begin
+    Result:=0;
+    for i:=1 to Length(S) do
+        if (S[i]=#46) then
+            Result:=Result+1;
+end;
+
 function IsDowngrade(CurrentVersion,PreviousVersion:String):Boolean;
 var
     Path:String;
@@ -876,8 +886,8 @@ var
 begin
     Result:=(VersionCompare(CurrentVersion,PreviousVersion)<0);
 #ifdef GIT_VERSION
-    if Result then begin
-        // maybe the previous version was a prerelease?
+    if Result or (CountDots(CurrentVersion)>3) or (CountDots(PreviousVersion)>3) then begin
+        // maybe the previous version was a prerelease (prereleases have five numbers: v2.24.0-rc1.windows.1 reduces to '2.24.0.1.1')?
         if (RegQueryStringValue(HKEY_LOCAL_MACHINE,'Software\GitForWindows','InstallPath',Path))
                 and (Exec(ExpandConstant('{cmd}'),'/c ""'+Path+'\cmd\git.exe" version >"'+ExpandConstant('{tmp}')+'\previous.version""','',SW_HIDE,ewWaitUntilTerminated,i))
                 and (i=0) then begin

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -816,6 +816,13 @@ begin
         if Previous<0 then begin
             if Current>=0 then
                 Result:=+1;
+            Result:=Ord(CurrentVersion[i])-Ord(PreviousVersion[j]);
+            if (Result=0) then begin
+                // skip identical non-numerical characters
+                i:=i+1;
+                j:=j+1;
+                Continue;
+            end;
             Exit;
         end;
         if Current<0 then begin

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -649,6 +649,10 @@ begin
         Result:='(no output)'
     else
         Result:=Contents;
+    if (Length(Result)>0) and (Result[Length(Result)]=#10) then
+        SetLength(Result,Length(Result)-1);
+    if (Length(Result)>0) and (Result[Length(Result)]=#13) then
+        SetLength(Result,Length(Result)-1);
 end;
 
 function GitSystemConfigSet(Key,Value:String):Boolean;

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -119,6 +119,11 @@ else
 	die "Could not generate file list"
 fi
 
+cmd_git="$(echo "$LIST" | grep '^cmd/git\.exe$')"
+test -z "$cmd_git" ||
+inno_defines="$inno_defines$LF#define GIT_VERSION '$("/$cmd_git" version)'" ||
+die "Could not execute 'git version'"
+
 printf '; List of files\n%s\n%s\n%s\n%s\n%s\n%s\n' \
 	"Source: \"mingw$BITNESS\\bin\\blocked-file-util.exe\"; Flags: dontcopy" \
 	"Source: \"{#SourcePath}\\package-versions.txt\"; DestDir: {app}\\etc; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \


### PR DESCRIPTION
There is a pretty old bug where the Git for Windows installer warns about a "downgrade" when upgrading from, say, v2.23.0-rc2 to v2.23.0, because the versions that are actually compared are of the format `N.N.N.N` (by stripping out non-numerical letters, in the example, the compared versions would be `2.23.0.2` vs `2.23.0.0`).

Let's fix this by trying to be a bit more careful when we're about to warn about a downgrade, and compare the output of the installed `git version` vs the one we're about to install.