### PR TITLE
portable: add arm64 artifact option

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -4770,12 +4770,13 @@ build_mingw_w64_git () { # [--only-32-bit] [--only-64-bit] [--skip-test-artifact
 }
 
 # This function does not "clean up" after installing the packages
-make_installers_from_mingw_w64_git () { # [--pkg=<package>[,<package>...]] [--version=<version>] [--installer] [--portable] [--mingit] [--mingit-busybox] [--nuget] [--nuget-mingit] [--archive]
+make_installers_from_mingw_w64_git () { # [--pkg=<package>[,<package>...]] [--version=<version>] [--installer] [--portable] [--mingit] [--mingit-busybox] [--nuget] [--nuget-mingit] [--archive] [--include-arm64-artifacts=<path>]
 	modes=
 	install_package=
 	output=
 	output_path=
 	version=0-test
+	include_arm64_artifacts=
 	while case "$1" in
 	--pkg=*)
 		install_package="${install_package:+$install_package }$(echo "${1#*=}" | tr , ' ')"
@@ -4820,6 +4821,9 @@ make_installers_from_mingw_w64_git () { # [--pkg=<package>[,<package>...]] [--ve
 		output_path="$(cygpath -am "${1#-?}")"
 		output="--output=$output_path" || exit
 		;;
+	--include-arm64-artifacts=*)
+		include_arm64_artifacts="$1"
+		;;
 	-*) die "Unknown option: %s\n" "$1";;
 	*) break;;
 	esac; do shift; done
@@ -4855,7 +4859,7 @@ make_installers_from_mingw_w64_git () { # [--pkg=<package>[,<package>...]] [--ve
 		test installer != $mode ||
 		extra="${extra:+$extra }--window-title-version=$version"
 
-		sh -x "${this_script_path%/*}/$mode/release.sh" $output $extra $version
+		sh -x "${this_script_path%/*}/$mode/release.sh" $output $extra $include_arm64_artifacts $version
 	done
 }
 

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -22,6 +22,9 @@ do
 	--include-pdbs)
 		include_pdbs=t
 		;;
+	--include-arm64-artifacts=*)
+		arm64_artifacts_directory="${1#*=}"
+		;;
 	-*)
 		die "Unknown option: $1"
 		;;
@@ -134,6 +137,18 @@ test -z "$include_pdbs" || {
 } ||
 die "Could not unpack .pdb files"
 
+TITLE="$BITNESS-bit"
+
+# ARM64 Windows handling
+if test -n "$arm64_artifacts_directory"
+then
+	echo "Including ARM64 artifacts from $arm64_artifacts_directory";
+	TARGET="$output_directory"/PortableGit-"$VERSION"-arm64.7z.exe
+	TITLE="ARM64"
+	mkdir -p "$SCRIPT_PATH/root/arm64"
+	cp -ar $arm64_artifacts_directory/* "$SCRIPT_PATH/root/arm64"
+fi
+
 # 7-Zip will strip absolute paths completely... therefore, we can add another
 # root directory like this:
 
@@ -150,8 +165,8 @@ echo "Creating archive" &&
 (cd / && 7za a $OPTS7 $TMPPACK $LIST) &&
 (cat "$SCRIPT_PATH/../7-Zip/7zSD.sfx" &&
  echo ';!@Install@!UTF-8!' &&
- echo 'Title="Portable Git for Windows '$BITNESS'-bit"' &&
- echo 'BeginPrompt="This archive extracts a complete Git for Windows '$BITNESS'-bit"' &&
+ echo 'Title="Portable Git for Windows '$TITLE'"' &&
+ echo 'BeginPrompt="This archive extracts a complete Git for Windows '$TITLE'"' &&
  echo 'CancelPrompt="Do you want to cancel the portable Git installation?"' &&
  echo 'ExtractDialogText="Please, wait..."' &&
  echo 'ExtractPathText="Where do you want to install portable Git?"' &&


### PR DESCRIPTION
Builds further on https://github.com/git-for-windows/build-extra/pull/321. Very much a proof of concept, just sharing here for inspiration.

**Example release based on this PR**: https://github.com/dennisameling/git/releases/tag/2.30.0-beta2

Results in an actual working portable installer for ARM64 when taking the following steps:

- `sdk build mingw-w64-git`
- `pacman -U mingw-w64-i686-git-2.30.0.2.f8cbc844b8-1-any.pkg.tar.xz` (replace the filename with the actual filename that's generated)
- `sdk build git-extra` (so that `/etc/profile` gets overwritten to include ARM64)
- `pacman -U git-extra-1.1.513.20ab9a5-1-i686.pkg.tar.xz` (replace the filename with the actual filename that's generated)
- ([create the arm64 binaries](https://github.com/git-for-windows/git/pull/2915#issuecomment-739538291) now and output to `C:\git-sdk-32\arm64`)
- Go into `/usr/src/build-extra/portable` and run  `mkdir -p arm64 && ./release.sh --include-arm64-artifacts=/arm64 --output=./arm64 2.30.0`

It then looks like this on an ARM64 device:

![image](https://user-images.githubusercontent.com/17739158/105548378-d1ba5e80-5cff-11eb-84a5-251314624d37.png)
