### PR TITLE
Upgrade users to Git Credential Manager Core

### DIFF
--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -491,7 +491,7 @@ out_of_memory:
 	selected_helper = 0;
 
 	if (!previously_selected_helper)
-		previously_selected_helper = L"manager";
+		previously_selected_helper = L"manager-core";
 
 	for (p = env; *p; ) {
 		WCHAR *q = wcschr(p, L';');

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2042,7 +2042,7 @@ begin
     RdbGitCredentialManager[GCM_None]:=CreateRadioButton(GitCredentialManagerPage,'None','Do not use a credential helper.',TabOrder,Top,Left);
 
     // 2nd choice
-    RdbGitCredentialManager[GCM_Classic]:=CreateRadioButton(GitCredentialManagerPage,'Git Credential Manager','The <A HREF=https://github.com/Microsoft/Git-Credential-Manager-for-Windows>Git Credential Manager for Windows</A> handles credentials e.g. for Azure'+#13+'DevOps and GitHub (requires .NET framework v4.5.1 or later).',TabOrder,Top,Left);
+    RdbGitCredentialManager[GCM_Classic]:=CreateRadioButton(GitCredentialManagerPage,'Git Credential Manager','(DEPRECATED) The <A HREF=https://github.com/Microsoft/Git-Credential-Manager-for-Windows>Git Credential Manager for Windows</A> handles credentials e.g. for Azure'+#13+'DevOps and GitHub (requires .NET framework v4.5.1 or later).',TabOrder,Top,Left);
 
     // 3rd choice
     RdbGitCredentialManager[GCM_Core]:=CreateRadioButton(GitCredentialManagerPage,'Git Credential Manager Core','<RED>(NEW!)</RED> Use the new, <A HREF=https://github.com/microsoft/Git-Credential-Manager-Core>cross-platform version of the Git Credential Manager</A>.'+#13+'See more information about the future of Git Credential Manager <A HREF=https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/docs/faq.md#about-the-project>here</A>.',TabOrder,Top,Left);
@@ -2055,12 +2055,17 @@ begin
         RdbGitCredentialManager[GCM_Core].Checked:=False;
         RdbGitCredentialManager[GCM_Core].Enabled:=False;
     end else begin
-        case ReplayChoice('Use Credential Manager','Enabled') of
+        case ReplayChoice('Use Credential Manager','Core') of
             'Disabled': RdbGitCredentialManager[GCM_None].Checked:=True;
             'Enabled': RdbGitCredentialManager[GCM_Classic].Checked:=True;
             'Core': RdbGitCredentialManager[GCM_Core].Checked:=True;
         else
             RdbGitCredentialManager[GCM_Classic].Checked:=True;
+        end;
+        // Auto-upgrade GCM to GCM Core in version v2.29.0
+        if RdbGitCredentialManager[GCM_Classic].Checked and (PreviousGitForWindowsVersion<>'') and IsDowngrade(PreviousGitForWindowsVersion,'2.29.0') then begin
+            RdbGitCredentialManager[GCM_Core].Checked:=True;
+            AddToSet(CustomPagesWithUnseenOptions,GitCredentialManagerPage);
         end;
     end;
 

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -108,7 +108,7 @@ die "Could not generate file list"
 mkdir -p "$SCRIPT_PATH/root/${etc_gitconfig%/*}" &&
 cp /"$etc_gitconfig" "$SCRIPT_PATH/root/$etc_gitconfig" &&
 git config -f "$SCRIPT_PATH/root/$etc_gitconfig" \
-	credential.helper manager ||
+	credential.helper manager-core ||
 die "Could not configure Git-Credential-Manager as default"
 test 64 != $BITNESS ||
 git config -f "$SCRIPT_PATH/root/$etc_gitconfig" --unset pack.packSizeLimit


### PR DESCRIPTION
As per [GitHub's announcement](https://github.blog/changelog/2019-08-08-password-based-http-basic-authentication-deprecation-and-removal), password-based authentication is deprecated and will be removed in the near future.

Git Credential Manager for Windows (which is currently still the recommended default in Git for Windows) only supports that method when authenticating with GitHub, and it is unlikely that it will ever learn any other method: Git Credential Manager Core is the designated successor and all of the development effort goes into that project.

So let's upgrade Git Credential Manager for Windows users to Git Credential Manager Core in Git for Windows v2.29.0; upgrading in any later version would most likely be missing the date when GitHub turns off password-based authentication, and that in turn would most likely cause a lot of turmoil with our users.