### PR TITLE
git-update-git-for-windows: strip 'v' from fork tag

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -229,6 +229,9 @@ update_git_for_windows () {
 	esac
 
 	eval "$latest_eval"
+	# Be extra careful to remove a leading 'v' from the tag.
+	latest=${latest#v}
+
 	# Did we ask about this version already?
 	recently_seen="$(get_recently_seen)"
 	test -n "$quiet" && test "x$recently_seen" = "x$latest" && return


### PR DESCRIPTION
When checking for a Git version from a fork such as microsoft/git, we
need to extract the tag name from a JSON object that we get from a REST
API. This differs from the git-for-windows/git mechanism of using the
gitforwindows.org/latest-tag.txt file. In the case of the latest-tag.txt
file, the letter 'v' is stripped from the tag name, allowing comparison
to the installed Git version, which does not include the 'v'.

The 'v' was not previously stripped from the tag name from the fork.
Rectify that, allowing comparisons that present an upgrade.

---

What confuses me about this change is that I don't understand how this ever worked.

To test, I inserted this change into my installed script:

```diff
@@ -253,6 +253,7 @@ update_git_for_windows () {
                # We are not testing and we don't have exact equality,
                # so do a careful comparison and look to see if the
                # latest release is strictly newer than ours.
+               echo "Comparing $version to $latest"
                if test 0 -lt "$(version_compare "$version" "$latest")"
                then
                        return
```

And I saw that `$latest` included a `v` while `$version` did not. This causes the first iteration of `version_compare` to think there is no number in the `$b1` position, so it quits without presenting a new version.