### PR TITLE
Show 'current' version for Changes since collapsible headings

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -7,7 +7,7 @@ These release notes describe issues specific to the Git for Windows release. The
 
 See [http://git-scm.com/](http://git-scm.com/) for further details about Git including ports to other operating systems. Git for Windows is hosted at [https://gitforwindows.org/](https://gitforwindows.org/).
 
-# Known issues
+## Known issues
 * On Windows 10 before 1703, or when Developer Mode is turned off, special permissions are required when cloning repositories with symbolic links, therefore support for symbolic links is disabled by default. Use `git clone -c core.symlinks=true <URL>` to enable it, see details [here](https://github.com/git-for-windows/git/wiki/Symbolic-Links).
 * If configured to use Plink, you will have to connect with [putty](http://www.chiark.greenend.org.uk/~sgtatham/putty/) first and accept the host key.
 * Some console programs, most notably non-MSYS2 Python, PHP, Node and OpenSSL, interact correctly with MinTTY only when called through `winpty` (e.g. the Python console needs to be started as `winpty python` instead of just `python`).
@@ -24,6 +24,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
 * The Quick Launch icon will only be installed for the user running setup (typically the Administrator). This is a technical restriction and will not change.
 * Older versions of the Windows Explorer do *not* calculate Git for Windows' on-disk size correctly, as it is unaware of hard links. Therefore, it might look like Git for Windows takes up 1.5GB when in reality it is about a third of that.
 
+#### Other Problems
 Should you encounter other problems, please first search [the bug tracker](https://github.com/git-for-windows/git/issues) (also look at the closed issues) and [the mailing list](http://groups.google.com/group/git-for-windows), chances are that the problem was reported already. Also make sure that you use an up to date Git for Windows version (or a [current snapshot build](https://wingit.blob.core.windows.net/files/index.html)). If it has not been reported, please follow [our bug reporting guidelines](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) and [report the bug](https://github.com/git-for-windows/git/issues/new).
 
 ## Licenses

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -99,7 +99,7 @@ render_release_notes () {
 		body="$(markdown "$SCRIPT_PATH"/ReleaseNotes.md)" ||
 		die "Could not generate ReleaseNotes.html"
 		echo "$body" | perl -pe '
-			s/^(<h1)(>Known issues)/\1 id="known-issues" class="collapsible"\2/;
+			s/^(<h2)(>Known issues)/\1 id="known-issues" class="collapsible"\2/;
 			s/^(<h2)(>Licenses.*)/\1 id="licenses" class="collapsible"\2<div>/;
 			$v = $1 if (/<h1>Git for Windows (\S+)/);
 			if (/^<h2>Changes since Git for Windows ([^ ]*)/) {

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -126,12 +126,11 @@ render_release_notes () {
 				(() => {
 					for (let el of document.getElementsByClassName('collapsible')) {
 						let arrow = document.createElement('div');
-						arrow.innerHTML = '▽';
+						arrow.innerHTML = '▽ ' + el.id;
 						arrow.style.float = 'left';
 						arrow.style.position = 'relative';
 						arrow.style.left = '-1em';
 						arrow.style.top = '+1.5em';
-						arrow.style.fontSize = 'larger';
 						arrow.style.cursor = 'pointer';
 
 						const toggle = () => {
@@ -139,10 +138,10 @@ render_release_notes () {
 							let details = el.nextElementSibling;
 							if (details.style.display === 'none') {
 								details.style.display = 'block';
-								arrow.innerHTML = '▽';
+								arrow.innerHTML = '▽ ' + el.id;
 							} else {
 								details.style.display = 'none';
-								arrow.innerHTML = '▷';
+								arrow.innerHTML = '▷ ' + el.id;
 							}
 						};
 

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -115,7 +115,12 @@ render_release_notes () {
 
 				$nr = 0 if (!$nr);
 				$nr++;
-				s/^<h2/$& id="$v" nr="$nr" class="collapsible"/;
+				$id = $v;
+				if ($v eq $previous_version) {
+					# in-between version
+					$id = "snapshot"
+				}
+				s/^<h2>/<h2 id="$id" nr="$nr" class="collapsible"> /;
 				$v = $previous_version;
 				s/.*/<\/div>$&<div>/;
 			}'


### PR DESCRIPTION
These commits are a replacement for PR #284. It provides a small reminder of the release version that has the changes that are being discussed within the collapsed heading.  Snapshots are properly indicated. Other h2 collapsible headings have a similar tag at the top left.

The Known Issues heading is also set to h2, and the Other Problems paragraph given it's own small h4 heading.

Signed-off-by: Philip Oakley <philipoakley@iee.email>