### PR TITLE
git-artifacts(ARM64): add git-credential-manager-core-wrapper

### DIFF
--- a/archive/release.sh
+++ b/archive/release.sh
@@ -124,6 +124,11 @@ then
 	cp -ar "$arm64_artifacts_directory" "$SCRIPT_PATH/root/arm64" &&
 	ARM64_FOLDER="arm64" ||
 	die "Could not copy ARM64 artifacts from $arm64_artifacts_directory"
+
+	mkdir -p "$SCRIPT_PATH/root/mingw32/bin" &&
+	printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > "$SCRIPT_PATH/root/mingw32/bin/git-credential-manager-core" &&
+	chmod +x "$SCRIPT_PATH/root/mingw32/bin/git-credential-manager-core" ||
+	die "Could not add git-credential-manager-core wrapper for ARM64"
 fi
 
 # Create the archive

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -271,6 +271,13 @@ test -z "$arm64_artifacts_directory" || {
 	sed -e "s|^$arm64_artifacts_directory\\(/.*\)\?/\([^/]*\)$|Source: \"$mixed\\1/\\2\"; DestDir: {app}/arm64\\1; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore|" \
 		-e 's|/|\\|g' \
 		>> file-list.iss
+
+	mkdir -p root/mingw32/bin &&
+	printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > root/mingw32/bin/git-credential-manager-core &&
+	chmod +x root/mingw32/bin/git-credential-manager-core &&
+	printf '%s\n' \
+	"Source: \"{#SourcePath}\\root\\mingw32\\bin\\git-credential-manager-core\"; DestDir: {app}\\mingw32\\bin; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
+	>> file-list.iss || die "Could not add git-credential-manager-core wrapper for ARM64"
 } ||
 die "Could not include ARM64 artifacts"
 

--- a/mingit/release.sh
+++ b/mingit/release.sh
@@ -114,6 +114,11 @@ then
 	rm -rf "$SCRIPT_PATH/root/arm64" &&
 	cp -ar "$arm64_artifacts_directory" "$SCRIPT_PATH/root/arm64" ||
 	die "Could not copy ARM64 artifacts from $arm64_artifacts_directory"
+
+	mkdir -p "$SCRIPT_PATH/root/mingw32/bin" &&
+	printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > "$SCRIPT_PATH/root/mingw32/bin/git-credential-manager-core" &&
+	chmod +x "$SCRIPT_PATH/root/mingw32/bin/git-credential-manager-core" ||
+	die "Could not add git-credential-manager-core wrapper for ARM64"
 fi
 
 # Make the archive

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -148,6 +148,11 @@ then
 	rm -rf "$SCRIPT_PATH/root/arm64" &&
 	cp -ar "$arm64_artifacts_directory" "$SCRIPT_PATH/root/arm64" ||
 	die "Could not copy ARM64 artifacts from $arm64_artifacts_directory"
+
+	mkdir -p "$SCRIPT_PATH/root/mingw32/bin" &&
+	printf '%s\n' '#!/bin/sh' 'exec /mingw32/libexec/git-core/git-credential-manager-core.exe "$@"' > "$SCRIPT_PATH/root/mingw32/bin/git-credential-manager-core" &&
+	chmod +x "$SCRIPT_PATH/root/mingw32/bin/git-credential-manager-core" ||
+	die "Could not add git-credential-manager-core wrapper for ARM64"
 fi
 
 # 7-Zip will strip absolute paths completely... therefore, we can add another


### PR DESCRIPTION
In https://github.com/git-for-windows/git/pull/3076, we added a workaround for GCM Core by adding a wrapper in `arm64/bin/git-credential-manager-core`. What I didn't realize back then was that I had a hard link to GCM Core in my `~/.gitconfig`, so everything seemed to work as expected.

However, I just tried a clean installation of Git for Windows on ARM64 and removed my `~/.gitconfig`. Then ran into:

```
PS C:\repos\demo-repo> git push
git: 'credential-manager-core' is not a git command. See 'git --help'.
Username for 'https://github.com':
```

... even though `arm64/bin/git-credential-manager-core` was present. When I moved the file to `mingw32/bin/git-credential-manager-core`, everything started to work as expected:

```
PS C:\repos\demo-repo> git push
Everything up-to-date
```

This PR adds `git-credential-manager-core` to the proper folder in `mingw32`. Additional benefit is that folks will have this fix included, even when their artifacts weren't built with GitHub Actions: 

https://github.com/dennisameling/git/blob/6686bba2f0a38f78f8406116c5adc8e7dcd0fd82/.github/workflows/git-artifacts.yml#L421-L427

I'll remove the workaround in `git-artifacts.yml` as this PR is a successor to it.