### PR TITLE
installer: do show unseen experimental options

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -993,11 +993,14 @@ begin
         if (PageID<wpSelectComponents) and HasUnseenComponents then
             PageID:=wpSelectComponents
         else if (PageID<=wpSelectProgramGroup) then
-            PageID:=FirstCustomPageID;
-        while (PageID<PageIDBeforeInstall) and not IsInSet(CustomPagesWithUnseenOptions,PageID) do
+            PageID:=FirstCustomPageID
+        else
             PageID:=PageID+1;
-    end;
-    Result:=(PageID=PageIDBeforeInstall);
+        while (PageID<=PageIDBeforeInstall) and not IsInSet(CustomPagesWithUnseenOptions,PageID) do
+            PageID:=PageID+1;
+        Result:=(PageID>PageIDBeforeInstall);
+    end else
+        Result:=(PageID=PageIDBeforeInstall);
 end;
 
 procedure AdjustNextButtonLabel(Sender:TObject);


### PR DESCRIPTION
This fixes a long-standing bug that I only detected while trying to release Git for Windows v2.32.0-rc2: if there were unseen experimental options, they would not be shown by mistake, but skipped when "Only show new options" was checked.