### PR TITLE
installer: default to GCM Core (including fresh installs, not just upgrades)

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2128,10 +2128,10 @@ begin
             'Enabled': RdbGitCredentialManager[GCM_Classic].Checked:=True;
             'Core': RdbGitCredentialManager[GCM_Core].Checked:=True;
         else
-            RdbGitCredentialManager[GCM_Classic].Checked:=True;
+            RdbGitCredentialManager[GCM_Core].Checked:=True;
         end;
         // Auto-upgrade GCM to GCM Core in version v2.29.0
-        if RdbGitCredentialManager[GCM_Classic].Checked and (PreviousGitForWindowsVersion<>'') and IsDowngrade(PreviousGitForWindowsVersion,'2.29.0') then begin
+        if RdbGitCredentialManager[GCM_Classic].Checked and ((PreviousGitForWindowsVersion='') or IsDowngrade(PreviousGitForWindowsVersion,'2.29.0')) then begin
             RdbGitCredentialManager[GCM_Core].Checked:=True;
             AddToSet(CustomPagesWithUnseenOptions,GitCredentialManagerPage);
         end;


### PR DESCRIPTION
I completely missed the fact that we still install GCM(W) by default... 😠 