### PR TITLE
Link to the FSMonitor discussion from the release notes/the installer

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -47,7 +47,7 @@ This package contains software from a number of other projects including Bash, z
 * The installer now offers to install [a Windows Terminal profile](https://github.com/git-for-windows/build-extra/pull/339).
 * Comes with [cURL v7.77.0](https://curl.haxx.se/changes.html#7_77_0).
 * Comes with [PCRE2 v10.37](https://pcre.org/news.txt).
-* The experimental, built-in file system monitor [is now featured as an experimental option in the installer](https://github.com/git-for-windows/build-extra/pull/351).
+* The experimental, built-in [file system monitor](https://github.com/git-for-windows/git/discussions/3251) is now [featured as an experimental option in the installer](https://github.com/git-for-windows/build-extra/pull/351).
 * Comes with [Git Credential Manager Core v2.0.474.41365](https://github.com/microsoft/git-credential-manager-core/releases/tag/v2.0.474).
 
 ### Bug Fixes

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2339,7 +2339,7 @@ begin
 #endif
 
 #ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
-    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Enable experimental built-in file system monitor','<RED>(NEW!)</RED> Automatically run a built-in file system watcher, to speed up common'+#13+'operations such as `git status`, `git add`, `git commit`, etc in worktrees'+#13+'containing many files.',TabOrder,Top,Left);
+    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Enable experimental built-in file system monitor','<RED>(NEW!)</RED> Automatically run a <A HREF=https://github.com/git-for-windows/git/discussions/3251>built-in file system watcher</A>, to speed up common'+#13+'operations such as `git status`, `git add`, `git commit`, etc in worktrees'+#13+'containing many files.',TabOrder,Top,Left);
 
     // Restore the settings chosen during a previous install
     RdbExperimentalOptions[GP_EnableFSMonitor].Checked:=ReplayChoice('Enable FSMonitor','Auto')='Enabled';


### PR DESCRIPTION
I just posted a "Show and Tell" in Git for Windows' discussions: https://github.com/git-for-windows/git/discussions/3251

A strong motivator for that was to have a place to which I can point interested readers who wish to find out what the FSMonitor business is all about.

So let's point them there, from the release notes, and from Git for Windows' installer.