### PR TITLE
Prevent missing DLLs in Git for Windows

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+thisdir="$(cd "$(dirname "$0")" && pwd)" ||
+die "Could not determine script directory"
+
+sys_dlls="$(ls "$SYSTEMROOT/system32"/*.dll "$SYSTEMROOT/system32"/*.DLL "$SYSTEMROOT/system32"/*.drv | tr A-Z a-z)" ||
+die "Could not enumerate system .dll files"
+
+LF='
+'
+
+ARCH="$(uname -m)" ||
+die "Could not determine architecture"
+
+case "$ARCH" in
+i686) BITNESS=32;;
+x86_64) BITNESS=64;;
+*) die "Unhandled architecture: $ARCH";;
+esac
+
+if test -t 2
+then
+	next_line='\033[K\r'
+else
+	next_line='\n'
+fi
+
+all_files="$(export ARCH BITNESS && "$thisdir"/make-file-list.sh | tr A-Z a-z)" &&
+usr_bin_dlls="$(echo "$all_files" | grep '^usr/bin/[^/]*\.dll$')" &&
+mingw_bin_dlls="$(echo "$all_files" | grep '^mingw'$BITNESS'/bin/[^/]*\.dll$')" &&
+dirs="$(echo "$all_files" | sed -n 's/[^/]*\.\(dll\|exe\)$//p' | sort | uniq)" &&
+for dir in $dirs
+do
+	printf "dir: $dir$next_line\\r" >&2
+
+	case "$dir" in
+	usr/*) dlls="$dlls$LF$usr_bin_dlls$LF";;
+	mingw$BITNESS/*) dlls="$dlls$LF$mingw_bin_dlls$LF";;
+	*) dlls="$sys_dlls$LF";;
+	esac
+
+	/usr/bin/objdump -p $(echo "$all_files" | sed -ne 's,[][],\\&,g' -e "s,^$dir[^/]*\.\(dll\|exe\)$,/&,p") |
+	tr A-Z\\r a-z\  |
+	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' |
+	while read a b c d
+	do
+		case "$a,$b" in
+		*.exe:,*|*.dll:,*) current="${a%:}";;
+		dll,name:)
+			case "$dlls" in
+			*"/$c$LF"*) ;; # okay, it's included
+			*) echo "$current is missing $c" >&2;;
+			esac
+			;;
+		esac
+	done
+done
+printf "$next_line" >&2

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -51,7 +51,13 @@ do
 	do
 		case "$a,$b" in
 		*.exe:,*|*.dll:,*) current="${a%:}";;
-		dll,name:)
+		*.dll,"=>") # `ldd` output
+			case "$dlls" in
+			*"/$a$LF"*) ;; # okay, it's included
+			*) echo "$current is missing $a" >&2;;
+			esac
+			;;
+		dll,name:) # `objdump -p` output
 			case "$dlls" in
 			*"/$c$LF"*) ;; # okay, it's included
 			*) echo "$current is missing $c" >&2;;

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -148,6 +148,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../bin/\(autopoint\|[a-z]*-config\)$' \
 	-e '^/mingw../bin/lib\(asprintf\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|quadmath\|stdc++\)[^/]*\.dll$' \
 	-e '^/mingw../bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\)[^/]*\.exe$' \
+	-e '^/mingw../bin/recode-sr-latin.exe$' \
 	-e '^/mingw../bin/\(cert\|p11\|psk\|srp\)tool.exe$' \
 	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \
 	-e '^/mingw../.*/git-\(remote-testsvn\|shell\)\.exe$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -146,8 +146,9 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../itcl/' \
 	-e '^/mingw../t\(cl\|k\)[^/]*/\(demos\|msgs\|encoding\|tzdata\)/' \
 	-e '^/mingw../bin/\(autopoint\|[a-z]*-config\)$' \
-	-e '^/mingw../bin/lib\(asprintf\|gettext\|gnutlsxx\|pcre[013-9a-oq-z]\|quadmath\|stdc++\)[^/]*\.dll$' \
+	-e '^/mingw../bin/lib\(asprintf\|gettext\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|quadmath\|stdc++\)[^/]*\.dll$' \
 	-e '^/mingw../bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\)[^/]*\.exe$' \
+	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \
 	-e '^/mingw../.*/git-\(remote-testsvn\|shell\)\.exe$' \
 	-e '^/mingw../.*/git-cvsserver.*$' \
 	-e '^/mingw../.*/gitweb/' \
@@ -161,6 +162,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../share/git\(k\|-gui\)/lib/msgs/' \
 	-e '^/mingw../share/nghttp2/' \
 	-e '^/usr/bin/msys-\(db\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
+	-e '^/usr/bin/msys-\(gmpxx\|gnutlsxx\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/dumper\.exe$' \
 	-e '^/usr/share.*/magic$' \
 	-e '^/usr/share/perl5/core_perl/Unicode/' \
@@ -194,7 +196,7 @@ else
 		-e '^/mingw../bin/\(gettext\.sh\|gettextize\)$' \
 		-e '^/mingw../bin/\(gitk\|git-upload-archive\.exe\)$' \
 		-e '^/mingw../bin/lib\(atomic\|charset\)-.*\.dll$' \
-		-e '^/mingw../bin/lib\(gcc_s_seh\|gmpxx\)-.*\.dll$' \
+		-e '^/mingw../bin/libgcc_s_seh-.*\.dll$' \
 		-e '^/mingw../bin/lib\(gomp\|jansson\|minizip\)-.*\.dll$' \
 		-e '^/mingw../bin/libvtv.*\.dll$' \
 		-e '^/mingw../bin/libpcreposix.*\.dll$' \
