### PR TITLE
Teach the installer that it is relatively safe to terminate any running GPG agent

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2579,7 +2579,7 @@ begin
 
         if not Result then begin
             Result:=(SuppressibleMsgBox(
-                'If you continue without closing the listed applications they will be closed and restarted automatically.' + #13 + #13 +
+                'If you continue without closing the listed applications they will be terminated/restarted automatically.' + #13 + #13 +
                 'Are you sure you want to continue?'
             ,   mbConfirmation
             ,   MB_YESNO

--- a/installer/modules.inc.iss
+++ b/installer/modules.inc.iss
@@ -537,7 +537,7 @@ begin
                 Processes[Have].ID:=AppList[i].Process.dwProcessId;
                 Processes[Have].Name:=ArrayToString(AppList[i].strAppName);
                 Processes[Have].Restartable:=AppList[i].bRestartable;
-                if (Pos('ssh-add.exe',Processes[Have].Name)>0) or (Pos('ssh-agent.exe',Processes[Have].Name)>0) or (Pos('ssh-pageant.exe',Processes[Have].Name)>0) then
+                if ('ssh-add'=Processes[Have].Name) or ('ssh-agent'=Processes[Have].Name) or ('ssh-pageant'=Processes[Have].Name) then
                     Processes[Have].ToTerminate:=True;
             end;
             Result:=Handle;

--- a/installer/modules.inc.iss
+++ b/installer/modules.inc.iss
@@ -538,7 +538,7 @@ begin
                 Processes[Have].Name:=ArrayToString(AppList[i].strAppName);
                 Processes[Have].Restartable:=AppList[i].bRestartable;
                 if (Pos('ssh-add.exe',Processes[Have].Name)>0) or (Pos('ssh-agent.exe',Processes[Have].Name)>0) or (Pos('ssh-pageant.exe',Processes[Have].Name)>0) then
-		    Processes[Have].ToTerminate:=True;
+                    Processes[Have].ToTerminate:=True;
             end;
             Result:=Handle;
         end;

--- a/installer/modules.inc.iss
+++ b/installer/modules.inc.iss
@@ -537,7 +537,7 @@ begin
                 Processes[Have].ID:=AppList[i].Process.dwProcessId;
                 Processes[Have].Name:=ArrayToString(AppList[i].strAppName);
                 Processes[Have].Restartable:=AppList[i].bRestartable;
-                if ('ssh-add'=Processes[Have].Name) or ('ssh-agent'=Processes[Have].Name) or ('ssh-pageant'=Processes[Have].Name) then
+                if ('ssh-add'=Processes[Have].Name) or ('ssh-agent'=Processes[Have].Name) or ('ssh-pageant'=Processes[Have].Name) or ('gpg-agent'=Processes[Have].Name) or ('scdaemon'=Processes[Have].Name) then
                     Processes[Have].ToTerminate:=True;
             end;
             Result:=Handle;


### PR DESCRIPTION
The GPG agent is started automatically. While running, it prevents the corresponding files from being replaced. Therefore, it has to be stopped before upgrading Git for Windows.

This PR does that, and cleans up a bit more while in the neighborhood.