### PR TITLE
installer: allow Pseudo Console support to be re-disabled

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -259,6 +259,9 @@ Type: dirifempty; Name: {app}\{#MINGW_BITNESS}\libexec
 Type: dirifempty; Name: {app}\{#MINGW_BITNESS}
 Type: dirifempty; Name: {app}
 
+; Delete Git Bash options
+Type: files; Name: {app}\etc\git-bash.config
+
 [Code]
 #include "helpers.inc.iss"
 #include "environment.inc.iss"


### PR DESCRIPTION
As noted by @satsuper in https://github.com/git-for-windows/git/issues/2729#issuecomment-653090026, when a user enabled support for Pseudo Consoles and then reinstalled to disable it, by mistake the Pseudo Console support would _still_ be enabled.

The reason? We only write `/etc/git-bash.config` to enable the Pseudo Console support, but not when we disable it (because it is disabled by default, anyway). However, we failed to remove that file upon uninstall/upgrade.