@@ -247,14 +249,14 @@ else
 		-e '^/usr/bin/msys-\(atomic\|charset\|cilkrts\)-.*\.dll$' \
 		-e '^/usr/bin/msys-\(hdb\|kadm5\|kafs\|kdc\|otp\|sl\).*\.dll$' \
 		-e '^/usr/bin/msys-sqlite3[a-z].*\.dll$' \
-		-e '^/usr/bin/msys-\(gmpxx\|gomp.*\|vtv.*\)-.*\.dll$' \
+		-e '^/usr/bin/msys-\(gomp.*\|vtv.*\)-.*\.dll$' \
 		-e '^/usr/lib/\(awk\|coreutils\|gawk\|openssl\|ssh\)/' \
 		-e '^/usr/libexec/\(bigram\|code\|frcode\)\.exe$' \
 		-e '^/usr/share/\(cygwin\|git\)/' \
 		-e '^/usr/ssl/misc/' \
 		-e '^/usr/bin/\(captoinfo\|clear\|infocmp\|infotocap\)\.exe$' \
 		-e '^/usr/bin/\(reset\|tabs\|tic\|toe\|tput\|tset\)\.exe$' \
-		-e '^/usr/bin/msys-\(formw6\|menuw6\|ncurses++w6\)\.dll$' \
+		-e '^/usr/bin/msys-\(formw6\|menuw6\)\.dll$' \
 		-e '^/usr/bin/msys-\(panelw6\|ticw6\)\.dll$' \
 		-e '^/usr/\(lib\|share\)/terminfo/' -e '^/usr/share/tabset/' \
 		-e "^\\($(echo $EXTRA_FILE_EXCLUDES |

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -166,7 +166,8 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/msys-\(db\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
 	-e '^/usr/bin/msys-\(gmpxx\|gnutlsxx\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/msys-svn_swig_\(py\|ruby\)-.*\.dll$' \
-	-e '^/usr/bin/dumper\.exe$' \
+	-e '^/usr/bin/\(dumper\|sasl.*\)\.exe$' \
+	-e '^/usr/lib/sasl2/msys-sasldb-.*\.dll$' \
 	-e '^/usr/share.*/magic$' \
 	-e '^/usr/share/perl5/core_perl/Unicode/' \
 	-e '^/usr/share/perl5/core_perl/pods/' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -167,7 +167,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/msys-\(gmpxx\|gnutlsxx\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/msys-svn_swig_\(py\|ruby\)-.*\.dll$' \
 	-e '^/usr/bin/\(dumper\|sasl.*\)\.exe$' \
-	-e '^/usr/lib/sasl2/msys-sasldb-.*\.dll$' \
+	-e '^/usr/lib/gio/' -e '^/usr/lib/sasl2/msys-sasldb-.*\.dll$' \
 	-e '^/usr/share.*/magic$' \
 	-e '^/usr/share/perl5/core_perl/Unicode/' \
 	-e '^/usr/share/perl5/core_perl/pods/' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -165,6 +165,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../share/nghttp2/' \
 	-e '^/usr/bin/msys-\(db\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
 	-e '^/usr/bin/msys-\(gmpxx\|gnutlsxx\|xml2\|xslt\|exslt\)-.*\.dll$' \
+	-e '^/usr/bin/msys-svn_swig_\(py\|ruby\)-.*\.dll$' \
 	-e '^/usr/bin/dumper\.exe$' \
 	-e '^/usr/share.*/magic$' \
 	-e '^/usr/share/perl5/core_perl/Unicode/' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -197,10 +197,12 @@ else
 		-e '^/git-\(bash\|cmd\)\.exe$' \
 		-e '^/mingw../bin/\(certtool\.exe\|create-shortcut\.exe\)$' \
 		-e '^/mingw../bin/\(curl\.exe\|envsubst\.exe\|gettext\.exe\)$' \
+		-e '^/mingw../bin/.*-\(inflate\|deflate\)hd\.exe$' \
 		-e '^/mingw../bin/\(gettext\.sh\|gettextize\)$' \
 		-e '^/mingw../bin/\(gitk\|git-upload-archive\.exe\)$' \
 		-e '^/mingw../bin/lib\(atomic\|charset\)-.*\.dll$' \
 		-e '^/mingw../bin/libgcc_s_seh-.*\.dll$' \
+		-e '^/mingw../bin/libjemalloc\.dll$' \
 		-e '^/mingw../bin/lib\(gomp\|jansson\|minizip\)-.*\.dll$' \
 		-e '^/mingw../bin/libvtv.*\.dll$' \
 		-e '^/mingw../bin/libpcreposix.*\.dll$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -146,8 +146,9 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../itcl/' \
 	-e '^/mingw../t\(cl\|k\)[^/]*/\(demos\|msgs\|encoding\|tzdata\)/' \
 	-e '^/mingw../bin/\(autopoint\|[a-z]*-config\)$' \
-	-e '^/mingw../bin/lib\(asprintf\|gettext\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|quadmath\|stdc++\)[^/]*\.dll$' \
+	-e '^/mingw../bin/lib\(asprintf\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|quadmath\|stdc++\)[^/]*\.dll$' \
 	-e '^/mingw../bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\)[^/]*\.exe$' \
+	-e '^/mingw../bin/\(cert\|p11\|psk\|srp\)tool.exe$' \
 	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \
 	-e '^/mingw../.*/git-\(remote-testsvn\|shell\)\.exe$' \
 	-e '^/mingw../.*/git-cvsserver.*$' \


### PR DESCRIPTION
A recent snapshot was missing `libzstd.dll` although it was required to load `libcurl-4.dll`. With this script, which I intend to hook up in an automated build, we should be able to safeguard against similar issues in the future.

While at it, clean up the exclusion patterns in `make-file-list.sh` a bit more.