### PR TITLE
In preparation for supporting contrib/scalar/, teach the installer about it

### DIFF
--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -200,3 +200,18 @@ begin
         Result:=False;
     end;
 end;
+
+function ExecSilentlyAsOriginalUser(Cmd,LogKey,ErrorMessage:String):Boolean;
+var
+    OutPath,ErrPath:String;
+    Res:Longint;
+begin
+    OutPath:=ExpandConstant('{tmp}\')+LogKey+'.out';
+    ErrPath:=ExpandConstant('{tmp}\')+LogKey+'.err';
+    if ExecAsOriginalUser(ExpandConstant('{sys}\cmd.exe'),'/D /C "'+Cmd+' >"'+OutPath+'" 2>"'+ErrPath+'""','',SW_HIDE,ewWaitUntilTerminated,Res) and (Res=0) then
+        Result:=True
+    else begin
+        LogError(ErrorMessage+' (output: '+ReadFileAsString(OutPath)+', errors: '+ReadFileAsString(ErrPath)+').');
+        Result:=False;
+    end;
+end;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2850,6 +2850,49 @@ begin
     end;
 end;
 
+function UpgradeFromDotNetBasedScalar:Boolean;
+var
+    RegKey,UninstallScalar,ScalarExe,Cmd:String;
+    Res:Longint;
+    Enlistments:TArrayOfString;
+    i:Integer;
+begin
+    Result:=True;
+
+    RegKey:='SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{82F731CB-1CFC-406D-8D84-8467BF6040C7}_is1';
+    if not RegQueryStringValue(HKEY_LOCAL_MACHINE,RegKey,'UninstallString',UninstallScalar) then
+        // No existing Scalar found; ignore this silently
+        Exit;
+
+    // Check twice that .NET-based Scalar is there
+    ScalarExe:=UninstallScalar;
+    StringChangeEx(ScalarExe,'"','',True); // strip the surrounding double-quote characters
+    StringChangeEx(ScalarExe,'\unins000.exe','\scalar.exe',True);
+    if not FileExists(ScalarExe) then
+        Exit;
+
+    WizardForm.StatusLabel.Caption:='Upgrading from .NET-based Scalar';
+
+    // First, get .NET-based Scalar's idea of the registered enlistments
+    if not ExecSilently('"'+ScalarExe+'" list','scalar-list',ExpandConstant('Line {#__LINE__}: Unable to run `scalar list`')) then
+        Result:=False;
+    LoadStringsFromFile(ExpandConstant('{tmp}\scalar-list.out'),Enlistments);
+
+    // Now, register them with the C-based Scalar
+    for i:=0 to Length(Enlistments)-1 do begin
+        WizardForm.StatusLabel.Caption:='Registering '+Enlistments[i]+' with Scalar';
+        ExecSilentlyAsOriginalUser('"'+AppDir+'\cmd\scalar.exe" register "'+Enlistments[i]+'"','scalar-register-'+IntToStr(i),ExpandConstant('Line {#__LINE__}: Could not register "'+Enlistments[i]+'" with Scalar'));
+    end;
+
+    // Now uninstall the .NET-based Scalar
+    // (leaving C:\ProgramData\Scalar in place, in case
+    // the user needs to downgrade again to get unblocked)
+    WizardForm.StatusLabel.Caption:='Uninstalling .NET-based Scalar';
+    Cmd:='"'+UninstallScalar+'/VERYSILENT /SILENT /NORESTART /SUPPRESSMSGBOXES /LOG"';
+    if (not Exec(ExpandConstant('{sys}\cmd.exe'),'/D /C '+Cmd,'',SW_HIDE,ewWaitUntilTerminated,Res)) or (Res<>0) then
+        LogError('Could not uninstall Scalar. Trying to continue anyway.');
+end;
+
 procedure CurStepChanged(CurStep:TSetupStep);
 var
     DllPath,FileName,Cmd,Msg,Ico:String;
@@ -3249,7 +3292,8 @@ begin
            not DeleteFile(AppDir+'\{#MINGW_BITNESS}\share\doc\git-doc\scalar.html') then begin
             LogError('Line {#__LINE__}: Unable to delete "scalar.exe".');
         end;
-    end;
+    end else
+        UpgradeFromDotNetBasedScalar();
 #endif
 
     {

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -3292,8 +3292,10 @@ begin
            not DeleteFile(AppDir+'\{#MINGW_BITNESS}\share\doc\git-doc\scalar.html') then begin
             LogError('Line {#__LINE__}: Unable to delete "scalar.exe".');
         end;
-    end else
+    end else begin
         UpgradeFromDotNetBasedScalar();
+        ExecSilentlyAsOriginalUser('"'+AppDir+'\cmd\scalar.exe" reconfigure --all','scalar-reconfigure','Line {#__LINE__}: Could not reconfigure Scalar enlistments');
+    end;
 #endif
 
     {

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -114,6 +114,10 @@ Name: assoc_sh; Description: Associate .sh files to be run with Bash; Types: def
 Name: consolefont; Description: Use a TrueType font in all console windows; OnlyBelowVersion: 10.0
 Name: autoupdate; Description: Check daily for Git for Windows updates
 Name: windowsterminal; Description: "(NEW!) Add a Git Bash Profile to Windows Terminal"; MinVersion: 10.0.18362
+#ifdef WITH_SCALAR
+Name: scalar; Description: "(NEW!) Scalar (Git add-on to manage large-scale repositories)"; Types: default
+#endif
+
 
 [Run]
 Filename: {app}\git-bash.exe; Parameters: --cd-to-home; Description: Launch Git Bash; Flags: nowait postinstall skipifsilent runasoriginaluser unchecked
@@ -3231,6 +3235,22 @@ begin
         if not DeleteFile(AppDir+'\{#MINGW_BITNESS}\bin\git-lfs.exe') and not DeleteFile(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-lfs.exe') then
             LogError('Line {#__LINE__}: Unable to delete "git-lfs.exe".');
     end;
+
+    {
+        Handle Scalar
+    }
+
+#ifdef WITH_SCALAR
+    if not IsComponentSelected('scalar') then begin
+        // Remove scalar.exe from Git for Windows' files
+        if not DeleteFile(AppDir+'\cmd\scalar.exe') or
+           not DeleteFile(AppDir+'\{#MINGW_BITNESS}\bin\scalar.exe') or
+           not DeleteFile(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\scalar.exe') or
+           not DeleteFile(AppDir+'\{#MINGW_BITNESS}\share\doc\git-doc\scalar.html') then begin
+            LogError('Line {#__LINE__}: Unable to delete "scalar.exe".');
+        end;
+    end;
+#endif
 
     {
         Create the Windows Terminal integration

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -223,6 +223,12 @@ then
 	inno_defines="$inno_defines$LF#define WITH_EXPERIMENTAL_BUILTIN_FSMONITOR 1"
 fi
 
+case "$LIST" in
+*/scalar.exe*)
+	inno_defines="$inno_defines$LF#define WITH_SCALAR 1"
+	;;
+esac
+
 GITCONFIG_PATH="$(echo "$LIST" | grep "^$etc_gitconfig\$")"
 test -z "$GITCONFIG_PATH" || {
 	keys="$(git config -f "/$GITCONFIG_PATH" -l --name-only)" &&


### PR DESCRIPTION
Scalar is a project that tests out new strategies to make Git scale better. Over the years, hits like "partial clone" and "commit-graph" and `git maintenance` were developed in Scalar and then upstreamed into Git.

Over in the Microsoft fork, I am busy at work re-implementing the remaining parts of [Scalar](https://github.com/microsoft/scalar#readme) in C, putting them in `contrib/scalar/`. The idea is to eventually upstream all remaining bits and pieces of Scalar that do not require the GVFS protocol (which are only required because Azure Repos do not support partial clones, at time of writing).

To give this a smooth gliding path, I want to include the `contrib/scalar/` parts in the releases of the Microsoft fork first, given them some real world testing, and then start upstreaming.

To help with this, I want to teach Git for Windows' scripts to build the installer to prepare for this by offering the C Port of Scalar as an experimental option (if the `scalar.exe` artifacts are included in the installer's payload).