### PR TITLE
added different return code for yes on update

### DIFF
--- a/git-extra/git-update-git-for-windows
+++ b/git-extra/git-update-git-for-windows
@@ -173,7 +173,11 @@ update_git_for_windows () {
 			"Usage: git update-git-for-windows [options]" \
 			"Options:" \
 			"-g, --gui Use GUI instead of terminal to prompt" \
-			"-y, --yes Automatic yes to download and install prompt"
+			"-y, --yes Automatic yes to download and install prompt" \
+			"Return code:" \
+			" 0: no update available" \
+			" 1: update available and user selected not to update" \
+			" 2: update available and it was started"
 		return 1
 	done
 
@@ -348,6 +352,7 @@ update_git_for_windows () {
 	# that link to *this* MSYS2 runtime, i.e. no processes from other Git
 	# installations (e.g. Git for Windows' SDK) will be killed.
 	ps | grep ' /usr/bin/bash$' | awk '{print "kill -9 " $1 ";" }' | sh
+	return 2
 }
 
 update_git_for_windows "$@"


### PR DESCRIPTION
If the user selects yes, the update code is not waiting for the update to finish.
We would like to stop/end our script when the user selected to update git otherwise the git executable may not be available for the next steps in the script.
With returning 2 the calling program/script knows that the update is running and can do appropriate next steps.

Let me know if this is a good way to solve the problem or if there is a better solution.

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
