### PR TITLE
Improve error message in silent mode when Git for Windows' files are in use

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2431,14 +2431,33 @@ begin
                         Log(Msg);
                     ExitEarlyWithSuccess();
                 end;
-                if WizardSilent() then begin
-                    Msg:='Silent setup failed because the following process(es) use Git for Windows:'+#13+#10;
-                    for j:=i to GetArrayLength(Processes)-1 do
-                        if not Processes[j].Restartable then
-                            Msg:=Msg+#13+#10+Processes[j].Name+' (PID '+IntToStr(Processes[j].ID)+')';
-                end else
+                if WizardSilent() then
+                    while True do begin
+                        Msg:='';
+                        for j:=i to GetArrayLength(Processes)-1 do
+                            if not Processes[j].Restartable then
+                                Msg:=Msg+#13+#10+Processes[j].Name+' (PID '+IntToStr(Processes[j].ID)+')'
+                            else if (Processes[j].ToTerminate) and (not TerminateProcessByID(Processes[i].ID)) then
+                                Msg:=Msg+#13+#10+Processes[j].Name+' (PID '+IntToStr(Processes[j].ID)+')';
+
+                        if Msg='' then begin
+                            Result:=True;
+                            Exit;
+                        end;
+
+                        Msg:='The following process(es) use Git for Windows:'+#13+#10+Msg+#13+#10+#13+#10+'Please terminate those processes and retry.'+#13+#10+'Alternatively, cancel to abandon setup altogether.';
+                        if SuppressibleMsgBox(Msg, mbCriticalError, MB_RETRYCANCEL, IDCANCEL) = IDCANCEL then begin
+                            Result:=False;
+                            Exit;
+                        end;
+
+                        RefreshProcessList(NIL);
+                        i:=0;
+                    end
+                else begin
                     Msg:='Setup cannot continue until you close at least those applications in the list that are marked as "closing is required".';
-                SuppressibleMsgBox(Msg, mbCriticalError, MB_OK, IDOK);
+                    SuppressibleMsgBox(Msg, mbCriticalError, MB_OK, IDOK);
+                end;
                 Result:=False;
                 Exit;
             end;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2371,7 +2371,7 @@ end;
 
 function NextButtonClick(CurPageID:Integer):Boolean;
 var
-    i:Integer;
+    i,j:Integer;
     Version:TWindowsVersion;
     Msg:String;
 begin
@@ -2431,12 +2431,14 @@ begin
                         Log(Msg);
                     ExitEarlyWithSuccess();
                 end;
-                SuppressibleMsgBox(
-                    'Setup cannot continue until you close at least those applications in the list that are marked as "closing is required".'
-                ,   mbCriticalError
-                ,   MB_OK
-                ,   IDOK
-                );
+                if WizardSilent() then begin
+                    Msg:='Silent setup failed because the following process(es) use Git for Windows:'+#13+#10;
+                    for j:=i to GetArrayLength(Processes)-1 do
+                        if not Processes[j].Restartable then
+                            Msg:=Msg+#13+#10+Processes[j].Name+' (PID '+IntToStr(Processes[j].ID)+')';
+                end else
+                    Msg:='Setup cannot continue until you close at least those applications in the list that are marked as "closing is required".';
+                SuppressibleMsgBox(Msg, mbCriticalError, MB_OK, IDOK);
                 Result:=False;
                 Exit;
             end;

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -13,6 +13,7 @@ force=
 inno_defines=
 skip_files=
 test_installer=
+test_installer_options=
 include_pdbs=
 LF='
 '
@@ -45,6 +46,14 @@ do
 		;;
 	--test)
 		test_installer=t
+		inno_defines="$inno_defines$LF#define OUTPUT_TO_TEMP ''"
+		inno_defines="$inno_defines$LF#define DO_NOT_INSTALL 1"
+		inno_defines="$inno_defines$LF[Code]${LF}function SetSystemConfigDefaults():Boolean;${LF}begin${LF}    Result:=True;${LF}end;$LF"
+		;;
+	--silent-test)
+		test_installer=t
+		test_installer_options="//SILENT //NORESTART"
+		skip_files=t
 		inno_defines="$inno_defines$LF#define OUTPUT_TO_TEMP ''"
 		inno_defines="$inno_defines$LF#define DO_NOT_INSTALL 1"
 		inno_defines="$inno_defines$LF[Code]${LF}function SetSystemConfigDefaults():Boolean;${LF}begin${LF}    Result:=True;${LF}end;$LF"
@@ -295,7 +304,7 @@ die "Could not make installer"
 if test -n "$test_installer"
 then
 	echo "Launching $TEMP/$version.exe"
-	exec "$TEMP/$version.exe"
+	exec "$TEMP/$version.exe" $test_installer_options
 	exit
 fi
 


### PR DESCRIPTION
In silent mode, we do not see the "Processes" page to which the error message refers:

![image](https://user-images.githubusercontent.com/1947968/111285620-9eca8200-8641-11eb-82bf-bcd51db6534f.png)

Let's change the error message in silent mode, to be more helpful. Example:

<img src="https://user-images.githubusercontent.com/127790/111301665-c37b2580-8652-11eb-9a9a-46f84689db6b.png" width=380px>

An alternative I would have _loved_ to implement would have shown the wizard form via `WizardForm.Show()`, i.e. by turning the silent installer non-silent. However, clicking the <kbd>OK</kbd> button of the error message will cause the installer to exit anyway, i.e. it won't let the user interact with the wizard form before exiting, so that is not an option.

This fixes https://github.com/git-for-windows/git/issues/3118