### PR TITLE
[RFC PATCH] Installer: Suggest also '.gitattributes' EOL setting

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2068,7 +2068,7 @@ begin
     CRLFPage:=CreatePage(PrevPageID,'Configuring the line ending conversions','How should Git treat line endings in text files?',TabOrder,Top,Left);
 
     // 1st choice
-    RdbCRLF[GC_CRLFAlways]:=CreateRadioButton(CRLFPage,'Checkout Windows-style, commit Unix-style line endings','Git will convert LF to CRLF when checking out text files. When committing'+#13+'text files, CRLF will be converted to LF. For cross-platform projects,'+#13+'this is the recommended setting on Windows ("core.autocrlf" is set to "true").',TabOrder,Top,Left);
+    RdbCRLF[GC_CRLFAlways]:=CreateRadioButton(CRLFPage,'Checkout Windows-style, commit Unix-style line endings','Git will convert LF to CRLF when checking out text files. When committing'+#13+'text files, CRLF will be converted to LF. For cross-platform projects,'+#13+'this is the recommended setting on Windows ("core.autocrlf" is set to "true").'+#13+#13+'Also consider including a ".gitattributes" file'+#13+'containing "* text=auto" in all cross-platform repositories.',TabOrder,Top,Left);
 
     // 2nd choice
     RdbCRLF[GC_LFOnly]:=CreateRadioButton(CRLFPage,'Checkout as-is, commit Unix-style line endings','Git will not perform any conversion when checking out text files. When'+#13+'committing text files, CRLF will be converted to LF. For cross-platform projects,'+#13+'this is the recommended setting on Unix ("core.autocrlf" is set to "input").',TabOrder,Top,Left);


### PR DESCRIPTION
fixes: #2808

Inform users that cross-platform repositories should also have a
`.gitattributes` file containing "* text=auto" as described in
https://www.edwardthomson.com/blog/git_for_windows_line_endings.html.

Hence Git-for-Windows Windows users will have text files converted from
Windows style line endings (\r\n) to Unix style line endings (\n) when
they’re added to the repository, even if they have not set "core.autocrlf".

Signed-off-by: Philip Oakley <philipoakley@iee.email>

This is an untested draft to follow up G-f-W #2808 