### PR TITLE
Cache recentlySeenVersion in ~/.git-for-windows-updater instead of global config

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -115,13 +115,15 @@ http_get () {
 }
 
 get_recently_seen() {
-    git config --global winUpdater.recentlySeenVersion
+    if [ -f ~/.git-for-windows-updater ]; then
+        git config -f ~/.git-for-windows-updater winUpdater.recentlySeenVersion
+    else
+        git config --global winUpdater.recentlySeenVersion
+    fi
 }
 
 set_recently_seen() {
-    local latest="$1"
-
-    git config --global winUpdater.recentlySeenVersion "$latest"
+    git config -f ~/.git-for-windows-updater winUpdater.recentlySeenVersion "$1"
 }
 
 # The main function of this script

--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -114,6 +114,16 @@ http_get () {
 	return "$ret"
 }
 
+get_recently_seen() {
+    git config --global winUpdater.recentlySeenVersion
+}
+
+set_recently_seen() {
+    local latest="$1"
+
+    git config --global winUpdater.recentlySeenVersion "$latest"
+}
+
 # The main function of this script
 
 update_git_for_windows () {
@@ -180,7 +190,7 @@ update_git_for_windows () {
 
 	latest=${latest_tag#v}
 	# Did we ask about this version already?
-	recently_seen="$(git config --global winUpdater.recentlySeenVersion)"
+	recently_seen="$(get_recently_seen)"
 	test -n "$quiet" && test "x$recently_seen" = "x$latest" && return
 
 	version=$(git --version | sed "s/git version //")
@@ -188,7 +198,7 @@ update_git_for_windows () {
 	if test -z "$testing" && test "$latest" = "$version"
 	then
 		echo "Up to date" >&2
-		git config --global winUpdater.recentlySeenVersion "$latest"
+		set_recently_seen "$latest"
 		return
 	fi
 	test -n "$testing" ||
@@ -237,8 +247,7 @@ update_git_for_windows () {
 				;;
 			1|17)
 				# dismiseed, or clicked No: ignore this release
-				git config --global \
-					winUpdater.recentlySeenVersion "$latest"
+				set_recently_seen "$latest"
 				return 1
 				;;
 			4|5|6|9|10)
@@ -248,8 +257,7 @@ update_git_for_windows () {
 				git askyesno \
 					--title "Git Update Available" \
 					"Download and install $name$warn?" || {
-				    git config --global \
-					winUpdater.recentlySeenVersion "$latest"
+				    set_recently_seen "$latest"
 				    return 1
 				}
 				;;
@@ -263,8 +271,7 @@ update_git_for_windows () {
 		then
 			git askyesno --title "Git Update Available" \
 				"Download and install $name$warn?" || {
-				git config --global \
-					winUpdater.recentlySeenVersion "$latest"
+				set_recently_seen "$latest"
 				return 1
 			}
 		else
@@ -273,8 +280,7 @@ update_git_for_windows () {
 			case "$yn" in
 			[Yy]*) ;;
 			*)
-				git config --global \
-					winUpdater.recentlySeenVersion "$latest"
+				set_recently_seen "$latest"
 				return 1;;
 			esac
 		fi


### PR DESCRIPTION
Implementation as suggested by @dscho in https://github.com/git-for-windows/git/issues/2485#issuecomment-576653219

Depends on `set_recently_seen` being called to make transision, up to user to rm exising global config which is ignored going forward.

Personally I'd rather store it somewhere outside of $HOME, like `/tmp` (problematic for per-user installs I'd guess), `~/.cache/gitforwindows` or even the registry. Any suggestions?