### PR TITLE
Add choice for external OpenSSH

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -469,7 +469,7 @@ var
     RdbPath:array[GP_BashOnly..GP_CmdTools] of TRadioButton;
 
     // Wizard page and variables for the SSH options.
-    PuTTYPage:TWizardPage;
+    SSHChoicePage:TWizardPage;
     RdbSSH:array[GS_OpenSSH..GS_Plink] of TRadioButton;
     EdtPlink:TEdit;
     TortoisePlink:TCheckBox;
@@ -2063,18 +2063,18 @@ begin
      *)
 
     if RegGetSubkeyNames(HKEY_CURRENT_USER,'Software\SimonTatham\PuTTY\Sessions',PuTTYSessions) and (GetArrayLength(PuTTYSessions)>0) then begin
-        PuTTYPage:=CreatePage(PrevPageID,'Choosing the SSH executable','Which Secure Shell client program would you like Git to use?',TabOrder,Top,Left);
+        SSHChoicePage:=CreatePage(PrevPageID,'Choosing the SSH executable','Which Secure Shell client program would you like Git to use?',TabOrder,Top,Left);
 
         // 1st choice
-        RdbSSH[GS_OpenSSH]:=CreateRadioButton(PuTTYPage,'Use bundled OpenSSH','This uses ssh.exe that comes with Git.',TabOrder,Top,Left);
+        RdbSSH[GS_OpenSSH]:=CreateRadioButton(SSHChoicePage,'Use bundled OpenSSH','This uses ssh.exe that comes with Git.',TabOrder,Top,Left);
 
         // 2nd choice
-        RdbSSH[GS_Plink]:=CreateRadioButton(PuTTYPage,'Use (Tortoise)Plink','To use PuTTY, specify the path to an existing copy of (Tortoise)Plink.exe:',TabOrder,Top,Left);
-        EdtPlink:=TEdit.Create(PuTTYPage);
+        RdbSSH[GS_Plink]:=CreateRadioButton(SSHChoicePage,'Use (Tortoise)Plink','To use PuTTY, specify the path to an existing copy of (Tortoise)Plink.exe:',TabOrder,Top,Left);
+        EdtPlink:=TEdit.Create(SSHChoicePage);
         EdtPlink.Left:=ScaleX(Left+24);
         EdtPlink.Top:=ScaleY(Top);
         with EdtPlink do begin
-            Parent:=PuTTYPage.Surface;
+            Parent:=SSHChoicePage.Surface;
 
             EnvSSH:=GetEnvStrings('GIT_SSH',IsAdminLoggedOn);
             if (GetArrayLength(EnvSSH)=1) and IsPlinkExecutable(EnvSSH[0]) then begin
@@ -2095,11 +2095,11 @@ begin
             TabOrder:=TabOrder;
         end;
         TabOrder:=TabOrder+1;
-        BtnPlink:=TButton.Create(PuTTYPage);
+        BtnPlink:=TButton.Create(SSHChoicePage);
         BtnPlink.Left:=ScaleX(Left+344);
         BtnPlink.Top:=ScaleY(Top);
         with BtnPlink do begin
-            Parent:=PuTTYPage.Surface;
+            Parent:=SSHChoicePage.Surface;
             Caption:='...';
             OnClick:=@BrowseForPuTTYFolder;
             Width:=ScaleX(21);
@@ -2110,12 +2110,12 @@ begin
         Top:=Top+29;
 
         // Add checkbox for tortoise plink
-        TortoisePlink:=TCheckBox.Create(PuTTYPage);
+        TortoisePlink:=TCheckBox.Create(SSHChoicePage);
         TortoisePlink.Left:=ScaleX(Left+24);
         TortoisePlink.Top:=ScaleY(Top);
         with TortoisePlink do begin
             Caption:='Set ssh.variant for Tortoise Plink';
-            Parent:=PuTTYPage.Surface;
+            Parent:=SSHChoicePage.Surface;
             Width:=ScaleX(405);
             Height:=ScaleY(17);
             TabOrder:=TabOrder;
@@ -2135,7 +2135,7 @@ begin
         if (data='true') then
             TortoisePlink.Checked:=True;
     end else begin
