### PR TITLE
git update-git-for-windows: escape installer arguments

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -290,7 +290,7 @@ update_git_for_windows () {
 		echo "Downloading $filename" >&2
 	fi
 	curl -# -L -o $installer $download || return
-	start "" "$installer" //SILENT //VERYSILENT //NORESTART
+	start "" "$installer" //SILENT //NORESTART
 
 	# Kill all Bash processes (which will let MinTTY quit, too)"
 	#

--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -290,7 +290,7 @@ update_git_for_windows () {
 		echo "Downloading $filename" >&2
 	fi
 	curl -# -L -o $installer $download || return
-	start "" "$installer" /SILENT /VERYSILENT /NORESTART
+	start "" "$installer" //SILENT //VERYSILENT //NORESTART
 
 	# Kill all Bash processes (which will let MinTTY quit, too)"
 	#


### PR DESCRIPTION
When installer is being executed MSYS2 subsystem tries to convert unix paths to Windows paths.

It seems it applies to installer arguments as well (because they start with slash).
Thus `/SILENT` is converted to `C:/Program Files/Git/SILENT` (or something alike).

This effectively bypasses installer arguments.

The solution is to escape slashes in installer arguments.

Signed-off-by: ge0rdi <ge0rdi@users.noreply.github.com>

---

With this change git update works silently without any user interaction and any progress.
That second part (no progress displayed) is caused by `/VERYSILENT` option and imo it is not good. Because user doesn't even know if the installation started/ended.

Personally I think `/VERYSILENT` should be removed. Without that option it seems to work well for me. There is still no user interaction (tried update from 2.28 to latest one) and there is at least installer window with progress shown.