### PR TITLE
install.iss: fix if/else syntax

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -851,7 +851,7 @@ begin
                         else
                             begin
                                 if EndsWith(Value, 'manager-core') then
-                                    RecordInferredDefault('Use Credential Manager','Core');
+                                    RecordInferredDefault('Use Credential Manager','Core')
                                 else
                                     RecordInferredDefault('Use Credential Manager','Disabled');
                             end;


### PR DESCRIPTION
This previously had this compile error:

  Error on line 858 in C:\(...)\install.iss: Column 33:
  Identifier expected

The reason we didn't catch this earlier was because we had inserted some
logging that changed the nature of this if/else to have begin/end
blocks.

Fixes the bug introduced by #390.