### PR TITLE
git update-git-for-windows: download ARM64 Git for Windows if applicable

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -215,7 +215,14 @@ update_git_for_windows () {
 	test -n "$quiet" && test "x$recently_seen" = "x$latest" && return
 
 	version=$(git --version | sed "s/git version //")
-	echo "$git_label $version (${bit}bit)" >&2
+	if test -d /arm64/bin
+	then
+		arch_bit=ARM64
+	else
+		arch_bit=${bit}-bit
+	fi
+
+	echo "$git_label $version ($arch_bit)" >&2
 	if test -z "$testing" && test "$latest" = "$version"
 	then
 		echo "Up to date" >&2
@@ -237,7 +244,7 @@ update_git_for_windows () {
 	releases=$(http_get $releases_url/latest) || return
 	download=$(echo "$releases" |
 		grep '"browser_download_url": "' |
-		grep "$bit\-bit\.exe" |
+		grep "$arch_bit\.exe" |
 		sed -E 's/.*": "([^"]*).*/\1/')
 	filename=$(echo "$download" | sed -E 's/.*\/([^\/]*)$/\1/')
 	name="$(echo "$releases" | sed -n 's/^  "name": "\(.*\)",$/\1/p')"


### PR DESCRIPTION
Builds further on #338 
Needed for https://github.com/git-for-windows/git/issues/3107

If the `/arm64/bin` folder is present, we assume that the user has the ARM64 version of Git for Windows installed. When a new version is available, we'll then automatically download the ARM64 version. This is similar to the logic in [git-wrapper.c](https://github.com/git-for-windows/MINGW-packages/blob/a723a9beca720c36378bce90e2085e0828d90012/mingw-w64-git/git-wrapper.c#L139-L144) in mingw-w64-git.

Sample release with a fake ARM64 installer (renamed 64-bit installer, just to show that the installer indeed downloads the correct file): https://github.com/dennisameling/git/releases/tag/2.31.2.windows.1

Tested as follows:
1. Ensure `/arm64/bin` folder is present
2. Point the update check script to my fake 2.31.2 release: https://github.com/dennisameling/git/releases/tag/2.31.2.windows.1
3. Run `cmd\git.exe update-git-for-windows --gui` from Git Bash
4. Get the "Update available" notification - it correctly downloaded the ARM64 installer