### PR TITLE
installer: Support Sublime Text 4 and (probably) newer

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -49,6 +49,7 @@ This package contains software from a number of other projects including Bash, z
 * Comes with [PCRE2 v10.37](https://pcre.org/news.txt).
 * The experimental, built-in file system monitor [is now featured as an experimental option in the installer](https://github.com/git-for-windows/build-extra/pull/351).
 * Comes with [Git Credential Manager Core v2.0.474.41365](https://github.com/microsoft/git-credential-manager-core/releases/tag/v2.0.474).
+* Sublime Text 4 [now gets detected by the installer](https://github.com/git-for-windows/build-extra/pull/355).
 
 ### Bug Fixes
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1810,11 +1810,15 @@ begin
         EditorAvailable[GE_VisualStudioCodeInsiders]:=RegQueryStringValue(HKEY_CURRENT_USER,'Software\Classes\Applications\Code - Insiders.exe\shell\open\command','',VisualStudioCodeInsidersPath);
         VisualStudioCodeInsidersUserInstallation:=True;
     end;
-    SublimeTextPath:=ExpandConstant('{pf}\Sublime Text 3\subl.exe');
+    SublimeTextPath:=ExpandConstant('{pf}\Sublime Text\subl.exe');
     EditorAvailable[GE_SublimeText]:=PathIsValidExecutable(SublimeTextPath);
     if (not EditorAvailable[GE_SublimeText]) then begin
-        EditorAvailable[GE_SublimeText]:=RegQueryStringValue(HKEY_CURRENT_USER,'Software\Classes\Applications\sublime_text.exe\shell\open\command','',SublimeTextPath);
-        SublimeTextUserInstallation:=True;
+        SublimeTextPath:=ExpandConstant('{pf}\Sublime Text 3\subl.exe');
+        EditorAvailable[GE_SublimeText]:=PathIsValidExecutable(SublimeTextPath);
+        if (not EditorAvailable[GE_SublimeText]) then begin
+            EditorAvailable[GE_SublimeText]:=RegQueryStringValue(HKEY_CURRENT_USER,'Software\Classes\Applications\sublime_text.exe\shell\open\command','',SublimeTextPath);
+            SublimeTextUserInstallation:=True;
+        end;
     end;
     EditorAvailable[GE_Atom]:=RegQueryStringValue(HKEY_CURRENT_USER,'Software\Classes\Applications\atom.exe\shell\open\command','',AtomPath);
     EditorAvailable[GE_CustomEditor]:=True;


### PR DESCRIPTION
Sublime Text has recently been released as version 4. Along with this new
version the install directory has been changed to no longer include the version
number in the directory name. Change the installer to detect newer versions of
Sublime Text and prefer them over version 3.

This fixes git-for-windows/git#3248