### PR TITLE
installer: offer the built-in FSMonitor explicitly as an option

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2249,7 +2249,7 @@ begin
      * Create a custom page for experimental options.
      *)
 
-    ExperimentalOptionsPage:=CreatePage(PrevPageID,'Configuring experimental options','Which bleeding-edge features would you like to enable?',TabOrder,Top,Left);
+    ExperimentalOptionsPage:=CreatePage(PrevPageID,'Configuring experimental options','These features are developed actively. Would you like to try them?',TabOrder,Top,Left);
 
 #ifdef WITH_EXPERIMENTAL_BUILTIN_DIFFTOOL
     RdbExperimentalOptions[GP_BuiltinDifftool]:=CreateCheckBox(ExperimentalOptionsPage,'Enable experimental, builtin difftool','Use the experimental builtin difftool (fast, but only lightly tested).',TabOrder,Top,Left);

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -409,6 +409,10 @@ const
 #define HAVE_EXPERIMENTAL_OPTIONS 1
 #endif
 
+#ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
+#define HAVE_EXPERIMENTAL_OPTIONS 1
+#endif
+
 #ifdef HAVE_EXPERIMENTAL_OPTIONS
     // Experimental options
     GP_BuiltinDifftool = 1;
@@ -416,6 +420,7 @@ const
     GP_BuiltinStash    = 3;
     GP_BuiltinAddI     = 4;
     GP_EnablePCon      = 5;
+    GP_EnableFSMonitor = 6;
 #endif
 
 var
@@ -496,7 +501,7 @@ var
 #ifdef HAVE_EXPERIMENTAL_OPTIONS
     // Wizard page and variables for the experimental options.
     ExperimentalOptionsPage:TWizardPage;
-    RdbExperimentalOptions:array[GP_BuiltinDifftool..GP_EnablePCon] of TCheckBox;
+    RdbExperimentalOptions:array[GP_BuiltinDifftool..GP_EnableFSMonitor] of TCheckBox;
 #endif
 
     // Mapping controls to hyperlinks
@@ -2286,6 +2291,13 @@ begin
     RdbExperimentalOptions[GP_EnablePCon].Checked:=ReplayChoice('Enable Pseudo Console Support','Auto')='Enabled';
 #endif
 
+#ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
+    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Enable experimental built-in file system monitor','<RED>(NEW!)</RED> Automatically run a built-in file system watcher, to speed up common'+#13+'operations such as `git status`, `git add`, `git commit`, etc in worktrees'+#13+'containing many files.',TabOrder,Top,Left);
+
+    // Restore the settings chosen during a previous install
+    RdbExperimentalOptions[GP_EnableFSMonitor].Checked:=ReplayChoice('Enable FSMonitor','Auto')='Enabled';
+#endif
+
 #endif
 
     PageIDBeforeInstall:=CurrentCustomPageID;
@@ -3032,6 +3044,13 @@ begin
         LogError('Could not write to '+ExpandConstant('{app}\etc\git-bash.config'));
 #endif
 
+#ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
+    if RdbExperimentalOptions[GP_EnableFSMonitor].checked then
+        GitSystemConfigSet('core.useBuiltinFSMonitor','true')
+    else
+        GitSystemConfigSet('core.useBuiltinFSMonitor',#0);
+#endif
+
     {
         Modify the environment
 
@@ -3420,6 +3439,14 @@ begin
         Data:='Enabled';
     end;
     RecordChoice(PreviousDataKey,'Enable Pseudo Console Support',Data);
+#endif
+
+#ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
+    Data:='Disabled';
+    if RdbExperimentalOptions[GP_EnableFSMonitor].Checked then begin
+        Data:='Enabled';
+    end;
+    RecordChoice(PreviousDataKey,'Enable FSMonitor',Data);
 #endif
 
     Path:=ExpandConstant('{app}\etc\install-options.txt');

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -218,6 +218,11 @@ then
 	inno_defines="$inno_defines$LF#define WITH_EXPERIMENTAL_PCON 1"
 fi
 
+if test -n "$(git version --build-options | grep fsmonitor--daemon)"
+then
+	inno_defines="$inno_defines$LF#define WITH_EXPERIMENTAL_BUILTIN_FSMONITOR 1"
+fi
+
 GITCONFIG_PATH="$(echo "$LIST" | grep "^$etc_gitconfig\$")"
 test -z "$GITCONFIG_PATH" || {
 	keys="$(git config -f "/$GITCONFIG_PATH" -l --name-only)" &&


### PR DESCRIPTION
It has been simmering in Git for Windows for a full release cycle, now it is time to give it even wider exposure. This is how the page looks at the moment:

<img src=https://user-images.githubusercontent.com/127790/119948881-94a9f580-bf99-11eb-8c39-5f708bd5eb22.png width=75% />

We might want to have a link to a verbose description of the built-in FSMonitor (such as a blog post), but I am not aware of any web page to which we could link. Maybe I'll have to blog about it...