### PR TITLE
Use ShellExecAsOriginalUser() instead of ShellExec() for custom editor tests

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1526,7 +1526,7 @@ begin
     else
         Show:=SW_SHOW;
 
-    if not ShellExec('',CustomEditorPath,CustomEditorOptions+' "'+TmpFile+'"','',Show,ewWaitUntilTerminated,Res) then begin
+    if not ShellExecAsOriginalUser('',CustomEditorPath,CustomEditorOptions+' "'+TmpFile+'"','',Show,ewWaitUntilTerminated,Res) then begin
         Wizardform.NextButton.Enabled:=False;
         SuppressibleMsgBox('Could not launch: "'+CustomEditorPath+'"',mbError,MB_OK,IDOK);
         Exit;


### PR DESCRIPTION
This fixes the issue reported in [git-for-windows#3155](https://github.com/git-for-windows/git/issues/3155) as suggested by @dscho.