### PR TITLE
remove cursor positioning autocmd

### DIFF
--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -37,19 +37,9 @@ endif
 if has("autocmd")
     " Set UTF-8 as the default encoding for commit messages
     autocmd BufReadPre COMMIT_EDITMSG,MERGE_MSG,git-rebase-todo setlocal fileencodings=utf-8
+    autocmd BufNewFile,BufRead *.patch set filetype=diff
 
-    " Remember the positions in files with some git-specific exceptions"
-    autocmd BufReadPost *
-      \ if line("'\"") > 0 && line("'\"") <= line("$")
-      \           && &filetype !~# 'commit\|gitrebase'
-      \           && expand("%") !~ "ADD_EDIT.patch"
-      \           && expand("%") !~ "addp-hunk-edit.diff" |
-      \   exe "normal g`\"" |
-      \ endif
-
-      autocmd BufNewFile,BufRead *.patch set filetype=diff
-
-      autocmd Filetype diff
+    autocmd Filetype diff
       \ highlight WhiteSpaceEOL ctermbg=red |
       \ match WhiteSpaceEOL /\(^+.*\)\@<=\s\+$/
 endif " has("autocmd")


### PR DESCRIPTION
The exceptions for it are exactly those that git cares about and the autocmd introduces errors on Vim 8.2.1895 standard build on Windows

```vim
--- Autocommands ---                                                              
Error detected while processing /etc/vimrc:             

line   43:                                                                        E10: \ should be followed by /, ? or &                                            
line   44:                                                                        E10: \ should be followed by /, ? or &                                            
line   45:                                                                        E10: \ should be followed by /, ? or &                                            
line   46:                                                                        E10: \ should be followed by /, ? or &                                            
line   47:                                                                        E10: \ should be followed by /, ? or &                                            
line   48:                                                                        E10: \ should be followed by /, ? or &                                            
line   53:                                                                        E10: \ should be followed by /, ? or &                                            
line   54:                                                                        E10: \ should be followed by /, ? or &                                            Press ENTER or type command to continue      
```