### PR TITLE
Added warning banner in case MSYS_NO_PATHCONV env var defined

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -45,6 +45,15 @@ sdk () {
 		EOF
 		;;
 	welcome)
+		test -z "$MSYS_NO_PATHCONV" || {
+			cat >&2 <<-EOF
+
+			WARNING: You have the MSYS_NO_PATHCONV env var defined
+			Consult documentation regarding potential consequences and advices
+
+			EOF
+		}
+
 		test -z "$GIT_SDK_WELCOME_SHOWN" || {
 			echo 'Reloaded the `sdk` function' >&2
 			return 0


### PR DESCRIPTION
A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
