### PR TITLE
installer: avoid trying to register missing Scalar enlistments

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2901,8 +2901,10 @@ begin
 
     // Now, register them with the C-based Scalar
     for i:=0 to Length(Enlistments)-1 do begin
-        WizardForm.StatusLabel.Caption:='Registering '+Enlistments[i]+' with Scalar';
-        ExecSilentlyAsOriginalUser('"'+AppDir+'\cmd\scalar.exe" register "'+Enlistments[i]+'"','scalar-register-'+IntToStr(i),ExpandConstant('Line {#__LINE__}: Could not register "'+Enlistments[i]+'" with Scalar'));
+        if DirExists(Enlistments[i]) then begin
+            WizardForm.StatusLabel.Caption:='Registering '+Enlistments[i]+' with Scalar';
+            ExecSilentlyAsOriginalUser('"'+AppDir+'\cmd\scalar.exe" register "'+Enlistments[i]+'"','scalar-register-'+IntToStr(i),ExpandConstant('Line {#__LINE__}: Could not register "'+Enlistments[i]+'" with Scalar'));
+        end;
     end;
 
     // Now uninstall the .NET-based Scalar


### PR DESCRIPTION
Under certain circumstances, enlistments registered with Scalar.NET were removed without being unregistered.

Do not try to register them.