-        PuTTYPage:=NIL;
+        SSHChoicePage:=NIL;
     end;
 
     (*
@@ -2486,7 +2486,7 @@ begin
             Wizardform.NextButton.Enabled:=False;
             Exit;
         end;
-    end else if (PuTTYPage<>NIL) and (CurPageID=PuTTYPage.ID) then begin
+    end else if (SSHChoicePage<>NIL) and (CurPageID=SSHChoicePage.ID) then begin
         Result:=RdbSSH[GS_OpenSSH].Checked or
             (RdbSSH[GS_Plink].Checked and FileExists(EdtPlink.Text));
         if not Result then begin
@@ -3158,7 +3158,7 @@ begin
     DeleteMarkedEnvString('GIT_SSH');
     DeleteMarkedEnvString('SVN_SSH');
 
-    if (PuTTYPage<>NIL) then begin
+    if (SSHChoicePage<>NIL) then begin
         GitSystemConfigSet('ssh.variant',#0);
         if RdbSSH[GS_Plink].Checked then begin
             SetAndMarkEnvString('GIT_SSH',EdtPlink.Text,True);
@@ -3460,7 +3460,7 @@ begin
     // Git SSH options.
     Data:='';
     Data2:='false';
-    if (PuTTYPage=NIL) or RdbSSH[GS_OpenSSH].Checked then begin
+    if (SSHChoicePage=NIL) or RdbSSH[GS_OpenSSH].Checked then begin
         Data:='OpenSSH';
     end else if RdbSSH[GS_Plink].Checked then begin
         Data:='Plink';

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2066,15 +2066,10 @@ begin
         PuTTYPage:=CreatePage(PrevPageID,'Choosing the SSH executable','Which Secure Shell client program would you like Git to use?',TabOrder,Top,Left);
 
         // 1st choice
-        RdbSSH[GS_OpenSSH]:=CreateRadioButton(PuTTYPage,'Use OpenSSH','This uses ssh.exe that comes with Git. The GIT_SSH and SVN_SSH'+#13+'environment variables will not be modified.',TabOrder,Top,Left);
+        RdbSSH[GS_OpenSSH]:=CreateRadioButton(PuTTYPage,'Use bundled OpenSSH','This uses ssh.exe that comes with Git.',TabOrder,Top,Left);
 
         // 2nd choice
-        RdbSSH[GS_Plink]:=CreateRadioButton(PuTTYPage,'Use (Tortoise)Plink',
-            'PuTTY sessions were found in your Registry. You may specify the path'+#13+
-            'to an existing copy of (Tortoise)Plink.exe from the TortoiseGit/SVN/CVS'+#13+
-            'or PuTTY applications. "ssh.variant" will be set in the GIT configuration. '+#13+
-            'The GIT_SSH and SVN_SSH environment variables will be adjusted to point '+#13+
-            'to the following executable:',TabOrder,Top,Left);
+        RdbSSH[GS_Plink]:=CreateRadioButton(PuTTYPage,'Use (Tortoise)Plink','To use PuTTY, specify the path to an existing copy of (Tortoise)Plink.exe:',TabOrder,Top,Left);
         EdtPlink:=TEdit.Create(PuTTYPage);
         EdtPlink.Left:=ScaleX(Left+24);
         EdtPlink.Top:=ScaleY(Top);

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -278,6 +278,15 @@ then
 	inno_defines="$inno_defines$LF#define DEFAULT_BRANCH_NAME '$(cat init.defaultBranch)'"
 fi
 
+# 1. Collect all SSH related files from $LIST and pacman, sort each and then return the overlap
+# 2. Convert paths to Windows filesystem compatible ones and construct the function body for the DeleteOpenSSHFiles function; one DeleteFile operation per file found
+# 3. Construct DeleteOpenSSHFiles function signature to be used in install.iss
+# 4. Assemble function body and compile flag to be used as guard in install.iss
+openssh_deletes="$(comm -12 <(echo "$LIST" | sort) <(pacman -Ql openssh | sed -n 's|^openssh /\(.*[^/]\)$|\1|p' | sort) |
+	sed -e 'y/\//\\/' -e "s|.*|    if not DeleteFile(AppDir+'\\\\&') then\n        Result:=False;|")"
+inno_defines="$inno_defines$LF[Code]${LF}function DeleteOpenSSHFiles():Boolean;${LF}var$LF    AppDir:String;${LF}begin$LF    AppDir:=ExpandConstant('{app}');$LF    Result:=True;"
+inno_defines="$inno_defines$LF$openssh_deletes${LF}end;$LF#define DELETE_OPENSSH_FILES 1"
+
 test -z "$LIST" ||
 echo "$LIST" |
 sed -e 's|/|\\|g' \


### PR DESCRIPTION
This pull request addresses git-for-windows/git/issues/1683 and git-for-windows/git/issues/2944 by adding an additional detecting mechanism for Windows OpenSSH to the choice page formerly known as PuTTYPage and allows the user to "skip" the installation of the bundled SSH related binaries that Windows also supplies.

![Screenshot 2021-07-22 at 17 17 29](https://user-images.githubusercontent.com/887496/126666552-c037235f-8cb2-4f5c-b318-641189087a02.png)
When selected this allows interaction between for example KeePassXC OpenSSH agent integration and Git. This may partially address keepassxreboot/keepassxc/issues/4681 I suppose.

![Screenshot 2021-07-22 at 17 27 25](https://user-images.githubusercontent.com/887496/126666503-e69653d0-9ea3-4075-8cc4-a428c6ea0822.png)
There is a small problem with the choice page, though, at the moment because the installer window is not tall enough to fully display the choices.
I suppose rewording the texts or omitting the PuTTY/Plink option if it wasn't successfully detected would work?

Also I have no 32Bit system to test this with 🤷‍♂️ 

Window supplies the following OpenSSH related binaries as documented [here](https://docs.microsoft.com/en-us/windows-server/administration/openssh/openssh_overview).

Microsoft built OpenSSH independent from Windows is available [here](https://github.com/PowerShell/openssh-portable) and releases are tracked [here](https://github.com/powershell/Win32-OpenSSH).
