### PR TITLE
Updated Update Install Command to improve silent installation

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -290,7 +290,7 @@ update_git_for_windows () {
 		echo "Downloading $filename" >&2
 	fi
 	curl -# -L -o $installer $download || return
-	start "" "$installer" /SILENT
+	start "" "$installer" /SILENT /VERYSILENT
 
 	# Kill all Bash processes (which will let MinTTY quit, too)"
 	#


### PR DESCRIPTION
Relates to issue [#2584](https://github.com/git-for-windows/git/issues/2548#issue-583892831).  This PR should stop the new installer showing a initial install screen by using the existing installer /VERYSILENT command.  

As I was using Visual Studio to make these changes an update to the .gitignore got included to avoid additional visual studio specific settings being included in the repo, I've left the .gitignore change in because I didn't think it would harm anything but can remove if required.  

This is my first contribution to git so I've not managed to build and test the code however considering the minor changes I didn't know if this was required.  I'll try and have a got at building the updated installer over the weekend.  

Please let me know if there are any other changes that are needed to be made (patch note additions etc) and I'll get them done as well

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: Leo D'Arcy leo.darcy@poweronplatforms.com
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/git-for-windows/build-extra/279)
<!-- Reviewable:end -->
