### PR TITLE
Add support for Git Credential Manager Core as a credential helper option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,12 @@ edit-git-bash.exe
 /mingw-w64-git-credential-manager/*.src.tar.gz
 /mingw-w64-git-credential-manager/gcmw-*.zip
 /mingw-w64-git-credential-manager/v[1-9]*.zip
+/mingw-w64-git-credential-manager-core/pkg/
+/mingw-w64-git-credential-manager-core/src/
+/mingw-w64-git-credential-manager-core/*.pkg.tar.*
+/mingw-w64-git-credential-manager-core/*.src.tar.gz
+/mingw-w64-git-credential-manager-core/gcmcore-*.zip
+/mingw-w64-git-credential-manager-core/v[1-9]*.zip
 /mingw-w64-wintoast/mingw-w64-*-wintoast-*-any.pkg.tar.xz
 /mingw-w64-wintoast/pkg
 /mingw-w64-wintoast/src

--- a/get-sources.sh
+++ b/get-sources.sh
@@ -211,7 +211,7 @@ do
 	then
 
 		case "$name" in
-		git-extra|mingw-w64-x86_64-git|mingw-w64-i686-git|msys2-runtime|mingw-w64-x86_64-git-credential-manager|mingw-w64-i686-git-credential-manager|mingw-w64-i686-git-lfs|mingw-w64-x86_64-git-lfs|curl|mingw-w64-i686-curl|mingw-w64-x86_64-curl|mingw-w64-i686-wintoast|mingw-w64-x86_64-wintoast|bash|heimdal|perl|openssh)
+		git-extra|mingw-w64-x86_64-git|mingw-w64-i686-git|msys2-runtime|mingw-w64-x86_64-git-credential-manager|mingw-w64-i686-git-credential-manager|mingw-w64-x86_64-git-credential-manager-core|mingw-w64-i686-git-credential-manager-core|mingw-w64-i686-git-lfs|mingw-w64-x86_64-git-lfs|curl|mingw-w64-i686-curl|mingw-w64-x86_64-curl|mingw-w64-i686-wintoast|mingw-w64-x86_64-wintoast|bash|heimdal|perl|openssh)
 			url="$azure_blobs_source_url/$filename"
 			sf1_url=
 			sf2_url=

--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -98,6 +98,7 @@ sdk () {
 			mingw-w64-cv2pdb \
 			mingw-w64-git \
 			mingw-w64-git-credential-manager \
+			mingw-w64-git-credential-manager-core \
 			mingw-w64-git-lfs \
 			mingw-w64-git-sizer \
 			mingw-w64-wintoast \

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1136,13 +1136,6 @@ begin
   ShellExec('','https://stackoverflow.blog/2017/05/23/stack-overflow-helping-one-million-developers-exit-vim/','','',SW_SHOW,ewNoWait,ExitStatus);
 end;
 
-procedure OpenGCMHomepage(Sender:TObject);
-var
-  ExitStatus:Integer;
-begin
-  ShellExec('','https://github.com/Microsoft/Git-Credential-Manager-for-Windows','','',SW_SHOW,ewNoWait,ExitStatus);
-end;
-
 procedure OpenSymlinksWikiPage(Sender:TObject);
 var
   ExitStatus:Integer;

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -82,7 +82,7 @@ pacman_list () {
 
 # Packages that have been added after Git SDK 1.0.0 was released...
 required=
-for req in mingw-w64-$ARCH-git-credential-manager $SH_FOR_REBASE \
+for req in mingw-w64-$ARCH-git-credential-manager mingw-w64-$ARCH-git-credential-manager-core $SH_FOR_REBASE \
 	$(test -n "$MINIMAL_GIT" || echo \
 		mingw-w64-$ARCH-connect git-flow unzip docx2txt \
 		mingw-w64-$ARCH-antiword mingw-w64-$ARCH-odt2txt \
@@ -97,7 +97,7 @@ test -z "$required" ||
 pacman -Sy --noconfirm $required >&2 ||
 die "Could not install required packages: $required"
 
-packages="mingw-w64-$ARCH-git mingw-w64-$ARCH-git-credential-manager
+packages="mingw-w64-$ARCH-git mingw-w64-$ARCH-git-credential-manager mingw-w64-$ARCH-git-credential-manager-core
 git-extra openssh $UTIL_PACKAGES"
 if test -z "$MINIMAL_GIT"
 then

--- a/mingw-w64-git-credential-manager-core/PKGBUILD
+++ b/mingw-w64-git-credential-manager-core/PKGBUILD
@@ -1,0 +1,29 @@
+# Maintainer: Johannes Schindelin/Matthew J Cheetham
+
+_realname="git-credential-manager-core"
+pkgbase="mingw-w64-${_realname}"
+pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
+pkgver=2.0.164.25618
+pkgrel=0
+_realver=$pkgver
+_realtag=v${pkgver%.*}-beta
+pkgdesc="Credential Manager for Git"
+arch=('any')
+project_url="https://github.com/microsoft/Git-Credential-Manager-Core"
+zip_url="${project_url}/releases/download/${_realtag}/gcmcore-win-x86-${_realver}.zip"
+src_zip_url="${project_url}/archive/${_realtag}.zip"
+license=('MIT')
+groups=('VCS')
+
+source=("${zip_url}" "$src_zip_url")
+
+sha256sums=('a9d424bb56e5571a9a80e195376aa7c7fcf5f890fe1029f45eb81be04eb9d264'
+            '7b07bf3317ae4e47446a93febe2b6fcde6f409bd3ab3b78358b6dfcc13ab5592')
+
+package() {
+  prefix="$pkgdir/${MINGW_PREFIX}"
+  srcdir2="${srcdir}/"
+  install -d -m755 "${prefix}"/libexec/git-core
+  install -m755 "$srcdir2"/*.{dll,exe} "${prefix}"/libexec/git-core
+  install -d -m755 "${prefix}"/doc/git-credential-manager-core
+}

--- a/please.sh
+++ b/please.sh
@@ -423,6 +423,15 @@ set_package () {
 		type=MINGW
 		pkgpath=/usr/src/build-extra/mingw-w64-git-credential-manager
 		;;
+	mingw-w64-git-credential-manager-core)
+		type=MINGW
+		pkgpath=/usr/src/build-extra/mingw-w64-git-credential-manager-core
+		;;
+	gcm|credential-manager-core|git-credential-manager-core)
+		package=mingw-w64-git-credential-manager-core
+		type=MINGW
+		pkgpath=/usr/src/build-extra/mingw-w64-git-credential-manager-core
+		;;
 	lfs|git-lfs|mingw-w64-git-lfs)
 		package=mingw-w64-git-lfs
 		type=MINGW
@@ -2926,6 +2935,41 @@ upgrade () { # [--directory=<artifacts-directory>] [--only-mingw] [--no-build] [
 		 create_bundle_artifact) &&
 		url=https://github.com/$repo/releases/tag/$tag_name &&
 		release_notes_feature='Comes with [Git Credential Manager v'$version']('"$url"').'
+		;;
+	mingw-w64-git-credential-manager-core)
+		repo=microsoft/Git-Credential-Manager-Core
+		url=https://api.github.com/repos/$repo/releases/latest
+		release="$(curl --netrc -s $url)"
+		test -n "$release" ||
+		die "Could not determine the latest version of %s\n" "$package"
+		tag_name="$(echo "$release" |
+			sed -n 's/^  "tag_name": "\(.*\)",\?$/\1/p')"
+		zip_name="$(echo "$release" | sed -n \
+			's/.*"browser_download_url":.*\/\(gcm.*\.zip\).*/\1/p')"
+		version=${tag_name#v}
+		zip_prefix=${zip_name%$version.zip}
+		if test "$zip_prefix" = "$zip_name"
+		then
+			# The version in the tag and the zip file name differ
+			zip_replace='s/^\(zip_url=.*\/\)gcm[^"]*/\1'$zip_name/
+		else
+			zip_replace='s/^\(zip_url=.*\/\)gcm[^"]*/\1'$zip_prefix'${_realver}.zip/'
+		fi
+		src_zip_prefix=${tag_name%$version}
+		(cd "$sdk64$pkgpath" &&
+		 sed -i -e "s/^\\(pkgver=\\).*/\1$version/" -e "$zip_replace" \
+		 -e 's/^\(src_zip_url=.*\/\).*\(\$.*\)/\1'$src_zip_prefix'\2/' \
+		 -e 's/^pkgrel=.*/pkgrel=1/' PKGBUILD &&
+		 updpkgsums &&
+		 srcdir2="$(unzip -l $zip_prefix$version.zip | sed -n \
+		   's/^.\{28\} *\(.*\/\)\?git-credential-manager-core.exe/\1/p')" &&
+		 sed -i -e 's/^\(  srcdir2=\).*/\1"${srcdir}\/'$srcdir2'"/' \
+			PKGBUILD &&
+		 maybe_force_pkgrel "$force_pkgrel" &&
+		 git commit -s -m "Upgrade $package to $version${force_pkgrel:+-$force_pkgrel}" PKGBUILD &&
+		 create_bundle_artifact) &&
+		url=https://github.com/$repo/releases/tag/$tag_name &&
+		release_notes_feature='Comes with [Git Credential Manager Core v'$version']('"$url"').'
 		;;
 	git-extra)
 		(cd "$sdk64$pkgpath" &&


### PR DESCRIPTION
Add Git Credential Manager (GCM) Core to the Git for Windows installer.
GCM Core is the cross-platform credential helper that will eventually
replace the exiting GCM for Windows (and GCM for Mac/Linux) helpers.

Move the "Enable Git Credential Manager" option to its own, new page
where you can select between the three options: none, GCM, or GCM Core.

Reusing the same "Use Credential Manager" replay choice key, we can
ensure that existing choices for GCM for Windows are carried forwards to
the new three-option choice. Enabled = GCM for Windows, Disabled = None,
and a new option Core = GCM Core.

Because GCM Core is still in beta we do not make it the default yet; GCM
for Windows is the default.

Signed-off-by: Matthew John Cheetham <mjcheetham@outlook.com>

![image](https://user-images.githubusercontent.com/5658207/85318640-3be3fa00-b4b8-11ea-8c99-c59237bce6ed.png)