### PR TITLE
Add bash-completion packages in Git for Windows 

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -49,6 +49,11 @@ then
 	UTIL_PACKAGES="$UTIL_PACKAGES tmux libevent"
 fi
 
+if test -z "$MINIMAL_GIT"
+then
+	UTIL_PACKAGES="$UTIL_PACKAGES bash-completion"
+fi
+
 this_script_dir="$(cd "$(dirname "$0")" && pwd -W)" ||
 die "Could not determine this script's dir"
 


### PR DESCRIPTION
This should fix https://github.com/git-for-windows/git/issues/2562 

The introduction of `bash-completion` should also fix `vim` completion which depends on `_filedir` function defined only with `bash-completion`.

This will also affect `_get_comp_words_by_ref`: the implementation found in Git (https://github.com/git/git/blob/master/contrib/completion/git-completion.bash#L261) differ from bash-completion (https://github.com/scop/bash-completion/blob/133790c464c68fa728b2957a66ee1fa012181a88/bash_completion#L369):

The following completion will not work as intended:

```bash
#!/bin/bash

_my_completion() {
  local lf=$'\n'
  local s="COMP_WORDBREAKS=[${COMP_WORDBREAKS}]${lf}"
  for exclude in '@=' '=' ; do
    local cur='' prev='' cword=''
    local -a words=()
    _get_comp_words_by_ref -n "${exclude}" cur prev words cword
    s+="exclude: ${exclude}"
    s+=", cur=[$cur]"
    s+=", prev=[$prev]"
    s+=", cword=[$cword]"
    s+=", words[${#words[@]}]:"
    for (( i = 0; i < ${#words[@]}; ++i)); do
      s+=" [${words[$i]}]"
    done
    s+="${lf}"
  done
  echo "${lf}$s"
}

complete -o bashdefault -o nospace -o dirnames -o filenames -F _my_completion x
```

On Linux (5.4.28-gentoo-x86_64 with bash-completion):

```text
  $ x --abricot @ad ppp @A<TAB>
  COMP_WORDBREAKS=[\n"'><=;|&(:]
  exclude: @=, cur=[@A], prev=[ppp], cword=[4], words[5]: [x] [--abricot] [@ad] [ppp] [@A]
  exclude: = , cur=[@A], prev=[ppp], cword=[4], words[5]: [x] [--abricot] [@ad] [ppp] [@A]
  $ export COMP_WORDBREAKS="${COMP_WORDBREAKS}@"
  $ x --abricot @ad ppp @A<TAB>
  COMP_WORDBREAKS=[\n"'><=;|&(:@]
  exclude: @=, cur=[@A], prev=[ppp], cword=[4], words[5]: [x] [--abricot] [@ad] [ppp] [@A]
  exclude: = , cur=[A] , prev=[@]  , cword=[6], words[7]: [x] [--abricot] [@] [ad] [ppp] [@] [A]
```

As we can see, the `_get_comp_words_by_ref` function work as intended: the `@A` is kept as is when exclude is `@=` or when `COMP_WORDBREAKS` does not contains `@`.

On Windows, with git version 2.27.0.windows.1, it behaves differently because we use Git definition of `_get_comp_words_by_ref`: we observe that `COMP_WORDBREAKS` contains `@` and that's when the `_get_comp_words_by_ref` fail to work correctly:

```
  $ x --abricot @ad ppp @A<TAB>
  COMP_WORDBREAKS=[\n"'@><=;|&(:]
  exclude: @=, cur=[ppp@A], prev=[--abricot@ad], cword=[2], words[3]: [x] [--abricot@ad] [ppp@A]
  exclude: = , cur=[A]    , prev=[@], cword=[6], words[7]: [x] [--abricot] [@] [ad] [ppp] [@] [A]
  $ export COMP_WORDBREAKS="${COMP_WORDBREAKS//@/}"
  $ x --abricot @ad ppp @A<TAB>
  COMP_WORDBREAKS=[\n"'><=;|&(:]
  exclude: @=, cur=[@A], prev=[ppp], cword=[4], words[5]: [x] [--abricot] [@ad] [ppp] [@A]
  exclude: = , cur=[@A], prev=[ppp], cword=[4], words[5]: [x] [--abricot] [@ad] [ppp] [@A]
```


