### PR TITLE
Let `sdk create-desktop-icon` use the correct API to determine the Desktop's location

### DIFF
--- a/git-extra/create-shortcut.c
+++ b/git-extra/create-shortcut.c
@@ -32,7 +32,6 @@ int main(int argc, char **argv)
 	IShellLink* psl;
 	IPersistFile* ppf;
 
-
 	while (argc > 2) {
 		if (argv[1][0] != '-')
 			break;

--- a/git-extra/create-shortcut.c
+++ b/git-extra/create-shortcut.c
@@ -26,6 +26,7 @@ int main(int argc, char **argv)
 	const char *work_dir = NULL, *arguments = NULL, *icon_file = NULL;
 	const char *description = NULL;
 	int show_cmd = 1, desktop_shortcut = 0, dry_run = 0;
+	size_t len;
 
 	static WCHAR wsz[1024];
 	HRESULT hres;
@@ -72,6 +73,11 @@ int main(int argc, char **argv)
 	if (argc != 3) {
 		fprintf(stderr, "Usage: %s [options] <source> <destination>\n",
 			progname);
+		return 1;
+	}
+
+	if ((len = strlen(argv[2])) < 5 || strcasecmp(argv[2] + len - 4, ".lnk")) {
+		fprintf(stderr, "Can only create .lnk files ('%s' was specified)\n", argv[2]);
 		return 1;
 	}
 

--- a/git-extra/create-shortcut.c
+++ b/git-extra/create-shortcut.c
@@ -25,7 +25,7 @@ int main(int argc, char **argv)
 	const char *progname = argv[0];
 	const char *work_dir = NULL, *arguments = NULL, *icon_file = NULL;
 	const char *description = NULL;
-	int show_cmd = 1, desktop_shortcut = 0;
+	int show_cmd = 1, desktop_shortcut = 0, dry_run = 0;
 
 	static WCHAR wsz[1024];
 	HRESULT hres;
@@ -50,6 +50,11 @@ int main(int argc, char **argv)
 			argc--;
 			argv++;
 			continue;
+		} else if (!strcmp(argv[1], "-n") || !strcmp(argv[1], "--dry-run")) {
+			dry_run = 1;
+			argc--;
+			argv++;
+			continue;
 		} else {
 			fprintf(stderr, "Unknown option: %s\n", argv[1]);
 			return 1;
@@ -68,6 +73,40 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Usage: %s [options] <source> <destination>\n",
 			progname);
 		return 1;
+	}
+
+	if (dry_run) {
+		printf("source: %s\n", argv[1]);
+
+		if (work_dir)
+			printf("work_dir: %s\n", work_dir);
+
+		if (show_cmd)
+			printf("show_cmd: %d\n", show_cmd);
+
+		if (icon_file)
+			printf("icon_file: %s\n", icon_file);
+
+		if (arguments)
+			printf("arguments: %s\n", arguments);
+
+		if (description)
+			printf("description: %s\n", description);
+
+		if (desktop_shortcut) {
+			PWSTR p;
+
+			hres = SHGetKnownFolderPath(&FOLDERID_Desktop,
+						    KF_FLAG_DONT_UNEXPAND, NULL, &p);
+			check_hres(hres, "could not get desktop path");
+
+			printf("destination: %ls\\%s\n", p, argv[2]);
+
+			CoTaskMemFree(p);
+		} else
+			printf("destination: %s\n", argv[2]);
+
+		return 0;
 	}
 
 	hres = CoInitialize(NULL);

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -65,14 +65,14 @@ sdk () {
 		'') break;;
 		-*) sdk die "Unknown option: %s\n" "$1"; return 1;;
 		esac; do shift; done &&
-
 		case "$(uname -m)" in
 		i686) bitness=" 32-bit";;
 		x86_64) bitness=" 64-bit";;
 		*) bitness=;;
 		esac &&
-		desktop_icon_path="$(reg query 'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders' //v Desktop |
-			sed -ne 'y/\\/\//' -e 's/.*REG_SZ *//p')/Git SDK$bitness.lnk" &&
+		desktop_icon_path="Git SDK$bitness.lnk" &&
+		desktop_icon_path="$(create-shortcut.exe -n --desktop-shortcut /git-bash.exe "$desktop_icon_path" |
+			sed -n 's/^destination: //p')" &&
 		if test -n "$force" || test ! -f "$desktop_icon_path"
 		then
 			create-shortcut.exe --icon-file /msys2.ico --work-dir \


### PR DESCRIPTION
Given OneDrive with the Desktop Redirection feature, and other supported methods to NOT have your Desktop in %USERPROFILE%\Desktop, we should use a more sophisticated method to get the path to the Desktop in order to put a shortcut there. Since we are using Bash we need to step out and invoke a vbs script to get the SpecialFolder called Desktop, and use that as a path.
