### PR TITLE
Added known issue about command hints for non-POSIX shells.

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -23,7 +23,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
 * As Git for Windows is shipped without Python support, `git p4` (which is backed by a Python script) is not supported.
 * The Quick Launch icon will only be installed for the user running setup (typically the Administrator). This is a technical restriction and will not change.
 * Older versions of the Windows Explorer do *not* calculate Git for Windows' on-disk size correctly, as it is unaware of hard links. Therefore, it might look like Git for Windows takes up 1.5GB when in reality it is about a third of that.
-* GIT command hints are designed for a POSIX shell, this can lead to issues when using them **AS IS** in non-POSIX shells like PowerShell. ([GH-2785](https://github.com/git-for-windows/git/issues/2785))
+* Git command hints are designed for a POSIX shell, this can lead to issues when using them **as is** in non-POSIX shells like PowerShell, [such as this ticket](https://github.com/git-for-windows/git/issues/2785).
 
 Should you encounter other problems, please first search [the bug tracker](https://github.com/git-for-windows/git/issues) (also look at the closed issues) and [the mailing list](http://groups.google.com/group/git-for-windows), chances are that the problem was reported already. Also make sure that you use an up to date Git for Windows version (or a [current snapshot build](https://wingit.blob.core.windows.net/files/index.html)). If it has not been reported, please follow [our bug reporting guidelines](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) and [report the bug](https://github.com/git-for-windows/git/issues/new).
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -23,6 +23,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
 * As Git for Windows is shipped without Python support, `git p4` (which is backed by a Python script) is not supported.
 * The Quick Launch icon will only be installed for the user running setup (typically the Administrator). This is a technical restriction and will not change.
 * Older versions of the Windows Explorer do *not* calculate Git for Windows' on-disk size correctly, as it is unaware of hard links. Therefore, it might look like Git for Windows takes up 1.5GB when in reality it is about a third of that.
+* GIT command hints are designed for a POSIX shell, this can lead to issues when using them **AS IS** in non-POSIX shells like PowerShell. ([GH-2785](https://github.com/git-for-windows/git/issues/2785))
 
 Should you encounter other problems, please first search [the bug tracker](https://github.com/git-for-windows/git/issues) (also look at the closed issues) and [the mailing list](http://groups.google.com/group/git-for-windows), chances are that the problem was reported already. Also make sure that you use an up to date Git for Windows version (or a [current snapshot build](https://wingit.blob.core.windows.net/files/index.html)). If it has not been reported, please follow [our bug reporting guidelines](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) and [report the bug](https://github.com/git-for-windows/git/issues/new).
 


### PR DESCRIPTION
Closes git-for-windows/git#2785