### PR TITLE
git-update-git-for-windows: optionally skip recently-seen

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -233,8 +233,11 @@ update_git_for_windows () {
 	latest=${latest#v}
 
 	# Did we ask about this version already?
-	recently_seen="$(get_recently_seen)"
-	test -n "$quiet" && test "x$recently_seen" = "x$latest" && return
+	if test -z "$use_recently_seen"
+	then
+		recently_seen="$(get_recently_seen)"
+		test -n "$quiet" && test "x$recently_seen" = "x$latest" && return
+	fi
 
 	version=$(git --version | sed "s/git version //")
 	if test -d /arm64/bin


### PR DESCRIPTION
I am trying to make the microsoft/git fork skip the recently-seen check,
allowing us to prompt users daily for upgrade. This turns the toast
notification from a "no, I don't ever want this version" to a "no, I
don't want to upgrade right now; reminde me tomorrow".

The way to make this work differently in microsoft/git is to change this
script during our build. For some reason, I am struggling to replace the
line

	recently_seen="$(get_recently_seen)"

during a GitHub Actions workflow, even though my 'sed' invocation works
on my machine. There are existing steps that do an _insertion_ of lines
which I can use to my advantage. The critical thing is that I will
initialize the 'use_recently_seen' variable as non-empty.

By adding a check to see if 'use_recently_seen' is empty, we can
maintain the same behavior in git-for-windows/git while making it
possible to change that behavior in microsoft/git.