### PR TITLE
GCM Core: don't strip signatures

### DIFF
--- a/mingw-w64-git-credential-manager-core/PKGBUILD
+++ b/mingw-w64-git-credential-manager-core/PKGBUILD
@@ -15,6 +15,7 @@ zip_url="${project_url}/releases/download/${_realtag}/gcmcore-win-x86-${_realver
 src_zip_url="${project_url}/archive/${_realtag}.zip"
 license=('MIT')
 groups=('VCS')
+options=('!strip')
 
 source=("${zip_url}" "$src_zip_url")
 


### PR DESCRIPTION
Stripping assembly signatures out of PE files without adjusting the header information leads to corrupted binaries. That causes issues with our effort to cresate an MSIX package.