### PR TITLE
installer: two fixes regarding the default branch name choice

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1899,7 +1899,8 @@ begin
     // Restore the setting chosen during a previous install.
     Data:=ReplayChoice('Default Branch Option','');
     case Data of
-        '': RdbDefaultBranch[DB_Unspecified].Checked:=True;
+        '':  RdbDefaultBranch[DB_Unspecified].Checked:=True;
+        ' ': RdbDefaultBranch[DB_Unspecified].Checked:=True;
     else begin
         RdbDefaultBranch[DB_Manual].Checked:=True;
         EdtDefaultBranch.Text:=Data;
@@ -3162,7 +3163,7 @@ begin
     RecordChoice(PreviousDataKey,'Custom Editor Path',CustomEditorData);
 
     // Default Branch options.
-    Data:='';
+    Data:=' ';
     if RdbDefaultBranch[DB_Manual].Checked then
         Data:=EdtDefaultBranch.Text;
     RecordChoice(PreviousDataKey,'Default Branch Option',Data);

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1631,6 +1631,28 @@ begin
         WizardForm.ActiveControl:=EdtDefaultBranch;
 end;
 
+procedure DefaultBranchNameChanged(Sender: TObject);
+var
+    IsValidBranchName:Boolean;
+begin
+    if EdtDefaultBranch.Enabled then begin
+        // Disallow illegal ref names
+        with EdtDefaultBranch do
+            IsValidBranchName:=(Text<>'') and (Text<>'@') and
+                    (Pos('..',Text)=0) and (Pos('@{',Text)=0) and (Pos('//',Text)=0) and
+                    (Pos(#8,Text)=0) and (Pos(' ',Text)=0) and (Pos(':',Text)=0) and
+                    (Pos('?',Text)=0) and (Pos('[',Text)=0) and (Pos('\',Text)=0) and
+                    (Pos('^',Text)=0) and (Pos('~',Text)=0) and (Pos(#127,Text)=0) and
+                    (Pos('/.','/'+Text)=0) and (Pos('./',Text+'/')=0) and (Pos('.lock/',Text+'/')=0);
+        if (WizardForm.CurPageID=DefaultBranchPage.ID) then
+            Wizardform.NextButton.Enabled:=IsValidBranchName;
+        if IsValidBranchName then
+            EdtDefaultBranch.Color:=clWhite
+        else
+            EdtDefaultBranch.Color:=clRed;
+    end;
+end;
+
 procedure QueryUninstallValues; forward;
 
 procedure InitializeWizard;
@@ -1888,6 +1910,7 @@ begin
     TabOrder:=TabOrder+1;
     EdtDefaultBranch.Text:='main';
     EdtDefaultBranch.Enabled:=False;
+    EdtDefaultBranch.OnChange:=@DefaultBranchNameChanged;
     Top:=Top+13+24;
 
     LblInfo:=TLabel.Create(DefaultBranchPage);
@@ -1905,6 +1928,7 @@ begin
         RdbDefaultBranch[DB_Manual].Checked:=True;
         EdtDefaultBranch.Text:=Data;
         EdtDefaultBranch.Enabled:=True;
+        DefaultBranchNameChanged(NIL);
     end end;
 
     (*


### PR DESCRIPTION
Yesterday, after I had released Git for Windows v2.29.0-rc2, I realized that I had been asked to choose whether I want to override the default branch name, even if I had checked the "Only show new options" checkbox, and even if I had previously said that I want to stay with Git's default.

Turns out that this choice was not recorded at all, due to an under-documented feature of the `SetPreviousData(Key,Value)` function: when specifying the empty string as value, it is not recorded at all; Instead, any previously recorded data for that key is deleted.

While working around this feature, I also noticed how easy it is to specify an invalid branch name, so I added code to prevent that from being accepted.