### PR TITLE
SDK: warn when MSYS_NO_PATHCONV is set

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -45,6 +45,13 @@ sdk () {
 		EOF
 		;;
 	welcome)
+		test -z "$MSYS_NO_PATHCONV" || cat >&2 <<-EOF
+		WARNING: You have the MSYS_NO_PATHCONV env var defined
+		Please consult the documentation, e.g. at
+		https://github.com/git-for-windows/build-extra/blob/HEAD/ReleaseNotes.md#known-issues
+
+		EOF
+
 		test -z "$GIT_SDK_WELCOME_SHOWN" || {
 			echo 'Reloaded the `sdk` function' >&2
 			return 0


### PR DESCRIPTION
When the environment variable `MSYS_NO_PATHCONV` is set, the MSYS2 runtime will stop trying to convert environment variables and command-line arguments it detects as Unix-style paths to Windows paths when executing non-MSYS2 programs.

This can be very helpful e.g. when calling `git blame -L /<some-regex>/ ...` so that the regular expression is not mistaken for a Unix-style absolute path and transformed.

However, setting that environment variable globally is prone to wreak havoc, and we should warn loudly when detecting this situation.

This addresses the concern identified as the root cause of https://github.com/git-for-windows/git/issues/3381