### PR TITLE
Enable FSCache in the Portable Git by default

### DIFF
--- a/portable/release.sh
+++ b/portable/release.sh
@@ -112,6 +112,7 @@ git config -f "$SCRIPT_PATH/root/$etc_gitconfig" \
 die "Could not configure Git-Credential-Manager as default"
 test 64 != $BITNESS ||
 git config -f "$SCRIPT_PATH/root/$etc_gitconfig" --unset pack.packSizeLimit
+git config -f "$SCRIPT_PATH/root/$etc_gitconfig" core.fscache true
 
 case "$LIST" in
 */git-credential-helper-selector.exe*)


### PR DESCRIPTION
Enable `core.fscache` in the portable git by default as discussed at
[#2467](https://github.com/git-for-windows/git/issues/2467#issuecomment-574109742).