### PR TITLE
Fix auto-updater when an -rc0 version is installed

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -231,7 +231,7 @@ update_git_for_windows () {
 	fi
 	test -n "$testing" ||
 	case "$version" in
-	*.rc[1-9]*)
+	*.rc[0-9]*)
 		# Do not downgrade from -rc versions to the latest stable one
 		if test 0 -lt "$(version_compare "$version" "$latest")"
 		then


### PR DESCRIPTION
I recently installed v2.32.0-rc0 and the auto-updater suggested to "upgrade" to v2.31.1. This fixes that.