### PR TITLE
install.iss: use --replace-all when setting config values

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -758,14 +758,14 @@ var
     StdOut,StdErr:String;
 begin
     if (Value=#0) then begin
-        if ExecWithCapture('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe" config --system --unset '+Key,StdOut,StdErr,ExitCode) And ((ExitCode=0) Or (ExitCode=5)) then
+        if ExecWithCapture('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe" config --system --unset-all '+Key,StdOut,StdErr,ExitCode) And ((ExitCode=0) Or (ExitCode=5)) then
             // exit code 5 means it was already unset, so that's okay
             Result:=True
         else begin
             LogError('Unable to unset system config "'+Key+'": exit code '+IntToStr(ExitCode)+#13+#10+StdOut+#13+#10+'stderr:'+#13+#10+StdErr);
             Result:=False
         end
-    end else if ExecWithCapture('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe" config --system '+ShellQuote(Key)+' '+ShellQuote(Value),StdOut,StdErr,ExitCode) And (ExitCode=0) then
+    end else if ExecWithCapture('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe" config --system --replace-all '+ShellQuote(Key)+' '+ShellQuote(Value),StdOut,StdErr,ExitCode) And (ExitCode=0) then
         Result:=True
     else begin
         LogError('Unable to set system config "'+Key+'":="'+Value+'": exit code '+IntToStr(ExitCode)+#13+#10+StdOut+#13+#10+'stderr:'+#13+#10+StdErr);

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -786,6 +786,13 @@ begin
     end;
 end;
 
+function EndsWith(S:String;T:String):Boolean;
+begin
+    if (Length(S)>Length(T)) then
+        Delete(S,0,Length(S)-Length(T));
+    Result:=(CompareText(S,T)=0)
+end;
+
 function GetDefaultsFromGitConfig(WhichOne:String):Boolean;
 var
     ExtraOptions,StdOut,StdErr,Key,Value:String;
@@ -841,7 +848,13 @@ begin
                         case Value of
                             'manager': RecordInferredDefault('Use Credential Manager','Core');
                             'manager-core': RecordInferredDefault('Use Credential Manager','Core');
-                        else RecordInferredDefault('Use Credential Manager','Disabled');
+                        else
+                            begin
+                                if EndsWith(Value, 'manager-core') then
+                                    RecordInferredDefault('Use Credential Manager','Core');
+                                else
+                                    RecordInferredDefault('Use Credential Manager','Disabled');
+                            end;
                         end;
                     'core.symlinks':
                         case Value of


### PR DESCRIPTION
When testing the 2.34.0 installer, I saw this confusing page of the wizard:

![image (1)](https://user-images.githubusercontent.com/570044/141852229-27ce08cd-f798-40de-83ef-787f08058665.png)

Changing the selection to GCM Core got me this error after the rest of everything was installed:

![image (2)](https://user-images.githubusercontent.com/570044/141852240-4d663162-0a5e-441e-aaeb-e669080bb741.png)

By using `--replace-all`, we get rid of this error.

The Wizard page's default setting might still be incorrect. My system config had multiple values because GCM configured it for the system, but used an exact path to the executable instead of just `manager-core`.

```
$ git config --show-origin --get-all credential.helper
file:C:/Program Files/Git/etc/gitconfig manager-core
file:C:/Program Files/Git/etc/gitconfig
file:C:/Program Files/Git/etc/gitconfig C:/Program\ Files\ \(x86\)/Git\ Credential\ Manager\ Core/git-credential-manager-core
file:C:/Users/dstolee/.gitconfig
file:C:/Users/dstolee/.gitconfig        C:/Program\ Files\ \(x86\)/Git\ Credential\ Manager\ Core/git-credential-manager-core
```

**Update:** I added a second commit that attempts to correct for this case. The `--replace-all` would still modify the system config incorrectly (it would only have one value, `manager-core`), but at least it wouldn't clear the system config entirely. Hopefully GCM Core configures itself correctly despite these things the Git installer is doing?