### PR TITLE
installer: PrivilegesRequired set to admin

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -82,7 +82,7 @@ InfoBeforeFile={#SourcePath}\..\gpl-2.0.rtf
 #ifdef OUTPUT_TO_TEMP
 PrivilegesRequired=lowest
 #else
-PrivilegesRequired=none
+PrivilegesRequired=admin
 #endif
 UninstallDisplayName={#APP_NAME}
 UninstallDisplayIcon={app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico


### PR DESCRIPTION
* "none" is undocumented:
  https://jrsoftware.org/ishelp/index.php?topic=setup_privilegesrequired
* "admin" implements the desired behavior of requiring a machine-wide
  install. See https://github.com/git-for-windows/git/issues/3550