### PR TITLE
Adapt `check-for-missing-dlls.sh` for i686

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -164,7 +164,12 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../share/git\(k\|-gui\)/lib/msgs/' \
 	-e '^/mingw../share/nghttp2/' \
 	-e '^/usr/bin/msys-\(db\|curl\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
-	-e '^/usr/bin/msys-\(fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|lzma\|xml2\|xslt\|exslt\)-.*\.dll$' \
+	-e '^/usr/bin/msys-\('$(if test i686 = "$ARCH"
+	    then
+		echo 'uuid\|'
+	    else
+		echo 'lzma\|'
+	    fi)'fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(hdb\|history8\|kadm5\|kdc\|otp\|sl\).*\.dll$' \
 	-e '^/usr/bin/msys-\(atomic\|blkid\|charset\|gthread\|metalink\|nghttp2\|pcre2-8\|ssh2\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \


### PR DESCRIPTION
We recently stumbled over a breakage in the 32-bit Git for Windows SDK, where GNU Privacy Guard was completely broken due to a missing `.dll` (caused by a `libnettle` upgrade).

Let's modify the script we already use to prevent such issues from happening in the 64-bit Git for Windows SDK without being noticed, so that it extends to 32-bit as well.