### PR TITLE
Installer: drop special treatment for Windows versions prior to Vista

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -553,66 +553,26 @@ begin
         Exit;
     end;
 
-    GetWindowsVersionEx(Version);
-
-    // Use the Restart Manager API when installing the shell extension on Windows Vista and above.
-    if Version.Major>=6 then begin
-        SetArrayLength(Modules,17);
-        Modules[0]:=AppDir+'\usr\bin\msys-2.0.dll';
-        Modules[1]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll';
-        Modules[2]:=AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll';
-        Modules[3]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll';
-        Modules[4]:=AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll';
-        Modules[5]:=AppDir+'\git-cheetah\git_shell_ext.dll';
-        Modules[6]:=AppDir+'\git-cheetah\git_shell_ext64.dll';
-        Modules[7]:=AppDir+'\git-cmd.exe';
-        Modules[8]:=AppDir+'\git-bash.exe';
-        Modules[9]:=AppDir+'\bin\bash.exe';
-        Modules[10]:=AppDir+'\bin\git.exe';
-        Modules[11]:=AppDir+'\bin\sh.exe';
-        Modules[12]:=AppDir+'\cmd\git.exe';
-        Modules[13]:=AppDir+'\cmd\gitk.exe';
-        Modules[14]:=AppDir+'\cmd\git-gui.exe';
-        Modules[15]:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
-        Modules[16]:=AppDir+'\usr\bin\bash.exe';
-        SessionHandle:=FindProcessesUsingModules(Modules,Processes);
-    end else begin
-        SetArrayLength(Modules,15);
-        Modules[0]:=AppDir+'\usr\bin\msys-2.0.dll';
-        Modules[1]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll';
-        Modules[2]:=AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll';
-        Modules[3]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll';
-        Modules[4]:=AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll';
-        Modules[5]:=AppDir+'\git-cmd.exe';
-        Modules[6]:=AppDir+'\git-bash.exe';
-        Modules[7]:=AppDir+'\bin\bash.exe';
-        Modules[8]:=AppDir+'\bin\git.exe';
-        Modules[9]:=AppDir+'\bin\sh.exe';
-        Modules[10]:=AppDir+'\cmd\git.exe';
-        Modules[11]:=AppDir+'\cmd\gitk.exe';
-        Modules[12]:=AppDir+'\cmd\git-gui.exe';
-        Modules[13]:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
-        Modules[14]:=AppDir+'\usr\bin\bash.exe';
-        SessionHandle:=FindProcessesUsingModules(Modules,ProcsCloseRequired);
-
-        SetArrayLength(Modules,2);
-        Modules[0]:=AppDir+'\git-cheetah\git_shell_ext.dll';
-        Modules[1]:=AppDir+'\git-cheetah\git_shell_ext64.dll';
-        SessionHandle:=FindProcessesUsingModules(Modules,ProcsCloseOptional) or SessionHandle;
-
-        // Misuse the "Restartable" flag to indicate which processes are required
-        // to be closed before setup can continue, and which just should be closed
-        // in order to make changes take effect immediately.
-        SetArrayLength(Processes,GetArrayLength(ProcsCloseRequired)+GetArrayLength(ProcsCloseOptional));
-        for i:=0 to GetArrayLength(ProcsCloseRequired)-1 do begin
-            Processes[i]:=ProcsCloseRequired[i];
-            Processes[i].Restartable:=False;
-        end;
-        for i:=0 to GetArrayLength(ProcsCloseOptional)-1 do begin
-            Processes[GetArrayLength(ProcsCloseRequired)+i]:=ProcsCloseOptional[i];
-            Processes[GetArrayLength(ProcsCloseRequired)+i].Restartable:=True;
-        end;
-    end;
+    // Use the Restart Manager API when installing the shell extension.
+    SetArrayLength(Modules,17);
+    Modules[0]:=AppDir+'\usr\bin\msys-2.0.dll';
+    Modules[1]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll';
+    Modules[2]:=AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll';
+    Modules[3]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll';
+    Modules[4]:=AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll';
+    Modules[5]:=AppDir+'\git-cheetah\git_shell_ext.dll';
+    Modules[6]:=AppDir+'\git-cheetah\git_shell_ext64.dll';
+    Modules[7]:=AppDir+'\git-cmd.exe';
+    Modules[8]:=AppDir+'\git-bash.exe';
+    Modules[9]:=AppDir+'\bin\bash.exe';
+    Modules[10]:=AppDir+'\bin\git.exe';
+    Modules[11]:=AppDir+'\bin\sh.exe';
+    Modules[12]:=AppDir+'\cmd\git.exe';
+    Modules[13]:=AppDir+'\cmd\gitk.exe';
+    Modules[14]:=AppDir+'\cmd\git-gui.exe';
+    Modules[15]:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
+    Modules[16]:=AppDir+'\usr\bin\bash.exe';
+    SessionHandle:=FindProcessesUsingModules(Modules,Processes);
 
     ManualClosingRequired:=False;
 
@@ -2353,24 +2313,13 @@ begin
         Result:=(GetArrayLength(Processes)=0);
 
         if not Result then begin
-            GetWindowsVersionEx(Version);
-            if Version.Major>=6 then begin
-                Result:=(SuppressibleMsgBox(
-                    'If you continue without closing the listed applications they will be closed and restarted automatically.' + #13 + #13 +
-                    'Are you sure you want to continue?'
-                ,   mbConfirmation
-                ,   MB_YESNO
-                ,   IDYES
-                )=IDYES);
-            end else begin
-                Result:=(SuppressibleMsgBox(
-                    'If you continue without closing the listed applications you will need to log off and on again before changes take effect.' + #13 + #13 +
-                    'Are you sure you want to continue anyway?'
-                ,   mbConfirmation
-                ,   MB_YESNO
-                ,   IDNO
-                )=IDYES);
-            end;
+            Result:=(SuppressibleMsgBox(
+                'If you continue without closing the listed applications they will be closed and restarted automatically.' + #13 + #13 +
+                'Are you sure you want to continue?'
+            ,   mbConfirmation
+            ,   MB_YESNO
+            ,   IDYES
+            )=IDYES);
         end;
     end;
 end;


### PR DESCRIPTION
We've dropped support for Windows versions older than Windows Vista
years ago. There's no reason to keep these special code paths  in the
installer just to work around missing features in these old versions.

Since we error out early on old Windows versions, this code was unreachable.