### PR TITLE
mingit: add arm64 artifact option

### DIFF
--- a/mingit/release.sh
+++ b/mingit/release.sh
@@ -25,6 +25,9 @@ while case "$1" in
 --include-pdbs)
 	include_pdbs=t
 	;;
+--include-arm64-artifacts=*)
+	arm64_artifacts_directory="${1#*=}"
+	;;
 -*) die "Unknown option: %s\n" "$1";;
 *) break;;
 esac; do shift; done
@@ -102,6 +105,15 @@ $(cat "/$original_etc_gitconfig")
 	path = C:/Program Files/Git/etc/gitconfig
 EOF
 die "Could not generate system config"
+
+# ARM64 Windows handling
+if test -n "$arm64_artifacts_directory"
+then
+	echo "Including ARM64 artifacts from $arm64_artifacts_directory";
+	TARGET="$output_directory"/MinGit-"$VERSION"-arm64.zip
+	mkdir -p "$SCRIPT_PATH/root/arm64"
+	cp -ar $arm64_artifacts_directory/* "$SCRIPT_PATH/root/arm64"
+fi
 
 # Make the archive
 


### PR DESCRIPTION
Related to https://github.com/git-for-windows/build-extra/pull/323, needs https://github.com/git-for-windows/build-extra/pull/321 & #323 

Example release based on this PR: https://github.com/dennisameling/git/releases/tag/2.30.0-beta2

This probably needs optimization. The generated ZIP is 207MB 😅 any tips/guidance are/is welcome!

### GitHub Desktop / Dugite Native / Dugite
The mingit packages are used by [desktop/dugite-native](https://github.com/desktop/dugite-native) > [desktop/dugite](https://github.com/desktop/dugite) > [desktop/desktop](https://github.com/desktop/desktop) (GitHub Desktop), so I tested with those as well.

⚠️ Note: `dugite-native` is still on Git 2.26.2, so the failing tests might be due to the bump to 2.30.0 as well

dugite-native: https://github.com/desktop/dugite-native/pull/347
dugite: https://github.com/desktop/dugite/pull/421