### PR TITLE
Use /bin/bash when launching from Windows Terminal

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2715,7 +2715,7 @@ begin
         '    "profiles": ['+
         '      {'+
         '        "name": "Git Bash",'+
-        '        "commandline": "'+AppPath+'/usr/bin/bash.exe -i -l",'+
+        '        "commandline": "'+AppPath+'/bin/bash.exe -i -l",'+
         '        "icon": "'+AppPath+'/{#MINGW_BITNESS}/share/git/git-for-windows.ico",'+
         '        "startingDirectory": "%USERPROFILE%"'+
         '      }'+


### PR DESCRIPTION
Using /usr/bin/bash does not fully initialise the environment, see https://github.com/git-for-windows/build-extra/pull/339#discussion_r634803606 for details

Signed-off-by: Paul "TBBle" Hampson <Paul.Hampson@Pobox.com>