### PR TITLE
make-file-list.sh: don't exclude /usr/share/nano

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -188,7 +188,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/share/perl5/core_perl/CPAN/' \
 	-e '^/usr/share/perl5/core_perl/TAP/' \
 	-e '^/usr/share/vim/vim74/lang/' \
-	-e '^/usr/share/\(bash-completion\|makepkg\|nano\)/' \
+	-e '^/usr/share/\(bash-completion\|makepkg\)/' \
 	-e '^/update-via-pacman.bat$' \
 	-e '^/etc/profile.d/git-sdk.sh$' |
 if test -n "$WITH_L10N" && test -z "$MINIMAL_GIT"


### PR DESCRIPTION
The files in there are used by nano for syntax highlighting
and get included from our `/ec/nanorc`.

This is a partial revert of 43db63670e49f (make-file-list: exclude some unneeded files).
This fixes git-for-windows/git#3315

We might still want to exclude them for MinGit, but not the rest.