### PR TITLE
fix: make shift+insert do Paste in ConHost bash again

### DIFF
--- a/git-extra/inputrc
+++ b/git-extra/inputrc
@@ -28,7 +28,7 @@ set show-all-if-ambiguous off
 # MSYSTEM is emacs based
 $if mode=emacs
   # Common to Console & RXVT
-  "\e[2~": paste-from-clipboard     # "Ins. Key"
+  "\e[2;2~": paste-from-clipboard   # Shift-Insert
   "\e[5~": beginning-of-history     # Page up
   "\e[6~": end-of-history           # Page down
 


### PR DESCRIPTION
This should fix issue git-for-windows/git#3254, seen on Windows 10 in the "plain console" terminal (i. e. in "ConHost bash").

Technical details are given in the commit message.