### PR TITLE
Some hot fixes for the installer, in preparation for v2.33.0-rc2

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -47,6 +47,7 @@ This package contains software from a number of other projects including Bash, z
 * Comes with [Perl v5.34.0](http://search.cpan.org/dist/perl-5.34.0/pod/perldelta.pod) (and some updated Perl modules).
 * It is [now possible](https://github.com/git-for-windows/build-extra/pull/367) to ask Git for Windows to use an SSH found on the `PATH` instead of its bundled OpenSSH executable.
 * Comes with [Git Credential Manager Core v2.0.498.54650](https://github.com/microsoft/git-credential-manager-core/releases/tag/v2.0.498).
+* The experimental FSMonitor patches were replaced with [a newer version](https://github.com/git-for-windows/git/pull/3350).
 
 ### Bug Fixes
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -610,7 +610,7 @@ begin
                 BuiltinFSMonitorStopOption:='(huh?)';
                 if not ExecWithCapture('"'+AppDir+'\cmd\git.exe" fsmonitor--daemon -h',Str,Str,ExitCode) or (ExitCode<>129) then begin
                     if (i<>1) and (i<>127) then // Suppress message if `git.exe` was not found, or if it does not know about the built-in FSMonitor
-                        LogError('Could not get FSMonitor help (exit code'++IntToStr(ExitCode)+'):'+#13+Str);
+                        LogError('Could not get FSMonitor help (exit code '+IntToStr(ExitCode)+'):'+#13+Str);
                     Exit;
                 end else begin
                     i:=Pos('stop'+#10,Str);

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2144,8 +2144,8 @@ begin
 
         // 3rd choice
         RdbSSH[GS_ExternalOpenSSH]:=CreateRadioButton(SSHChoicePage,'Use external OpenSSH',
-            'This uses an external ssh.exe. Git will not install its own OpenSSH (related)'+#13+
-            'binaries but use them as found on the PATH.',
+            '<RED>NEW!</RED> This uses an external ssh.exe. Git will not install its own OpenSSH'+#13+
+            '(and related) binaries but use them as found on the PATH.',
             TabOrder,Top,Left);
 
         // Restore the setting chosen during a previous install.

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -636,6 +636,14 @@ begin
             if (Length(Path)>2) and (Path[2]='_') then
                 Path[2]:=':';
 
+            // Now we have the gitdir, but we need to get to the worktree
+            if FileExists(Path+'\gitdir') then begin
+                Path:=ReadFileAsString(Path+'\gitdir');
+                StringChangeEx(Path,'/','\',True);
+            end;
+            if WildcardMatch(Path,'*\.git') then
+                Path:=Copy(Path,1,Length(Path)-5);
+
             if ExecSilently('"'+AppDir+'\cmd\git.exe" -C "'+Path+'" fsmonitor--daemon '+BuiltinFSMonitorStopOption,'fsmonitor-stop','Could not stop FSMonitor daemon in '+Path) then
                 Result:=True;
         end;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -997,7 +997,10 @@ begin
 #ifdef GIT_VERSION
     if Result or (CountDots(CurrentVersion)>3) or (CountDots(PreviousGitForWindowsVersion)>3) then begin
         // maybe the previous version was a prerelease (prereleases have five numbers: v2.24.0-rc1.windows.1 reduces to '2.24.0.1.1')?
-        CurrentVersion:='{#GIT_VERSION}';
+        if CurrentVersion=ExpandConstant('{#APP_VERSION}') then
+            CurrentVersion:='{#GIT_VERSION}'
+        else
+            CurrentVersion:='git version '+CurrentVersion+'.windows.1';
         Result:=(VersionCompare(CurrentVersion,GetPreviousGitVersion())<0);
     end;
 #endif

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2157,6 +2157,10 @@ begin
             RdbSSH[GS_OpenSSH].Checked:=True;
         end;
 
+        // Even if the user saw the Tortoise options before v2.33.0, the external SSH choice was not seen yet
+        if IsUpgrade('2.33.0') then
+            AddToSet(CustomPagesWithUnseenOptions,SSHChoicePage.ID);
+
         data:=ReplayChoice('Tortoise Option','');
         if (data='true') then
             TortoisePlink.Checked:=True;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1102,10 +1102,12 @@ begin
         end;
     end;
 
+#ifdef GIT_VERSION
     // Warn about switching away from VFS-enabled Git
     if Result and (Pos('.vfs.','{#GIT_VERSION}')=0) and (Pos('.vfs.',GetPreviousGitVersion())>0) then
         if SuppressibleMsgBox('The VFS for Git-aware flavor of Git for Windows is currently installed.'+#13+'Switching away from that flavor might break your Scalar/VFS for Git enlistments.'+#13+'Do you still want to switch?',mbConfirmation,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO then
             Result:=False;
+#endif
 #endif
 end;
 

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -49,7 +49,7 @@ do
 		   ! grep "^ *$page:TWizardPage;$" install.iss >/dev/null &&
 		   ! grep "^ *$page:TInputFileWizardPage;$" install.iss >/dev/null
 		then
-			echo "Unknown page '$page'. Known pages:" >&2
+			printf 'Unknown page "%s". Known pages:\n    %s\n' "$page" wpSelectComponents >&2
 			sed -n -e 's/:TWizardPage;$//p' -e 's/:TInputFileWizardPage;$//p' <install.iss >&2
 			exit 1
 		fi


### PR DESCRIPTION
This fixes three problems I just saw while testing a tentative version of the -rc2 installer:

- The running instances of the FSMonitor daemon did not shut down properly because the stop command was invoked from the gitdirs instead of the worktree directories, and FSMonitor now mistakes the former scenario for being called in a bare repository.
- The components page was shown still, to show the Windows Terminal Profile option (which was new in v2.32.0), even if upgrading _from v2.32.0_.
- The "external SSH" choice was not shown when running the installer in the "Only show unseen options" mode, even if it could not possibly have been seen before v2.33.0.

[EDIT] While at it, I also added the missing entry in the release notes where I want to mention that the FSMonitor patches were updated.