### PR TITLE
Handle patch number and some other improvements and fixes

### DIFF
--- a/git-extra/getgit
+++ b/git-extra/getgit
@@ -135,9 +135,10 @@ else
 fi
 latest=$(curl $gh_tags)
 version=$(echo $latest | grep -Po "\d+\.\d+.\d+")
-echo "Gathered { system: \"$system\", bit: \"$bit\", latest: \"$latest\", version: \"$version\" }"
+patch=$(echo $latest | grep -Po "windows\.\K\d")
+echo "Gathered { system: \"$system\", bit: \"$bit\", latest: \"$latest\", version: \"$version\", patch: \"$patch\" }"
 # I think there's no chance that the local version is greater than the latest released version
-if [[ x$force_update != x1 && "$version" == "$(git --version 2>/dev/null | grep -Po "\d+\.\d+.\d+")" ]]; then
+if [[ x$force_update != x1 && "$latest" == "v$(git --version 2>/dev/null | grep -Po "\d+\.\d+.\d+\.windows\.\d")" ]]; then
     echo There is no need to update git 
     echo ""
     echo "[ git --version ]" 
@@ -148,7 +149,8 @@ fi
 
 echo ""
 # Downloading
-filename=PortableGit-$version-$bit-bit.7z.exe
+[[ "$patch" != "" && $patch -gt 1 ]] && n=".$patch"
+filename=PortableGit-$version$n-$bit-bit.7z.exe
 download_href="https://github.com/git-for-windows/git/releases/download/$latest/$filename"
 if [[ ! x$skip_download == x1 ]]; then
     downloader=`type wget > /dev/null 2>&1 && echo "wget -c -O" \
@@ -220,8 +222,8 @@ if [[ "$system" == "Msys" ]]; then
 '\"cd '"'%%v'; export CHERE_INVOKING=1; export MSYSTEM=MINGW$bit; exec /usr/bin/bash --login -i"'\""' >> $ctxmenu
 else # Cygwin
 	echo 'reg add "HKEY_CLASSES_ROOT\Directory\Background\shell\git_shell\command" '\
-'/f /ve /d "\"%~dp0..\bin\mintty.exe\" -i /cmd/git-gui.exe /bin/bash --login -i -c '\
-'\"cd '"'%%v'; export CHERE_INVOKING=1; export PATH=/mingw$bit/bin:\$PATH; exec /bin/bash"'\""' >> $ctxmenu
+'/f /ve /d "\"%~dp0..\bin\mintty.exe\" -i /cmd/git-gui.exe /bin/bash -c '\
+'\"cd '"'%%v'; export CHERE_INVOKING=1; export PATH=/mingw$bit/bin:\$PATH; exec /bin/bash --login -i"'\""' >> $ctxmenu
 fi
 echo '' >> $ctxmenu
 echo 'pause' >> $ctxmenu

--- a/git-extra/getgit
+++ b/git-extra/getgit
@@ -64,7 +64,8 @@ function restore(){
 function cleanup(){
     if [[ -e "$1" ]]; then
         echo -n \* cleaning up... >&2
-        rm -rf "$1"
+        # rm -rf "$1"
+        mv -f "$1" "/tmp/${1//\//.}$(date +%Y%m%d%H%M%S)"
         echo done >&2
 	else
 		echo "* nothing to cleanup, skip" >&2
@@ -78,7 +79,7 @@ function cleanup(){
 function process(){
     until [ $# -eq 0 ]; do
         case "$1" in
-            -f) f=1; shift;;
+            -f) local f=1; shift;;
             *) local target="$1"; local files="$2"; shift; shift;;
         esac    
     done

--- a/git-extra/getgit
+++ b/git-extra/getgit
@@ -42,7 +42,7 @@ function backup(){
 function update(){
     mkdir -p "$2"
     echo -n \* upating.......
-    \cp -rnf "$1" "$2" > /dev/null 2>&1 || \cp -rf "$1" "$2"
+    \cp -rlf "$1" "$2" > /dev/null 2>&1 || \cp -rf "$1" "$2"
     echo done
 }
 


### PR DESCRIPTION
**Handle patch number** 

While there's a patch number greater than 1 appended, the name of the file about to be downloaded should also have that number appended after the version part.   
For example: `v2.24.0.windows.2` ==> `PortableGit-2.24.0.2-64-bit.7z.exe`

**Remove the inadvertently added "-n" option**

In an updating scenario, this "-n" option in the `update` function would prevent files from being overwritten, yet our intention indeed is to overwrite them.

**Move the backed up files to /tmp instead of "rm -rf" them**

This can help to keep the original files at least in the temporary folder in case something unexpected happen. Users can restore the original files as they wish.

**Let `Git Bash Here` perform an identical behavior on Cygwin comparing to Git-for-windows**

To let `Git Bash Here` on Cygwin perform the identical behavior, the final executed bash in the command string of the shell item should have "--login -i" options. So that the environment is well prepared the same way `Git-for-windows` does. And this also makes the bootstrap bash of the command string redundant thus should be removed.

Signed-off-by: liuxy <391861737@qq.com>