### PR TITLE
ReleaseNotes: highlight the upstream Product release notes links

### DIFF
--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -96,7 +96,7 @@ render_release_notes () {
 				</div>
 				<div class="content">
 		EOF
-		body="$(markdown "$SCRIPT_PATH"/ReleaseNotes.md)" ||
+		body="$(sed -r 's|(^\* Comes with \[Git v[0-9].*\))|\1 \(Product release notes\)|' "$SCRIPT_PATH"/ReleaseNotes.md | markdown)" ||
 		die "Could not generate ReleaseNotes.html"
 		echo "$body" | perl -pe '
 			s/^(<h1)(>Known issues)/\1 id="known-issues" class="collapsible"\2/;


### PR DESCRIPTION
The "* Comes with Git v2.x.y" in the link does not do justice to the
reality that this is _the_ link to the upstream's release notes for
the key bug fixes, improvements and backward compatibility issues in
this release.

Explicitly state that this link is for the `Product release notes`.

Editing is performed here to avoid affecting the maintainer scripts.

Signed-off-by: Philip Oakley <philipoakley@iee.email>
