### PR TITLE
Fix recall of experimental pseudo console support setting

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2143,7 +2143,7 @@ begin
     RdbExperimentalOptions[GP_EnablePCon]:=CreateCheckBox(ExperimentalOptionsPage,'Enable experimental support for pseudo consoles.','<RED>(NEW!)</RED> This allows running native console programs like Node or Python in a'+#13+'Git Bash window without using winpty, but it still has known bugs.',TabOrder,Top,Left);
 
     // Restore the settings chosen during a previous install
-    RdbExperimentalOptions[GP_EnablePCon].Checked:=ReplayChoice('Enable Pseudo Console Support','Auto')='Disabled';
+    RdbExperimentalOptions[GP_EnablePCon].Checked:=ReplayChoice('Enable Pseudo Console Support','Auto')='Enabled';
 #endif
 
 #endif


### PR DESCRIPTION
The Pseudo Console support experimental option was not being recalled
correctly on subsequent installs. If the option was unset it would
default to unchecked (correct), but if the option was set to 'disabled'
then it would become default checked!

Signed-off-by: Matthew John Cheetham <mjcheetham@outlook.com>