### PR TITLE
installer: try to deal with running FSMonitor daemons gracefully

### DIFF
--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -1,5 +1,25 @@
 [Code]
 
+procedure LogError(Msg:String);
+begin
+    SuppressibleMsgBox(Msg,mbError,MB_OK,IDOK);
+    Log(Msg);
+end;
+
+function ReadFileAsString(Path:String):String;
+var
+    Contents:AnsiString;
+begin
+    if not LoadStringFromFile(Path,Contents) then
+        Result:='(no output)'
+    else
+        Result:=Contents;
+    if (Length(Result)>0) and (Result[Length(Result)]=#10) then
+        SetLength(Result,Length(Result)-1);
+    if (Length(Result)>0) and (Result[Length(Result)]=#13) then
+        SetLength(Result,Length(Result)-1);
+end;
+
 // Copies a NULL-terminated array of characters to a string.
 function ArrayToString(Chars:array of Char):String;
 var

--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -185,3 +185,18 @@ procedure SaveInfString(Section,Key,Value:String);
 begin
     SetIniString(Section,Key,Value,SaveInfFilename);
 end;
+
+function ExecSilently(Cmd,LogKey,ErrorMessage:String):Boolean;
+var
+    OutPath,ErrPath:String;
+    Res:Longint;
+begin
+    OutPath:=ExpandConstant('{tmp}\')+LogKey+'.out';
+    ErrPath:=ExpandConstant('{tmp}\')+LogKey+'.err';
+    if Exec(ExpandConstant('{sys}\cmd.exe'),'/D /C "'+Cmd+' >"'+OutPath+'" 2>"'+ErrPath+'""','',SW_HIDE,ewWaitUntilTerminated,Res) and (Res=0) then
+        Result:=True
+    else begin
+        LogError(ErrorMessage+' (output: '+ReadFileAsString(OutPath)+', errors: '+ReadFileAsString(ErrPath)+').');
+        Result:=False;
+    end;
+end;

--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -34,6 +34,13 @@ begin
     Result[i]:=#0;
 end;
 
+function AppendToArray(var AnArray:TArrayOfString;Str:String):Integer;
+begin
+    Result:=GetArrayLength(AnArray)+1;
+    SetArrayLength(AnArray,Result);
+    AnArray[Result-1]:=Str;
+end;
+
 // Deletes the currently processed file as part of Check, BeforeInstall or AfterInstall
 // from the user's virtual store to ensure the installed file is used.
 procedure DeleteFromVirtualStore;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -607,6 +607,7 @@ begin
     AppendToArray(Modules,AppDir+'\cmd\gitk.exe');
     AppendToArray(Modules,AppDir+'\cmd\git-gui.exe');
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\git.exe');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git.exe');
     AppendToArray(Modules,AppDir+'\usr\bin\bash.exe');
     SessionHandle:=FindProcessesUsingModules(Modules,Processes);
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -573,7 +573,7 @@ begin
 end;
 
 var
-    BuiltinFSMonitorStopOption:String;
+    BuiltinFSMonitorStopOption,AlreadyHandledFSMonitorPaths:String;
 
 // Returns true if at least one FSMonitor daemon was shut down successfully
 function ShutdownFSMonitorDaemons():Boolean;
@@ -588,8 +588,14 @@ begin
         Exit;
     if not FindFirst('\\.\pipe\*',FindRec) then
         Exit;
+    if (AlreadyHandledFSMonitorPaths='') then
+        AlreadyHandledFSMonitorPaths:=#0;
     repeat
         if WildcardMatch(FindRec.Name,'*\fsmonitor--daemon.ipc') or WildcardMatch(FindRec.Name,'*\.git\fsmonitor') then begin
+            if (Pos(#0+FindRec.Name+#0,AlreadyHandledFSMonitorPaths)>0) then
+                Continue;
+            AlreadyHandledFSMonitorPaths:=AlreadyHandledFSMonitorPaths+FindRec.Name+#0;
+
             // An earlier `fsmonitor--daemon` iteration called it `--stop`, not `stop`;
             // Find out which form to use.
             if (BuiltinFSMonitorStopOption='') then begin

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -287,12 +287,6 @@ Type: files; Name: {localappdata}\Microsoft\Windows Terminal\Fragments\Git\git-b
 #include "putty.inc.iss"
 #include "modules.inc.iss"
 
-procedure LogError(Msg:String);
-begin
-    SuppressibleMsgBox(Msg,mbError,MB_OK,IDOK);
-    Log(Msg);
-end;
-
 function ParamIsSet(Key:String):Boolean;
 begin
     Result:=CompareStr('0',ExpandConstant('{param:'+Key+'|0}'))<>0;
@@ -672,20 +666,6 @@ begin
     StringChangeEx(Value,#92,#92+#92,True);
     StringChangeEx(Value,#34,#92+#34,True);
     Result:=#34+Value+#34;
-end;
-
-function ReadFileAsString(Path:String):String;
-var
-    Contents:AnsiString;
-begin
-    if not LoadStringFromFile(Path,Contents) then
-        Result:='(no output)'
-    else
-        Result:=Contents;
-    if (Length(Result)>0) and (Result[Length(Result)]=#10) then
-        SetLength(Result,Length(Result)-1);
-    if (Length(Result)>0) and (Result[Length(Result)]=#13) then
-        SetLength(Result,Length(Result)-1);
 end;
 
 function GitSystemConfigSet(Key,Value:String):Boolean;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -593,24 +593,23 @@ begin
     end;
 
     // Use the Restart Manager API when installing the shell extension.
-    SetArrayLength(Modules,17);
-    Modules[0]:=AppDir+'\usr\bin\msys-2.0.dll';
-    Modules[1]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll';
-    Modules[2]:=AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll';
-    Modules[3]:=AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll';
-    Modules[4]:=AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll';
-    Modules[5]:=AppDir+'\git-cheetah\git_shell_ext.dll';
-    Modules[6]:=AppDir+'\git-cheetah\git_shell_ext64.dll';
-    Modules[7]:=AppDir+'\git-cmd.exe';
-    Modules[8]:=AppDir+'\git-bash.exe';
-    Modules[9]:=AppDir+'\bin\bash.exe';
-    Modules[10]:=AppDir+'\bin\git.exe';
-    Modules[11]:=AppDir+'\bin\sh.exe';
-    Modules[12]:=AppDir+'\cmd\git.exe';
-    Modules[13]:=AppDir+'\cmd\gitk.exe';
-    Modules[14]:=AppDir+'\cmd\git-gui.exe';
-    Modules[15]:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
-    Modules[16]:=AppDir+'\usr\bin\bash.exe';
+    AppendToArray(Modules,AppDir+'\usr\bin\msys-2.0.dll');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tcl85.dll');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll');
+    AppendToArray(Modules,AppDir+'\git-cheetah\git_shell_ext.dll');
+    AppendToArray(Modules,AppDir+'\git-cheetah\git_shell_ext64.dll');
+    AppendToArray(Modules,AppDir+'\git-cmd.exe');
+    AppendToArray(Modules,AppDir+'\git-bash.exe');
+    AppendToArray(Modules,AppDir+'\bin\bash.exe');
+    AppendToArray(Modules,AppDir+'\bin\git.exe');
+    AppendToArray(Modules,AppDir+'\bin\sh.exe');
+    AppendToArray(Modules,AppDir+'\cmd\git.exe');
+    AppendToArray(Modules,AppDir+'\cmd\gitk.exe');
+    AppendToArray(Modules,AppDir+'\cmd\git-gui.exe');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\git.exe');
+    AppendToArray(Modules,AppDir+'\usr\bin\bash.exe');
     SessionHandle:=FindProcessesUsingModules(Modules,Processes);
 
     ManualClosingRequired:=False;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2636,8 +2636,7 @@ end;
 
 procedure InstallAutoUpdater;
 var
-    Res:Longint;
-    LogPath,ErrPath,AppPath,XMLPath,Start:String;
+    AppPath,XMLPath,Start:String;
 begin
     Start:=GetDateTimeString('yyyy-mm-dd','-',':')+'T'+GetDateTimeString('hh:nn:ss','-',':');
     XMLPath:=ExpandConstant('{tmp}\auto-updater.xml');
@@ -2670,21 +2669,12 @@ begin
         '    </Exec>'+
         '  </Actions>'+
         '</Task>',False);
-    LogPath:=ExpandConstant('{tmp}\remove-autoupdate.log');
-    ErrPath:=ExpandConstant('{tmp}\remove-autoupdate.err');
-    if not Exec(ExpandConstant('{sys}\cmd.exe'),ExpandConstant('/D /C schtasks /Create /F /TN "Git for Windows Updater" /XML "'+XMLPath+'" >"'+LogPath+'" 2>"'+ErrPath+'"'),'',SW_HIDE,ewWaitUntilTerminated,Res) or (Res<>0) then
-        LogError(ExpandConstant('Line {#__LINE__}: Unable to schedule the Git for Windows updater (output: '+ReadFileAsString(LogPath)+', errors: '+ReadFileAsString(ErrPath)+').'));
+    ExecSilently('schtasks /Create /F /TN "Git for Windows Updater" /XML "'+XMLPath+'"','install-autoupdate',ExpandConstant('Line {#__LINE__}: Unable to schedule the Git for Windows updater'));
 end;
 
 procedure UninstallAutoUpdater;
-var
-    Res:Longint;
-    LogPath,ErrPath:String;
 begin
-    LogPath:=ExpandConstant('{tmp}\remove-autoupdate.log');
-    ErrPath:=ExpandConstant('{tmp}\remove-autoupdate.err');
-    if not Exec(ExpandConstant('{sys}\cmd.exe'),ExpandConstant('/D /C schtasks /Delete /F /TN "Git for Windows Updater" >"'+LogPath+'" 2>"'+ErrPath+'"'),'',SW_HIDE,ewWaitUntilTerminated,Res) or (Res<>0) then
-        LogError(ExpandConstant('Line {#__LINE__}: Unable to remove the Git for Windows updater (output: '+ReadFileAsString(LogPath)+', errors: '+ReadFileAsString(ErrPath)+').'));
+    ExecSilently('schtasks /Delete /F /TN "Git for Windows Updater"','remove-autoupdate',ExpandConstant('Line {#__LINE__}: Unable to remove the Git for Windows updater'));
 end;
 
 procedure InstallWindowsTerminalFragment;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -598,8 +598,6 @@ begin
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll');
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll');
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll');
-    AppendToArray(Modules,AppDir+'\git-cheetah\git_shell_ext.dll');
-    AppendToArray(Modules,AppDir+'\git-cheetah\git_shell_ext64.dll');
     AppendToArray(Modules,AppDir+'\git-cmd.exe');
     AppendToArray(Modules,AppDir+'\git-bash.exe');
     AppendToArray(Modules,AppDir+'\bin\bash.exe');

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -598,17 +598,8 @@ begin
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tk85.dll');
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tcl86.dll');
     AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\tk86.dll');
-    AppendToArray(Modules,AppDir+'\git-cmd.exe');
-    AppendToArray(Modules,AppDir+'\git-bash.exe');
-    AppendToArray(Modules,AppDir+'\bin\bash.exe');
-    AppendToArray(Modules,AppDir+'\bin\git.exe');
-    AppendToArray(Modules,AppDir+'\bin\sh.exe');
-    AppendToArray(Modules,AppDir+'\cmd\git.exe');
-    AppendToArray(Modules,AppDir+'\cmd\gitk.exe');
-    AppendToArray(Modules,AppDir+'\cmd\git-gui.exe');
-    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\git.exe');
-    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git.exe');
-    AppendToArray(Modules,AppDir+'\usr\bin\bash.exe');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\bin\zlib1.dll');
+    AppendToArray(Modules,AppDir+'\{#MINGW_BITNESS}\libexec\git-core\zlib1.dll');
     SessionHandle:=FindProcessesUsingModules(Modules,Processes);
 
     ManualClosingRequired:=False;


### PR DESCRIPTION
We now have long-running Git processes, processes that would potentially block upgrades.

However, due to a mistake the installer would not show them: we only looked for processes using `/mingw64/bin/git.exe` (or the equivalent in 32-bit setups), while the FSMonitor daemon typically runs via `/mingw64/libexec/git-core/git.exe`, namely when it was spawned implicitly.

Since the installer missed these processes, they would not be killed, and InnoSetup would "helpfully" require a reboot after the upgrade.

This PR not only plugs that hole by detecting more Git processes, but also brings code to automatically shut down all FSMonitor daemons before the actual upgrade.

The method presented here might not be ideal, but is probably a bit more robust and simpler than the approach implemented inhttps://github.com/git-for-windows/git/pull/3237 (which would still have required a bit of work on the installer in order not to bother the user about needing to stop Git processes manually).