### PR TITLE
[RFC] ReleaseNotes: Show 'current' version for "Changes Since" titles

### DIFF
--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -105,6 +105,13 @@ render_release_notes () {
 			if ((/^<h2>Changes since (Git for Windows ([^ <]*)|(Win)?Git-([^ <]*))/)) {
 				$previous_version = $2 ? $2 : "v$4";
 
+				if ($v eq $previous_version) {
+					# in-between version
+					$v = "snapshot"
+				}
+
+				s/^<h2>Changes since(.*)/<h2>Changes in $v <small>since \1<\/small>/;
+
 				if (!$latest) {
 					s/>[^<]*/><a name="latest"$&<\/a>/;
 					$latest = 1;
@@ -116,10 +123,7 @@ render_release_notes () {
 				$nr = 0 if (!$nr);
 				$nr++;
 				$id = $v;
-				if ($v eq $previous_version) {
-					# in-between version
-					$id = "snapshot"
-				}
+
 				s/^<h2>/<h2 id="$id" nr="$nr" class="collapsible"> /;
 				$v = $previous_version;
 				s/.*/<\/div>$&<div>/;

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -110,7 +110,7 @@ render_release_notes () {
 					$v = "snapshot"
 				}
 
-				s/^<h2>Changes since(.*)/<h2>Changes in $v <small>since \1<\/small>/;
+				s/^<h2>Changes since (?:Git(?: for Windows|-))(.*)/<h2>Changes in $v <small>since \1<\/small>/;
 
 				if (!$latest) {
 					s/>[^<]*/><a name="latest"$&<\/a>/;


### PR DESCRIPTION
Third version, based on most recent master.

Opinions, especially the colours! 
(Helped by colleague @strath.ac.uk who knows a bit more about some of the HTML fu)
Also, should a title at the bottom of the page auto scroll a little when opened, to show something happening..

P.


The Git for Windows Release Notes show the "Changes Since" title lines
but don't tell the user the current version they refer to.

Convert the Arrow indication to a floating button at the top left
of the header showing the version, and an expansion arrow.

Currently the button is a default grey shade, with a contrasting
green font lettering (valuely matching the logo's green).

Signed-off-by: Philip Oakley <philipoakley@iee.email>
---
RFC. The previous white font is not readable/accessible against
the grey button.