### PR TITLE
Add User-manual and git-scm Pro Git book icons to Start menu

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -128,6 +128,8 @@ Name: {group}\Git Bash; Filename: {app}\git-bash.exe; Parameters: "--cd-to-home"
 Name: {group}\Git CMD; Filename: {app}\git-cmd.exe; Parameters: "--cd-to-home"; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 Name: {group}\Git Release Notes; Filename: {app}\ReleaseNotes.html; Parameters: ""; WorkingDir: %HOMEDRIVE%%HOMEPATH%; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 Name: {group}\Git FAQs (Frequently Asked Questions); Filename: https://github.com/git-for-windows/git/wiki/FAQ; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
+Name: {group}\Git User Manual; Filename: {app}\{#MINGW_BITNESS}\share\doc\git-doc\user-manual.html; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
+Name: {group}\Pro Git book (Chacon & Straub); Filename: https://git-scm.com/book/en/v2; IconFilename: {app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 
 [Messages]
 BeveledLabel={#APP_URL}


### PR DESCRIPTION
The Git user-manual is not easy to find. It is not accessible via
`git help`. Provide a link on the start menu.

While at it, also provide a direct link to the Everyday Git man page.
This avoids a long slip-prone route via `git help`, `git help -g`, and
`git help everyday`.

Signed-off-by: Philip Oakley <philipoakley@iee.email>
---
These links should help our new users on Windows, 
and should root out errors in the user-manual and Everyday Git pages

I think I have the bitness correct (worked for me)
