### PR TITLE
installer: only use SW_HIDE on custom editors that use a wrapper script

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1483,6 +1483,8 @@ var
     InputText,OutputText:AnsiString;
     TmpFile:String;
     Res:Longint;
+    CustomEditorExt:String;
+    Show:Integer;
 begin
     if not PathIsValidExecutable(CustomEditorPath) then begin
         Wizardform.NextButton.Enabled:=False;
@@ -1494,7 +1496,13 @@ begin
     InputText:='Please modify this text, e.g. delete it, then save it and exit the editor.'
     SaveStringToFile(TmpFile,InputText,False);
 
-    if not ShellExec('',CustomEditorPath,CustomEditorOptions+' "'+TmpFile+'"','',SW_HIDE,ewWaitUntilTerminated,Res) then begin
+    CustomEditorExt:=ExtractFileExt(CustomEditorPath);
+    if (CompareText(CustomEditorExt,'.bat')=0) or (CompareText(CustomEditorExt,'.cmd')=0) then
+        Show:=SW_HIDE
+    else
+        Show:=SW_SHOW;
+
+    if not ShellExec('',CustomEditorPath,CustomEditorOptions+' "'+TmpFile+'"','',Show,ewWaitUntilTerminated,Res) then begin
         Wizardform.NextButton.Enabled:=False;
         SuppressibleMsgBox('Could not launch: "'+CustomEditorPath+'"',mbError,MB_OK,IDOK);
         Exit;


### PR DESCRIPTION
We're currently assuming that directly called editors ignore our request
to hide their initial window, but some editors honor that request.
This causes the installer to get stuck waiting for user input in a
hidden window.

This fixes git-for-windows/git#2684.