### PR TITLE
Warn about switching away from .vfs versions

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1112,6 +1112,11 @@ begin
                 Result:=False;
         end;
     end;
+
+    // Warn about switching away from VFS-enabled Git
+    if Result and (Pos('.vfs.','{#GIT_VERSION}')=0) and (Pos('.vfs.',GetPreviousGitVersion())>0) then
+        if SuppressibleMsgBox('The VFS for Git-aware flavor of Git for Windows is currently installed.'+#13+'Switching away from that flavor might break your Scalar/VFS for Git enlistments.'+#13+'Do you still want to switch?',mbConfirmation,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO then
+            Result:=False;
 #endif
 end;
 


### PR DESCRIPTION
The most likely reasons why users have .vfs versions (i.e. Git for Windows flavors whose `git version` show something like `git version 2.31.1.vfs.0.1`) is that they have downloaded VFS for Git or Scalar and cloned from an Azure Repo.

In such a scenario, it would not be good to switch away from a .vfs version because regular Git for Windows has no support to talk the GVFS protocol (which is used by the .vfs flavor to emulate partial clones), and therefore their VFS for Git or Scalar enlistments would be broken as a consequence.

Let's try to be helpful in such circumstances and give the user a chance to stay with the working setup. This is how it will look like:

<img width=75% src=https://user-images.githubusercontent.com/127790/121523643-ba51e880-c9f6-11eb-8d12-8e8b2354d8b6.png />
