### PR TITLE
provide explicit GUID for Windows Terminal profile

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2771,6 +2771,7 @@ begin
         '{'+
         '    "profiles": ['+
         '      {'+
+        '        "guid": "{2ece5bfe-50ed-5f3a-ab87-5cd4baafed2b}",'+
         '        "name": "Git Bash",'+
         '        "commandline": "'+AppPath+'/bin/bash.exe -i -l",'+
         '        "icon": "'+AppPath+'/{#MINGW_BITNESS}/share/git/git-for-windows.ico",'+


### PR DESCRIPTION
This allows user-customizations of the profile to continue to refer to the profile even if its name or directory should change.

Based on discussion from https://github.com/microsoft/terminal/issues/10374 and https://github.com/git-for-windows/build-extra/pull/339#issuecomment-857043296