### PR TITLE
installer: fix missing check for SSH choice

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -3365,7 +3365,7 @@ begin
     }
 
 #ifdef DELETE_OPENSSH_FILES
-    if RdbSSH[GS_ExternalOpenSSH].Checked then begin
+    if (SSHChoicePage<>NIL) and (RdbSSH[GS_ExternalOpenSSH].Checked) then begin
         WizardForm.StatusLabel.Caption:='Removing bundled Git OpenSSH binaries';
         if not DeleteOpenSSHFiles() then
             LogError('Failed to remove OpenSSH file(s)');


### PR DESCRIPTION
As documented in git-for-windows/git/issues/3368 the installer has to check for a valid SSH choice before attempting to remove the bundled SSH binaries.

As @PetSerAl helpfully pointed out in the [original pull request](https://github.com/git-for-windows/build-extra/pull/367#discussion_r693312186) the installer has to verify any SSH choice was made or else things break.

This fixes git-for-windows/git/issues/3368 – I used a [Windows 7 VM](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/), uninstalled the bundled OpenSSH, and ran the newly built installer with this fix applied, confirming @PetSerAl's findings.