### PR TITLE
installer: bump NetFx version requirement from 4.5.1 -> 4.6.1

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2287,12 +2287,12 @@ begin
     // No credential helper
     RdbGitCredentialManager[GCM_None]:=CreateRadioButton(GitCredentialManagerPage,'None','Do not use a credential helper.',TabOrder,Top,Left);
 
-    // Restore the settings chosen during a previous install, if .NET 4.7.2
+    // Restore the settings chosen during a previous install, if .NET Framework 4.7.2
     // or later is available.
     if DetectNetFxVersion()<461808 then begin
         RdbGitCredentialManager[GCM].Checked:=False;
         RdbGitCredentialManager[GCM].Enabled:=False;
-        RdbGitCredentialManager[GCM].Caption:=RdbGitCredentialManager[GCM].Caption+' (requires .NET >= 4.7.2)'
+        RdbGitCredentialManager[GCM].Caption:=RdbGitCredentialManager[GCM].Caption+' (requires .NET Framework >= 4.7.2)'
     end else begin
         case ReplayChoice('Use Credential Manager','Enabled') of
             'Disabled': RdbGitCredentialManager[GCM_None].Checked:=True;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2292,6 +2292,7 @@ begin
     if DetectNetFxVersion()<378675 then begin
         RdbGitCredentialManager[GCM].Checked:=False;
         RdbGitCredentialManager[GCM].Enabled:=False;
+        RdbGitCredentialManager[GCM].Caption:=RdbGitCredentialManager[GCM].Caption+' (requires .NET >= 4.5.1)'
     end else begin
         case ReplayChoice('Use Credential Manager','Enabled') of
             'Disabled': RdbGitCredentialManager[GCM_None].Checked:=True;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1174,8 +1174,8 @@ end;
 
 function DetectNetFxVersion:Cardinal;
 begin
-    // We are only interested in version v4.5.1 or later, therefore it
-    // is enough to only use the 4.5 method described in
+    // We are only interested in version v4.7.2 or later, therefore it
+    // is enough to only use the "4.5 and later" method described in
     // https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/how-to-determine-which-versions-are-installed
     if IsWin64 then begin
         if (
@@ -2287,12 +2287,12 @@ begin
     // No credential helper
     RdbGitCredentialManager[GCM_None]:=CreateRadioButton(GitCredentialManagerPage,'None','Do not use a credential helper.',TabOrder,Top,Left);
 
-    // Restore the settings chosen during a previous install, if .NET 4.5.1
+    // Restore the settings chosen during a previous install, if .NET 4.7.2
     // or later is available.
-    if DetectNetFxVersion()<378675 then begin
+    if DetectNetFxVersion()<461808 then begin
         RdbGitCredentialManager[GCM].Checked:=False;
         RdbGitCredentialManager[GCM].Enabled:=False;
-        RdbGitCredentialManager[GCM].Caption:=RdbGitCredentialManager[GCM].Caption+' (requires .NET >= 4.5.1)'
+        RdbGitCredentialManager[GCM].Caption:=RdbGitCredentialManager[GCM].Caption+' (requires .NET >= 4.7.2)'
     end else begin
         case ReplayChoice('Use Credential Manager','Enabled') of
             'Disabled': RdbGitCredentialManager[GCM_None].Checked:=True;


### PR DESCRIPTION
We already require Fx4.6.1, but the installer checks for Fx4.5.1

Signed-off-by: Zak Kohler <git@y2kbugger.com>


I used the _lower_ of the two 4.6.1 checks as that is how 4.5.1 was done previously.

@mjcheetham 

> .NET Framework 4.6.1
> On Windows 10 November Update systems: 394254
> On all other Windows operating systems (including Windows 10): 394271


