### PR TITLE
Various system gitconfig-related fixes, in particular for MinGit

### DIFF
--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -216,10 +216,19 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 		sed -i '$i#undef _POSIX_THREAD_SAFE_FUNCTIONS\n#define _POSIX_THREAD_SAFE_FUNCTIONS 200112L\n' $header
 	done
 
-	# Make sure that `/ssl` is a symbolic link pointing to `/usr/ssl`.
-	# This is needed because `/etc/gitconfig` is shared between the MSYS
-	# and the MINGW variants of `git.exe`.
-	test -h /ssl || (cd / && rm -f ssl && cmd //c 'mklink /d ssl usr\ssl')
+	# We do not actually need the http.sslCAInfo setting anymore, as the
+	# cURL we ship with Git for Windows was patched to find the location of
+	# the TLS/SSL certificates.
+	test ! -f /etc/gitconfig || # just a little defensive programming
+	! grep -q '^	sslCAinfo = /ssl/certs/ca-bundle.crt$' /etc/gitconfig ||
+	sed -i -e 's/^	sslCAinfo = \/ssl\/certs\/ca-bundle\.crt$/#&/' /etc/gitconfig
+
+	# Previously, we made sure that `/ssl` is a symbolic link pointing to
+	# `/usr/ssl` so that the http.sslCAInfo setting could be shared between
+	# the MSYS and the MINGW variants of `git.exe`.
+	#
+	# As we no longer need it, delete it.
+	test ! -h /ssl || rm /ssl
 }
 
 post_upgrade () {

--- a/git-extra/gitconfig
+++ b/git-extra/gitconfig
@@ -10,8 +10,6 @@
 	packSizeLimit = 2g
 [help]
 	format = html
-[http]
-	sslCAinfo = /ssl/certs/ca-bundle.crt
 [diff "astextplain"]
 	textconv = astextplain
 [rebase]

--- a/mingit/release.sh
+++ b/mingit/release.sh
@@ -83,12 +83,12 @@ LIST="$(ARCH=$ARCH BITNESS=$BITNESS MINIMAL_GIT=1 ETC_GITCONFIG="$etc_gitconfig"
 die "Could not generate file list"
 
 cat >"$SCRIPT_PATH"/root/"$etc_gitconfig" <<EOF ||
+$(cat "/$etc_gitconfig")
 [include]
 	; include Git for Windows' system config in order
 	; to inherit settings like \`core.autocrlf\`
 	path = C:/Program Files (x86)/Git/etc/gitconfig
 	path = C:/Program Files/Git/etc/gitconfig
-$(cat "/$etc_gitconfig")
 EOF
 die "Could not generate system config"
 


### PR DESCRIPTION
I made a mistake when I added those `include.path` settings to MinGit's system config which are intended to inherit the installed Git for Windows' defaults: these includes are added _to the beginning_, which means that MinGit's hard-coded `core.autocrlf` and friends always override Git for Windows' defaults. Which defeats the purpose.

Let's fix that, and while at it also remove the no longer needed `http.sslCAInfo` from the system gitconfig of Git for Windows' SDK (the installer will _still_ set it, to help Git LFS use Git for Windows' certificate bundle).