### PR TITLE
Release notes: show version number for "Changes since" section

### DIFF
--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -115,7 +115,7 @@ render_release_notes () {
 
 				$nr = 0 if (!$nr);
 				$nr++;
-				s/^<h2/$& id="$v" nr="$nr" class="collapsible"/;
+				s/^<h2>/<h2 id="$v" nr="$nr" class="collapsible"><small>$v<\/small>: /;
 				$v = $previous_version;
 				s/.*/<\/div>$&<div>/;
 			}'


### PR DESCRIPTION
Add the current version number as a prefix to the 'Changes since' line.

The "Changes since" sections of the release notes are 'below the fold'
so it is not immediately obvious to readers what is the version the
changes refer to. The version is already available as the header id
but this isn't displayed to the user in any obvious manner.

The html release notes processing is multi-phase. There are maintainer
actions to add new notes to the original markdown version.
The html preparation is part of the `sdk build installer  process. This
provides conversion of the markdown to html, and finally some format
adjustments to the html in render-release-notes.sh.

This code change is just to the final html adjustments to avoid any
changes to the maintainer workflow.

The updated perl script isn't quite as neat as previously,
but is obvious.

Signed-off-by: Philip Oakley <philipoakley@iee.email>

---
With the extra prefix the heading line felt rather big and intimidating, maybe larger than some smaller screens, so I have chosen to make the prefix use `<small>` font. Comments welcomed.