### PR TITLE
Exclude unneeded DLLs from the installer/MinGit

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -146,15 +146,15 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../itcl/' \
 	-e '^/mingw../t\(cl\|k\)[^/]*/\(demos\|msgs\|encoding\|tzdata\)/' \
 	-e '^/mingw../bin/\(autopoint\|[a-z]*-config\)$' \
-	-e '^/mingw../bin/lib\(asprintf\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|quadmath\|stdc++\)[^/]*\.dll$' \
+	-e '^/mingw../bin/lib\(asprintf\|brotlienc\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|pcre2-[13p]\|quadmath\|stdc++\|zip\)[^/]*\.dll$' \
+	-e '^/mingw../bin/lib\(atomic\|charset\|ffi\|gomp\|systre\|tasn1\)-[0-9]*\.dll$' \
 	-e '^/mingw../bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\)[^/]*\.exe$' \
 	-e '^/mingw../bin/recode-sr-latin.exe$' \
 	-e '^/mingw../bin/\(cert\|p11\|psk\|srp\)tool.exe$' \
-	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \
 	-e '^/mingw../.*/git-\(remote-testsvn\|shell\)\.exe$' \
 	-e '^/mingw../.*/git-cvsserver.*$' \
 	-e '^/mingw../.*/gitweb/' \
-	-e '^/mingw../lib/tdbc' \
+	-e '^/mingw../lib/\(dde\|itcl\|sqlite\|tdbc\)' \
 	-e '^/mingw../libexec/git-core/git-archimport$' \
 	-e '^/mingw../share/doc/git-doc/git-archimport' \
 	-e '^/mingw../libexec/git-core/git-cvsimport$' \
@@ -163,11 +163,16 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../share/doc/git-doc/git-cvsimport' \
 	-e '^/mingw../share/git\(k\|-gui\)/lib/msgs/' \
 	-e '^/mingw../share/nghttp2/' \
-	-e '^/usr/bin/msys-\(db\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
-	-e '^/usr/bin/msys-\(gmpxx\|gnutlsxx\|xml2\|xslt\|exslt\)-.*\.dll$' \
+	-e '^/usr/bin/msys-\(db\|curl\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
+	-e '^/usr/bin/msys-\(fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|lzma\|xml2\|xslt\|exslt\)-.*\.dll$' \
+	-e '^/usr/bin/msys-\(hdb\|history8\|kadm5\|kdc\|otp\|sl\).*\.dll$' \
+	-e '^/usr/bin/msys-\(atomic\|blkid\|charset\|gthread\|metalink\|nghttp2\|pcre2-8\|ssh2\)-.*\.dll$' \
+	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \
+	-e '^/usr/bin/msys-\(formw6\|menuw6\|panelw6\)\.dll$' \
 	-e '^/usr/bin/msys-svn_swig_\(py\|ruby\)-.*\.dll$' \
 	-e '^/usr/bin/\(dumper\|sasl.*\)\.exe$' \
 	-e '^/usr/lib/gio/' -e '^/usr/lib/sasl2/msys-sasldb-.*\.dll$' \
+	-e '^/usr/lib/\(itcl\|tdbc\|pkcs11\|thread\)' \
 	-e '^/usr/share.*/magic$' \
 	-e '^/usr/share/perl5/core_perl/Unicode/' \
 	-e '^/usr/share/perl5/core_perl/pods/' \
@@ -200,10 +205,9 @@ else
 		-e '^/mingw../bin/.*-\(inflate\|deflate\)hd\.exe$' \
 		-e '^/mingw../bin/\(gettext\.sh\|gettextize\)$' \
 		-e '^/mingw../bin/\(gitk\|git-upload-archive\.exe\)$' \
-		-e '^/mingw../bin/lib\(atomic\|charset\)-.*\.dll$' \
 		-e '^/mingw../bin/libgcc_s_seh-.*\.dll$' \
 		-e '^/mingw../bin/libjemalloc\.dll$' \
-		-e '^/mingw../bin/lib\(gomp\|jansson\|minizip\)-.*\.dll$' \
+		-e '^/mingw../bin/lib\(gmp\|gomp\|jansson\|metalink\|minizip\)-.*\.dll$' \
 		-e '^/mingw../bin/libvtv.*\.dll$' \
 		-e '^/mingw../bin/libpcreposix.*\.dll$' \
 		-e '^/mingw../bin/\(.*\.def\|update-ca-trust\)$' \
@@ -252,8 +256,7 @@ else
 		-e '^/usr/bin/\(stty\|sum\|sync\|tac\|tee\|timeout\)\.exe$' \
 		-e '^/usr/bin/\(truncate\|tsort\|tty\|tzset\|umount\)\.exe$' \
 		-e '^/usr/bin/\(unexpand\|unlink\|users\|vdir\|who.*\)\.exe$' \
-		-e '^/usr/bin/msys-\(atomic\|charset\|cilkrts\)-.*\.dll$' \
-		-e '^/usr/bin/msys-\(hdb\|kadm5\|kafs\|kdc\|otp\|sl\).*\.dll$' \
+		-e '^/usr/bin/msys-\(cilkrts\|kafs\|ssl\)-.*\.dll$' \
 		-e '^/usr/bin/msys-sqlite3[a-z].*\.dll$' \
 		-e '^/usr/bin/msys-\(gomp.*\|vtv.*\)-.*\.dll$' \
 		-e '^/usr/lib/\(awk\|coreutils\|gawk\|openssl\|ssh\)/' \
@@ -262,8 +265,7 @@ else
 		-e '^/usr/ssl/misc/' \
 		-e '^/usr/bin/\(captoinfo\|clear\|infocmp\|infotocap\)\.exe$' \
 		-e '^/usr/bin/\(reset\|tabs\|tic\|toe\|tput\|tset\)\.exe$' \
-		-e '^/usr/bin/msys-\(formw6\|menuw6\)\.dll$' \
-		-e '^/usr/bin/msys-\(panelw6\|ticw6\)\.dll$' \
+		-e '^/usr/bin/msys-ticw6\.dll$' \
 		-e '^/usr/\(lib\|share\)/terminfo/' -e '^/usr/share/tabset/' \
 		-e "^\\($(echo $EXTRA_FILE_EXCLUDES |
 			sed 's/ /\\|/g')\\)\$"


### PR DESCRIPTION
This PR enhances the script we recently introduced to verify that we're not missing any `.dll` files, to _also_ verify that we're not shipping superfluous `.dll` files either.