### PR TITLE
helper-selector: fix quoting of trailing backslashes

### DIFF
--- a/git-extra/git-credential-helper-selector.c
+++ b/git-extra/git-credential-helper-selector.c
@@ -291,7 +291,8 @@ static LPWSTR quote(LPWSTR string)
 			while (end[1] == L'\\')
 				end++;
 			len += end - p;
-			if (end[1] == L'"')
+			if (end[1] == L'"' ||
+			    (needs_quotes && end[1] == L'\0'))
 				len += end - p + 1;
 			p = end;
 		}
@@ -313,7 +314,7 @@ static LPWSTR quote(LPWSTR string)
 				memcpy(q, p, (end - p) * sizeof(WCHAR));
 				q += end - p;
 			}
-			if (end[1] == L'"') {
+			if (end[1] == L'"' || end[1] == L'\0') {
 				memcpy(q, p, (end - p + 1) * sizeof(WCHAR));
 				q += end - p + 1;
 			}


### PR DESCRIPTION
In git-for-windows/git@6d8684161ee9, we fixed a bug where it would quote command-line arguments with trailing backslashes incorrectly when they needed to be quoted.

While the helper-selector only quotes paths to files (which, by definition, cannot end in a backslash), we still should fix the
`quote()` function, just in case that we will want to use it on parameters other than file paths.