### PR TITLE
Git Credential Manager has a new home

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,15 @@ jobs:
           cat packages.txt &&
           sed -e 's/\/$//' -e 's/.*/"&", /' -e '$s/, $//' <packages.txt >list.txt &&
           echo "::set-output name=matrix::[$(tr -d '\n' <list.txt)]"
+
+          git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&
+          comm -12 releaseable.txt touched.txt >artifacts.txt &&
+          cat artifacts.txt &&
+          sed -e 's/\/$//' -e 's/.*/"&", /' -e '$s/, $//' <artifacts.txt >list.txt &&
+          echo "::set-output name=artifacts::[$(tr -d '\n' <list.txt)]"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      artifacts: ${{ steps.set-matrix.outputs.artifacts }}
   build-packages:
     needs: determine-packages
     runs-on: windows-latest
@@ -42,6 +49,29 @@ jobs:
           artifacts="$(basename "${{ matrix.directory }}")-artifacts" &&
           mkdir -p "$top_dir/$artifacts" &&
           mv *.tar.* "$top_dir/$artifacts"/ &&
+          echo "artifacts=$artifacts" >>$GITHUB_ENV
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.artifacts }}
+          path: ${{ env.artifacts }}
+  build-artifacts:
+    needs: determine-packages
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        directory: ${{ fromJSON(needs.determine-packages.outputs.artifacts) }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: git-for-windows/setup-git-for-windows-sdk@v1
+        with:
+          flavor: build-installers
+      - name: build ${{ matrix.directory }}/
+        shell: bash
+        run: |
+          artifacts="$(basename "${{ matrix.directory }}")-artifacts" &&
+          mkdir -p "$artifacts" &&
+          ./"${{ matrix.directory }}"/release.sh --output="$PWD/$artifacts/" 0-test &&
           echo "artifacts=$artifacts" >>$GITHUB_ENV
       - uses: actions/upload-artifact@v2
         with:

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2281,7 +2281,7 @@ begin
     GitCredentialManagerPage:=CreatePage(PrevPageID,'Choose a credential helper','Which credential helper should be configured?',TabOrder,Top,Left);
 
     // Git Credential Manager Core
-    RdbGitCredentialManager[GCM_Core]:=CreateRadioButton(GitCredentialManagerPage,'Git Credential Manager Core','<RED>(NEW!)</RED> Use the new, <A HREF=https://github.com/microsoft/Git-Credential-Manager-Core>cross-platform version of the Git Credential Manager</A>.'+#13+'See more information about the future of Git Credential Manager <A HREF=https://github.com/microsoft/Git-Credential-Manager-Core/blob/master/docs/faq.md#about-the-project>here</A>.',TabOrder,Top,Left);
+    RdbGitCredentialManager[GCM_Core]:=CreateRadioButton(GitCredentialManagerPage,'Git Credential Manager Core','<RED>(NEW!)</RED> Use the new, <A HREF=https://github.com/GitCredentialManager/git-credential-manager>cross-platform version of the Git Credential Manager</A>.'+#13+'See more information about the future of Git Credential Manager <A HREF=https://github.com/GitCredentialManager/git-credential-manager/blob/HEAD/docs/faq.md#about-the-project>here</A>.',TabOrder,Top,Left);
 
     // No credential helper
     RdbGitCredentialManager[GCM_None]:=CreateRadioButton(GitCredentialManagerPage,'None','Do not use a credential helper.',TabOrder,Top,Left);

--- a/mingw-w64-git-credential-manager-core/PKGBUILD
+++ b/mingw-w64-git-credential-manager-core/PKGBUILD
@@ -10,7 +10,7 @@ _realtag=v${pkgver%.*}
 pkgdesc="Credential Manager for Git"
 install=git-credential-manager-core.install
 arch=('any')
-project_url="https://github.com/microsoft/Git-Credential-Manager-Core"
+project_url="https://github.com/GitCredentialManager/git-credential-manager"
 zip_url="${project_url}/releases/download/${_realtag}/gcmcore-win-x86-${_realver}.zip"
 src_zip_url="${project_url}/archive/${_realtag}.zip"
 license=('MIT')
@@ -20,7 +20,7 @@ options=('!strip')
 source=("${zip_url}" "$src_zip_url")
 
 sha256sums=('3433ebedd65fd7b19edbb52410a89621a4e32f00933b8b00f730cf540af04898'
-            'e55e95c85e093885f55becdd79345ba2f1ba7b4d7ae6b16cfe3caa0b537f9f5c')
+            'efa417d55d48c24f80de0a3358e9bb29e0b454a36168a76ae0b4f9688f05101b')
 
 package() {
   prefix="$pkgdir/${MINGW_PREFIX}"
@@ -28,5 +28,5 @@ package() {
   install -d -m755 "${prefix}"/libexec/git-core
   install -m755 "$srcdir2"/*.{dll,exe,config} "${prefix}"/libexec/git-core
   install -d -m755 "${prefix}"/doc/git-credential-manager-core
-  install -m644 "$srcdir2"/Git-Credential-Manager-Core-${_realtag#v}/{README.md,LICENSE,NOTICE} "${prefix}"/doc/git-credential-manager-core
+  install -m644 "$srcdir2"/git-credential-manager-${_realtag#v}/{README.md,LICENSE,NOTICE} "${prefix}"/doc/git-credential-manager-core
 }

--- a/please.sh
+++ b/please.sh
@@ -2457,7 +2457,7 @@ upgrade () { # [--directory=<artifacts-directory>] [--only-mingw] [--no-build] [
 	release_notes_feature=
 	case "$package" in
 	mingw-w64-git-credential-manager-core)
-		repo=microsoft/git-credential-manager-core
+		repo=GitCredentialManager/git-credential-manager
 		url=https://api.github.com/repos/$repo/releases
 		release="$(curl --netrc -s $url)"
 		test -n "$release" ||


### PR DESCRIPTION
Git Credential Manager moved recently. Let's accommodate for this move.

While at it, use this splendid opportunity to enhance our PR workflow to also build the installer/portable/etc artifacts touched by PRs (this is a splendid opportunity because the `installer/` files are touched by this PR).