### PR TITLE
installer: add arm64 artifact option

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -34,7 +34,11 @@ LZMAUseSeparateProcess=yes
 OutputBaseFilename={#FILENAME_VERSION}
 OutputDir={#GetEnv('TEMP')}
 #else
+#ifdef INSTALLER_FILENAME_SUFFIX
+OutputBaseFilename={#APP_NAME+'-'+FILENAME_VERSION+'-'+INSTALLER_FILENAME_SUFFIX}
+#else
 OutputBaseFilename={#APP_NAME+'-'+FILENAME_VERSION}-{#BITNESS}-bit
+#endif
 #ifdef OUTPUT_DIRECTORY
 OutputDir={#OUTPUT_DIRECTORY}
 #else


### PR DESCRIPTION
Adds ARM64 support to the installer 🚀 

Currently installs ARM64 Git into `C:\Program Files (x86)\Git` by default.