### PR TITLE
Address the fallout from the upgrade to MSYS2 runtime v3.1.4

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -16,7 +16,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
   > `MSYS_NO_PATHCONV=1 git blame -L/pathconv/ msys2_path_conv.cc`
 
   Alternatively, you can double the first slash to avoid POSIX-to-Windows path conversion, e.g. "`//usr/bin/bash.exe`".
-* Windows drives are normally recognised within the POSIX path as `/c/path/to/dir/` where `/c/` (or appropriate drive letter) is equivalent to the `C:\` Windows prefix to the `\path\to\dir`. If this is not recognised, revert to the `C:\path\to\dir` Windows style.
+* Windows drives are normally recognized within the POSIX path as `/c/path/to/dir/` where `/c/` (or appropriate drive letter) is equivalent to the `C:\` Windows prefix to the `\path\to\dir`. If this is not recognized, revert to the `C:\path\to\dir` Windows style.
 * Git for Windows will not allow commits containing DOS-style truncated 8.3-format filenames ending with a tilde and digit, such as `mydocu~1.txt`. A workaround is to call `git config core.protectNTFS false`, which is not advised. Instead, add a rule to .gitignore to ignore the file(s), or rename the file(s).
 * Many Windows programs (including the Windows Explorer) have problems with directory trees nested so deeply that the absolute path is longer than 260 characters. Therefore, Git for Windows refuses to check out such files by default. You can overrule this default by setting `core.longPaths`, e.g. `git clone -c core.longPaths=true ...`.
 * Some commands are not yet supported on Windows and excluded from the installation.

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -35,7 +35,7 @@ This package contains software from a number of other projects including Bash, z
 
 ## Changes since Git for Windows v2.26.2 (April 20th 2020)
 
-This release comes with a version of the MSYS2 runtime that uses the [Windows-native pseudo terminals](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/) by default. Meaning: Git Bash supports interactive native console programs such as `node.exe`, Python or PHP, without using the `winpty` helper (see [_Known Issues_ above](#known-issues)). Note that this is still a very new feature and is therefore it is expected to have some corner-case bugs. You can disable this feature by setting the environment variable to `MSYS=disable_pcon` _before_ starting the Git Bash (e.g. in the _System Properties_).
+This release comes with a Git Bash that optionally uses [Windows-native pseudo consoles](https://devblogs.microsoft.com/commandline/windows-command-line-introducing-the-windows-pseudo-console-conpty/). Meaning: finally, Git Bash can accommodate console programs like `node.exe`, Python or PHP, without using the `winpty` helper (see [_Known Issues_ above](#known-issues)). Note that this is still a very new feature and is therefore known to have some corner-case bugs.
 
 ### New Features
 
@@ -46,7 +46,6 @@ This release comes with a version of the MSYS2 runtime that uses the [Windows-na
 * The release notes [have been made a bit more readable and are now linked from the Start Menu group](https://github.com/git-for-windows/build-extra/pull/281).
 * The Frequently Asked Questions (FAQ) [are now linked in a Start Menu item](https://github.com/git-for-windows/build-extra/pull/283).
 * Comes with [Git LFS v2.11.0](https://github.com/git-lfs/git-lfs/releases/tag/v2.11.0).
-* Comes with [patch level 2](https://github.com/git-for-windows/msys2-runtime/commit/815446179f59e0898d8e220a9a20562b09b090c9) of the MSYS2 runtime (Git for Windows flavor) based on [Cygwin 3.1.4](https://cygwin.com/ml/cygwin-announce/2020-02/msg00006.html).
 
 ### Bug Fixes
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -112,7 +112,9 @@ Filename: {app}\ReleaseNotes.html; Description: View Release Notes; Flags: shell
 Source: {#SourcePath}\ReleaseNotes.html; DestDir: {app}; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore
 Source: {#SourcePath}\..\LICENSE.txt; DestDir: {app}; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore
 Source: {#SourcePath}\NOTICE.txt; DestDir: {app}; Flags: replacesameversion; AfterInstall: DeleteFromVirtualStore; Check: ParamIsSet('VSNOTICE')
+#ifdef INCLUDE_EDIT_GIT_BASH
 Source: {#SourcePath}\..\edit-git-bash.exe; Flags: dontcopy
+#endif
 
 [Dirs]
 Name: "{app}\dev"
@@ -285,12 +287,18 @@ function OverrideGitBashCommandLine(GitBashPath:String;CommandLine:String):Integ
 var
     Msg:String;
 begin
+#ifdef INCLUDE_EDIT_GIT_BASH
     if not FileExists(ExpandConstant('{tmp}\edit-git-bash.exe')) then
         ExtractTemporaryFile('edit-git-bash.exe');
+#endif
     StringChangeEx(GitBashPath,'"','\"',True);
     StringChangeEx(CommandLine,'"','\"',True);
     CommandLine:='"'+GitBashPath+'" "'+CommandLine+'"';
+#ifdef INCLUDE_EDIT_GIT_BASH
     Exec(ExpandConstant('{tmp}\edit-git-bash.exe'),CommandLine,'',SW_HIDE,ewWaitUntilTerminated,Result);
+#else
+    Exec(ExpandConstant('{app}\{#MINGW_BITNESS}\share\git\edit-git-bash.exe'),CommandLine,'',SW_HIDE,ewWaitUntilTerminated,Result);
+#endif
     if Result<>0 then begin
         if Result=1 then begin
             Msg:='Unable to edit '+GitBashPath+' (out of memory).';

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -181,6 +181,11 @@ then
 	inno_defines="$inno_defines$LF#define WITH_EXPERIMENTAL_BUILTIN_ADD_I 1"
 fi
 
+if grep -q enable_pcon /usr/bin/msys-2.0.dll
+then
+	inno_defines="$inno_defines$LF#define WITH_EXPERIMENTAL_PCON 1"
+fi
+
 GITCONFIG_PATH="$(echo "$LIST" | grep "^$etc_gitconfig\$")"
 test -z "$GITCONFIG_PATH" || {
 	keys="$(git config -f "/$GITCONFIG_PATH" -l --name-only)" &&

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -102,9 +102,16 @@ echo "Generating release notes to be included in the installer ..."
 ../render-release-notes.sh --css usr/share/git/ ||
 die "Could not generate release notes"
 
-echo "Compiling edit-git-bash.exe ..."
-make -C ../ edit-git-bash.exe ||
-die "Could not build edit-git-bash.exe"
+if grep -q edit-git-bash /var/lib/pacman/local/mingw-w64-$ARCH-git-[1-9]*/files
+then
+	INCLUDE_EDIT_GIT_BASH=
+else
+	INCLUDE_EDIT_GIT_BASH=1
+	inno_defines="$inno_defines$LF#define INCLUDE_EDIT_GIT_BASH$LF"
+	echo "Compiling edit-git-bash.exe ..."
+	make -C ../ edit-git-bash.exe ||
+	die "Could not build edit-git-bash.exe"
+fi
 
 etc_gitconfig="$(git -c core.editor=echo config --system -e 2>/dev/null)" &&
 etc_gitconfig="$(cygpath -au "$etc_gitconfig")" &&

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -120,10 +120,6 @@ die "Could not switch directory to $SCRIPT_PATH"
 ../render-release-notes.sh --css usr/share/git/ ||
 die "Could not generate ReleaseNotes.html."
 
-# Compile edit-git-bash.exe
-make -C ../ edit-git-bash.exe ||
-die "Could not build edit-git-bash.exe."
-
 # Make a list of files to include
 LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
 	PACKAGE_VERSIONS_FILE="$SCRIPT_PATH"/package-versions.txt \
@@ -159,10 +155,6 @@ BUILD_EXTRA_WINPATH="$(cd "$SCRIPT_PATH"/.. && pwd -W | tr / \\\\)"
             </Component>
             <Component Directory="INSTALLFOLDER:\\usr\\share\\git\\">
                 <File Id="ReleaseNotes_Css" Source="$BUILD_EXTRA_WINPATH\\ReleaseNotes.css" />
-            </Component>
-            <Component Directory="INSTALLFOLDER" Guid="">
-                <Condition>TERMINAL = "CmdPrompt"</Condition>
-                <File DoNotBind Id="EditGitBash" Source="$BUILD_EXTRA_WINPATH\\edit-git-bash.exe" KeyPath="yes" />
             </Component>
 EOF
 echo "$LIST" |


### PR DESCRIPTION
The main two things in this PR: we now offer an experimental option to opt-in to the pseudo console support, and we silence the `pull.rebase` warning proactively by forcing the user to choose in the installer.

While at it, I also slipped in a change accommodating for https://github.com/git-for-windows/MINGW-packages/pull/40: the `edit-git-bash.exe` helper is now included in the `mingw-w64-git` package (originally I had planned to modify the `git-bash.exe` via `edit-git-bash` so that it would enable pseudo consoles, but that would be confusing, as it would affect _only_ `git-bash.exe` (and not, say, `/cmd/git.exe -c alias.mintty='!mintty' mintty`).