### PR TITLE
Sanitize Pacman databases while adding new packages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -166,5 +166,6 @@
     ],
     "cSpell.ignoreRegExpList": [
         "3rdparty"
-    ]
+    ],
+    "git.ignoreLimitWarning": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
         "binutils",
         "bitness",
         "bsau",
+        "bsdtar",
         "bugfix",
         "busybox",
         "cacert",
@@ -165,7 +166,8 @@
         "xpdf"
     ],
     "cSpell.ignoreRegExpList": [
-        "3rdparty"
+        "3rdparty",
+	"d[-r][-w][-x][-r][-w][-x][-r][-w][-x]"
     ],
     "git.ignoreLimitWarning": true
 }

--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -614,8 +614,14 @@ quick_add () { # <file>...
 				echo "Downloading current $arch/$file..." >&2
 				curl -sfo "$dir/$arch/$file" "$(arch_url $arch)/$file" || return 1
 				dbs="$dbs $arch/$file $arch/${file%.tar.xz}"
-				test -z "$sign_option" ||
-				dbs="$dbs $arch/$file.sig $arch/${file%.tar.xz}.sig"
+				if test -n "$sign_option"
+				then
+					curl -sfo "$dir/$arch/$file.sig" "$(arch_url $arch)/$file.sig" ||
+					return 1
+					gpg --verify "$dir/$arch/$file.sig" ||
+					die "Could not verify GPG signature: $dir/$arch/$file"
+					dbs="$dbs $arch/$file.sig $arch/${file%.tar.xz}.sig"
+				fi
 			done
 		done
 		(cd "$dir/$arch" &&

--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -527,7 +527,15 @@ sanitize_db () { # <file>...
 				}
 			}
 		}
-	' "$@"
+	' "$@" &&
+	if test -n "$GPGKEY"
+	then
+		for path in "$@"
+		do
+			call_gpg --detach-sign --no-armor -u $GPGKEY "$path" ||
+			die "Could not sign $path"
+		done
+	fi
 }
 
 quick_add () { # <file>...

--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -622,6 +622,9 @@ quick_add () { # <file>...
 					die "Could not verify GPG signature: $dir/$arch/$file"
 					dbs="$dbs $arch/$file.sig $arch/${file%.tar.xz}.sig"
 				fi
+				sanitize_db "$dir/$arch/$file" || return 1
+				test ! -f "$dir/$arch/${file%.tar.xz}" ||
+				sanitize_db "$dir/$arch/${file%.tar.xz}" || return 1
 			done
 		done
 		(cd "$dir/$arch" &&

--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -38,7 +38,7 @@ export CURL_CA_BUNDLE
 
 mode=
 case "$1" in
-fetch|add|remove|push|files|dirs|orphans|push_missing_signatures|file_exists|lock|unlock|quick_add)
+fetch|add|remove|push|files|dirs|orphans|push_missing_signatures|file_exists|lock|unlock|quick_add|sanitize_db)
 	mode="$1"
 	shift
 	;;
@@ -473,6 +473,61 @@ push () {
 	}
 
 	push_next_db_version
+}
+
+sanitize_db () { # <file>...
+	perl -e '
+		foreach my $path (@ARGV) {
+			my @to_delete = ();
+			my %base_to_date = ();
+			my %base_to_full_name = ();
+
+			open($fh, "-|", "tar", "tvf", $path) or die;
+			while (<$fh>) {
+				# parse lines like this:
+				# drwxr-xr-x root/root         0 2019-02-17 21:45 bash -4.4.023-1 /
+				if (/(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+?)(-\d.*?)\/$/) {
+					my $date = $4 . " " . $5;
+					my $prefix = $6;
+					my $full_name = $6 . $7;
+					if ($prefix =~ / /) {
+						push @to_delete, $full_name;
+					} elsif (exists($base_to_date{$prefix})) {
+						print $prefix . ": " . $base_to_date{$prefix} . " vs " . $date . "\n";
+						if (($base_to_date{$prefix} cmp $date) < 0) {
+							print $base_to_date{$prefix} . " older than " . $date . ": delete " . $base_to_date{$prefix} . "\n";
+							push @to_delete, $base_to_full_name{$prefix};
+							# replace
+							$base_to_full_name{$prefix} = $full_name;
+							$base_to_date{$prefix} = $date;
+						} else {
+							print $base_to_date{$prefix} . " younger than " . $date . ": delete " . $date . "\n";
+							push @to_delete, $full_name;
+						}
+					} else {
+						$base_to_date{$prefix} = $date;
+						$base_to_full_name{$prefix} = $full_name;
+					}
+				}
+			}
+			close($fh);
+
+			if ($#to_delete > 0) {
+				@bsdtar = ("bsdtar", "-cJf", $path . ".bup");
+				foreach my $item (@to_delete) {
+					push @bsdtar, "--exclude";
+					push @bsdtar, $item . "*";
+				}
+				push @bsdtar, "@" . $path;
+				print "Sanitizing: " . join(" ", @bsdtar) . "\n";
+				if (system(@bsdtar) == 0) {
+					rename $path . ".bup", $path or die "Could not rename $path.bup to $path";
+				} else {
+					die "Could not run " . join(" ", @bsdtar);
+				}
+			}
+		}
+	' "$@"
 }
 
 quick_add () { # <file>...


### PR DESCRIPTION
Git for Windows' Pacman package databases are updated only via automated builds. In at least one of them, bogus entries were added (see git-for-windows/git#3034 and git-for-windows/git#3035). This PR adjusts the automated builds so that that won't happen again (or at least so that it will self-heal).