### PR TITLE
git-extra/wordpad: teach wordpad how to deal with spaces in path

### DIFF
--- a/git-extra/wordpad
+++ b/git-extra/wordpad
@@ -17,10 +17,10 @@ esac
 
 case "$1" in
 */.git/*) ;; # needs LF line endings
-*) exec $WORDPAD "$1" || die "Could not launch $WORDPAD";;
+*) exec "$WORDPAD" "$1" || die "Could not launch $WORDPAD";;
 esac
 
-$WORDPAD "$1" &&
+"$WORDPAD" "$1" &&
 dos2unix.exe "$1" &&
 case "$1" in
 */COMMIT_EDITMSG|*\\COMMIT_EDITMSG)


### PR DESCRIPTION
When wordpad path has spaces (ex: C:\Program Files\Windows NT\),
invoking the binary will fail.

Add quotes around the $WORDPAD variable to avoid that.

Signed-off-by: Carlo Marcelo Arenas Belón <carenas@gmail.com>