### PR TITLE
Show the update message in the Action Center again

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -154,7 +154,7 @@ update_git_for_windows () {
 	try_toast=
 	test -z "$use_gui" ||
 	case "$(uname -s)" in
-	*-6.[23]|*-10.0)
+	*-6.[23]|*-6.[23]-[1-9]*|*-10.0|*-10.0-[1-9]*)
 		# Only try to show a Toast notification on Windows 8 & 10,
 		# and only if we have a working wintoast.exe
 		! type wintoast.exe >/dev/null 2>&1 ||


### PR DESCRIPTION
The `git update-git-for-windows` script tries to be smart and only show the Toast in Windows 8 and later. But the test was broken by an update to Cygwin v3.x, which changed the format of the output of `uname -s`.

This fixes that.