### PR TITLE
skip options pages when upgrading

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1577,6 +1577,8 @@ begin
         Height:=WizardForm.CancelButton.Height;
         Top:=WizardForm.CancelButton.Top;
     end;
+    if (PreviousGitForWindowsVersion='') then
+        OnlyShowNewOptions.Hide;
 
     (*
      * Create a custom page for configuring the default Git editor.

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2496,7 +2496,7 @@ var
     RootKey:Integer;
 begin
     if CurStep=ssInstall then begin
-#ifdef DEBUG_WIZARD_PAGE
+#ifdef DO_NOT_INSTALL
         ExitEarlyWithSuccess();
 #endif
         // Shutdown locking processes just before the actual installation starts.

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -937,9 +937,9 @@ begin
     if (OnlyShowNewOptions.Checked) then begin
         // The "Select Program Group" page is suppressed when
         // re-installing/upgrading/downgrading, but not the Components page.
-        if (PageID=wpSelectProgramGroup) or ((PreviousGitForWindowsVersion<>'') and (PageID=wpSelectComponents)) then
+        if (PageID<=wpSelectProgramGroup) then
             PageID:=FirstCustomPageID;
-        while (PageID<PageIDBeforeInstall) and IsInSet(AllCustomPages,PageID) and not IsInSet(CustomPagesWithUnseenOptions,PageID) do
+        while (PageID<PageIDBeforeInstall) and not IsInSet(CustomPagesWithUnseenOptions,PageID) do
             PageID:=PageID+1;
     end;
     Result:=(PageID=PageIDBeforeInstall);
@@ -2111,9 +2111,12 @@ begin
         end;
         RefreshProcessList(NIL);
         Result:=(GetArrayLength(Processes)=0);
-    end else if OnlyShowNewOptions.Checked then
-        Result:=IsInSet(AllCustomPages,PageID) and not IsInSet(CustomPagesWithUnseenOptions,PageID)
-    else
+    end else if OnlyShowNewOptions.Checked then begin
+        if (IsInSet(AllCustomPages,PageID)) then
+            Result:=not IsInSet(CustomPagesWithUnseenOptions,PageID)
+        else
+            Result:=(PageID<>wpInfoBefore);
+    end else
         Result:=False;
 #ifdef DEBUG_WIZARD_PAGE
     Result:=PageID<>DebugWizardPage

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -513,51 +513,56 @@ var
     Caption:String;
     ManualClosingRequired:Boolean;
 begin
+    if (AppDir='') then begin
+        SetArrayLength(Processes,0);
+        Exit;
+    end;
+
     GetWindowsVersionEx(Version);
 
     // Use the Restart Manager API when installing the shell extension on Windows Vista and above.
     if Version.Major>=6 then begin
         SetArrayLength(Modules,17);
-        Modules[0]:=ExpandConstant('{app}\usr\bin\msys-2.0.dll');
-        Modules[1]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tcl85.dll');
-        Modules[2]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tk85.dll');
-        Modules[3]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tcl86.dll');
-        Modules[4]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tk86.dll');
-        Modules[5]:=ExpandConstant('{app}\git-cheetah\git_shell_ext.dll');
-        Modules[6]:=ExpandConstant('{app}\git-cheetah\git_shell_ext64.dll');
-        Modules[7]:=ExpandConstant('{app}\git-cmd.exe');
-        Modules[8]:=ExpandConstant('{app}\git-bash.exe');
-        Modules[9]:=ExpandConstant('{app}\bin\bash.exe');
-        Modules[10]:=ExpandConstant('{app}\bin\git.exe');
-        Modules[11]:=ExpandConstant('{app}\bin\sh.exe');
-        Modules[12]:=ExpandConstant('{app}\cmd\git.exe');
-        Modules[13]:=ExpandConstant('{app}\cmd\gitk.exe');
-        Modules[14]:=ExpandConstant('{app}\cmd\git-gui.exe');
-        Modules[15]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\git.exe');
-        Modules[16]:=ExpandConstant('{app}\usr\bin\bash.exe');
+        Modules[0]:=AppDir+'\usr\bin\msys-2.0.dll';
+        Modules[1]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll';
+        Modules[2]:=AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll';
+        Modules[3]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll';
+        Modules[4]:=AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll';
+        Modules[5]:=AppDir+'\git-cheetah\git_shell_ext.dll';
+        Modules[6]:=AppDir+'\git-cheetah\git_shell_ext64.dll';
+        Modules[7]:=AppDir+'\git-cmd.exe';
+        Modules[8]:=AppDir+'\git-bash.exe';
+        Modules[9]:=AppDir+'\bin\bash.exe';
+        Modules[10]:=AppDir+'\bin\git.exe';
+        Modules[11]:=AppDir+'\bin\sh.exe';
+        Modules[12]:=AppDir+'\cmd\git.exe';
+        Modules[13]:=AppDir+'\cmd\gitk.exe';
+        Modules[14]:=AppDir+'\cmd\git-gui.exe';
+        Modules[15]:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
+        Modules[16]:=AppDir+'\usr\bin\bash.exe';
         SessionHandle:=FindProcessesUsingModules(Modules,Processes);
     end else begin
         SetArrayLength(Modules,15);
-        Modules[0]:=ExpandConstant('{app}\usr\bin\msys-2.0.dll');
-        Modules[1]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tcl85.dll');
-        Modules[2]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tk85.dll');
-        Modules[3]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tcl86.dll');
-        Modules[4]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\tk86.dll');
-        Modules[5]:=ExpandConstant('{app}\git-cmd.exe');
-        Modules[6]:=ExpandConstant('{app}\git-bash.exe');
-        Modules[7]:=ExpandConstant('{app}\bin\bash.exe');
-        Modules[8]:=ExpandConstant('{app}\bin\git.exe');
-        Modules[9]:=ExpandConstant('{app}\bin\sh.exe');
-        Modules[10]:=ExpandConstant('{app}\cmd\git.exe');
-        Modules[11]:=ExpandConstant('{app}\cmd\gitk.exe');
-        Modules[12]:=ExpandConstant('{app}\cmd\git-gui.exe');
-        Modules[13]:=ExpandConstant('{app}\{#MINGW_BITNESS}\bin\git.exe');
-        Modules[14]:=ExpandConstant('{app}\usr\bin\bash.exe');
+        Modules[0]:=AppDir+'\usr\bin\msys-2.0.dll';
+        Modules[1]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll';
+        Modules[2]:=AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll';
+        Modules[3]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll';
+        Modules[4]:=AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll';
+        Modules[5]:=AppDir+'\git-cmd.exe';
+        Modules[6]:=AppDir+'\git-bash.exe';
+        Modules[7]:=AppDir+'\bin\bash.exe';
+        Modules[8]:=AppDir+'\bin\git.exe';
+        Modules[9]:=AppDir+'\bin\sh.exe';
+        Modules[10]:=AppDir+'\cmd\git.exe';
+        Modules[11]:=AppDir+'\cmd\gitk.exe';
+        Modules[12]:=AppDir+'\cmd\git-gui.exe';
+        Modules[13]:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
+        Modules[14]:=AppDir+'\usr\bin\bash.exe';
         SessionHandle:=FindProcessesUsingModules(Modules,ProcsCloseRequired);
 
         SetArrayLength(Modules,2);
-        Modules[0]:=ExpandConstant('{app}\git-cheetah\git_shell_ext.dll');
-        Modules[1]:=ExpandConstant('{app}\git-cheetah\git_shell_ext64.dll');
+        Modules[0]:=AppDir+'\git-cheetah\git_shell_ext.dll';
+        Modules[1]:=AppDir+'\git-cheetah\git_shell_ext64.dll';
         SessionHandle:=FindProcessesUsingModules(Modules,ProcsCloseOptional) or SessionHandle;
 
         // Misuse the "Restartable" flag to indicate which processes are required

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2036,6 +2036,8 @@ begin
 
 #endif
 
+    PageIDBeforeInstall:=CurrentCustomPageID;
+
     (*
      * Create a custom page for finding the processes that lock a module.
      *)
@@ -2070,12 +2072,6 @@ begin
 
     // This button is only used by the uninstaller.
     ContinueButton:=NIL;
-
-#ifdef HAVE_EXPERIMENTAL_OPTIONS
-    PageIDBeforeInstall:=ExperimentalOptionsPage.ID;
-#else
-    PageIDBeforeInstall:=ExtraOptionsPage.ID;
-#endif
 
 #ifdef DEBUG_WIZARD_PAGE
     DebugWizardPage:={#DEBUG_WIZARD_PAGE}.ID;

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -39,8 +39,15 @@ do
 			exit 1
 		fi
 		inno_defines="$inno_defines$LF#define DEBUG_WIZARD_PAGE '$page'$LF#define OUTPUT_TO_TEMP ''"
+		inno_defines="$inno_defines$LF#define DO_NOT_INSTALL 1"
 		inno_defines="$inno_defines$LF[Code]${LF}function SetSystemConfigDefaults():Boolean;${LF}begin${LF}    Result:=True;${LF}end;${LF}${LF}"
 		skip_files=t
+		;;
+	--test)
+		test_installer=t
+		inno_defines="$inno_defines$LF#define OUTPUT_TO_TEMP ''"
+		inno_defines="$inno_defines$LF#define DO_NOT_INSTALL 1"
+		inno_defines="$inno_defines$LF[Code]${LF}function SetSystemConfigDefaults():Boolean;${LF}begin${LF}    Result:=True;${LF}end;$LF"
 		;;
 	--output=*)
 		output_directory="$(cygpath -m "${1#*=}")" ||


### PR DESCRIPTION
When upgrading Git-for-Windows, the current default behavior is to go through the entire installation dialog, which shows a number of pages for setting options.  This change suppresses those pages during upgrade, using the previous values (or values specified on the command installer command line, if they are present).  It does so by checking, for each options page, whether all the values on it have previously-set values.  

Behavior on two edge cases:
If a new option page is added, it's values won't be previously set, so it will be shown, even on upgrade.
If the user uninstalls and then reinstalls Git for Windows, all the pages/options are shown.

One known flaw: when all pages are shown, the last page before installation has a button labeled 'Install' instead of 'Next'.  With this change, the user may not see an 'Install' button.  I think that is a reasonable trade-off for the simpler experience for users.

```
        Signed-off-by: Denise Draper <draperd@acm.org>
```
