### PR TITLE
installer: handle Vim 8.2

### DIFF
--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -186,6 +186,7 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	sed -i -e '/^# Define default printer/,/^$/d' \
 		-e 's/^\(export .* \)PRINTER /\1/' /etc/profile
 
+	test ! -f /usr/share/vim/vim81/defaults.vim ||
 	! grep -A3 '^ *autocmd BufReadPost \*' \
 		/usr/share/vim/vim81/defaults.vim |
 	grep -q ' exe "normal! g`\\""' ||

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -148,6 +148,7 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	sed -i -e '/^# Define default printer/,/^$/d' \
 		-e 's/^\(export .* \)PRINTER /\1/' /etc/profile
 
+	test ! -f /usr/share/vim/vim81/defaults.vim ||
 	! grep -A3 '^ *autocmd BufReadPost \*' \
 		/usr/share/vim/vim81/defaults.vim |
 	grep -q ' exe "normal! g`\\""' ||


### PR DESCRIPTION
The installer bash script comments out a part of Vim's defaults.vim
file. This part resets the cursor line to the last one when reopening a
file. This is not desired in the case of commit messages, which are
always the same file name but composed from scratch each time.

In the meantime, MSYS2 Vim was updated to 8.2.

This causes a warning on installing git-extra because the installer
script unconditionally greps a Vim 8.1 file that is no longer present.
Fix this by checking the file's presence.

A similar installer script section is not necessary for Vim 8.2, because
this version includes in this line-resetting automatism an exception for
all file types matching "*commit*".

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
