### PR TITLE
Enable Tab-completion of `git update-git-for-windows`

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -137,7 +137,7 @@ package() {
   install -m644 msys2-32.ico $pkgdir/usr/share/git
   install -m644 99-post-install-cleanup.post $pkgdir/etc/post-install
   install -m755 astextplain $pkgdir/usr/bin
-  install -m755 git-update-git-for-windows $pkgdir${MINGW_PREFIX}/libexec/git-core
+  install -m755 git-update-git-for-windows $pkgdir${MINGW_PREFIX}/bin
   install -m755 git-update $pkgdir${MINGW_PREFIX}/libexec/git-core
   install -m755 update-via-pacman.bat $pkgdir
   install -m755 zzz_rm_stackdumps.sh $pkgdir/usr/share/makepkg/lint_package


### PR DESCRIPTION
It annoyed me one too many times that `git up<Tab>` would not show the `update-git-for-windows` command. So I fixed it.