### PR TITLE
Update aliases.sh

### DIFF
--- a/git-extra/aliases.sh
+++ b/git-extra/aliases.sh
@@ -5,8 +5,8 @@
 alias ls='ls -F --color=auto --show-control-chars'
 alias ll='ls -l'
 
-case "$TERM" in
-xterm*)
+case "$TERM_PROGRAM" in
+mintty*)
 	# The following programs are known to require a Win32 Console
 	# for interactive usage, therefore let's launch them through winpty
 	# when run inside `mintty`.


### PR DESCRIPTION
Recent windows versions have the improved console which reports as xterm-256color (and also Windows Terminal reports the same), and they definitely do not need winpty to translate anything. This PR fixes to check so that it applies solely to mintty. Also, given that mintty is not shipped with GfW (anymore?) maybe remove this file completely?