### PR TITLE
Provide GfW ReleaseNote Start menu Icon, and tweak collapsible div marker 

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -124,6 +124,7 @@ Name: "{app}\tmp"
 Name: {group}\Git GUI; Filename: {app}\cmd\git-gui.exe; Parameters: ""; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 Name: {group}\Git Bash; Filename: {app}\git-bash.exe; Parameters: "--cd-to-home"; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 Name: {group}\Git CMD; Filename: {app}\git-cmd.exe; Parameters: "--cd-to-home"; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
+Name: {group}\Git Release Notes; Filename: {app}\ReleaseNotes.html; Parameters: ""; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 
 [Messages]
 BeveledLabel={#APP_URL}

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -126,21 +126,23 @@ render_release_notes () {
 				(() => {
 					for (let el of document.getElementsByClassName('collapsible')) {
 						let arrow = document.createElement('div');
-						arrow.innerHTML = '⯆';
+						arrow.innerHTML = '▽';
 						arrow.style.float = 'left';
 						arrow.style.position = 'relative';
 						arrow.style.left = '-1em';
 						arrow.style.top = '+1.5em';
+						arrow.style.fontSize = 'larger';
+						arrow.style.cursor = 'pointer';
 
 						const toggle = () => {
 							// this.classList.toggle('active');
 							let details = el.nextElementSibling;
 							if (details.style.display === 'none') {
 								details.style.display = 'block';
-								arrow.innerHTML = '⯆';
+								arrow.innerHTML = '▽';
 							} else {
 								details.style.display = 'none';
-								arrow.innerHTML = '⯈';
+								arrow.innerHTML = '▷';
 							}
 						};
 


### PR DESCRIPTION
Improve the accessibility and readability of the release notes.

1. Add a start menu icon for the GfW's own release notes, so use can find and read them.

2. Small improvement to the readability of the notes by using larger, open 'white' triangles for the collapsible regions of the release notes - feels more like the typical explorer look. Previously they looked like basic bullet points

3. Also, specifically mark the upstream Git's link as being for their release notes (not tested successfully - may not have invoked the please.sh appropriately. I'd expected the `sdk build installer` to do it's magic - guidance needed!)

Signed-off-by: Philip Oakley <philipoakley@iee.email>

