### PR TITLE
sdk create-desktop-icon: use correct path to Desktop

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -71,7 +71,8 @@ sdk () {
 		x86_64) bitness=" 64-bit";;
 		*) bitness=;;
 		esac &&
-		desktop_icon_path="$USERPROFILE/Desktop/Git SDK$bitness.lnk" &&
+		desktop_icon_path="$(reg query 'HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders' //v Desktop |
+			sed -ne 'y/\\/\//' -e 's/.*REG_SZ *//p')/Git SDK$bitness.lnk" &&
 		if test -n "$force" || test ! -f "$desktop_icon_path"
 		then
 			create-shortcut.exe --icon-file /msys2.ico --work-dir \


### PR DESCRIPTION
We used to hard-code the default Desktop path, but that can be overridden (and often is, e.g. when the user follows OneDrive's suggestion to back up the Desktop folder on OneDrive).

This fixes https://github.com/git-for-windows/git-sdk-64/issues/22