### PR TITLE
installer: add editor.rogue configuration if EDITOR=vim selected

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1866,7 +1866,7 @@ begin
     // 2nd choice
     Top:=TopOfLabels;
     CbbEditor.Items.Add('Use Vim (the ubiquitous text editor) as Git'+#39+'s default editor');
-    CreateItemDescription(EditorPage,'The <A HREF=http://www.vim.org/>Vim editor</A>, while powerful, <A HREF=https://stackoverflow.blog/2017/05/23/stack-overflow-helping-one-million-developers-exit-vim/>can be hard to use</A>. Its user interface is'+#13+'unintuitive and its key bindings are awkward.'+#13+#13+'<RED>Note:</RED> Vim is the default editor of Git for Windows only for historical reasons, and'+#13+'it is highly recommended to switch to a modern GUI editor instead.'+#13+#13+'<RED>Note:</RED> This will leave the '+#39+'core.editor'+#39+' option unset, which will make Git fall back'+#13+'to the '+#39+'EDITOR'+#39+' environment variable. The default editor is Vim - but you'+#13+'may set it to some other editor of your choice.',Top,Left,LblEditor[GE_VIM],False);
+    CreateItemDescription(EditorPage,'The <A HREF=http://www.vim.org/>Vim editor</A>, while powerful, <A HREF=https://stackoverflow.blog/2017/05/23/stack-overflow-helping-one-million-developers-exit-vim/>can be hard to use</A>. Its user interface is'+#13+'unintuitive and its key bindings are awkward.'+#13+#13+'<RED>Note:</RED> Vim is the default editor of Git for Windows only for historical reasons, and'+#13+'it is highly recommended to switch to a modern GUI editor instead.'+#13+#13+'<RED>Note:</RED> This will leave the '+#39+'core.editor'+#39+' option unset, which will make Git fall back'+#13+'to the '+#39+'EDITOR'+#39+' environment variable. The default editor is Vim - but you'+#13+'may set it to some other editor of your choice.'+#13+#13+'<RED>Warning:</RED> This will set the '+#39+'editor.rogue'+#39+' experimental option to '+#39+'true'+#39+' to attempt'+#13+'to prevent known problems with Vim when used inside Windows Terminal'+#13+'and that is not compatible with other versions of git',Top,Left,LblEditor[GE_VIM],False);
     EditorAvailable[GE_VIM]:=True;
 
     // 3rd choice
@@ -3365,6 +3365,8 @@ begin
     WizardForm.StatusLabel.Caption:='Configuring default editor';
     if (CbbEditor.ItemIndex=GE_Nano) then
         GitSystemConfigSet('core.editor','nano.exe')
+    else if (CbbEditor.ItemIndex=GE_VIM) then
+        GitSystemConfigSet('editor.rogue', 'true')
     else if ((CbbEditor.ItemIndex=GE_NotepadPlusPlus)) and (NotepadPlusPlusPath<>'') then
         GitSystemConfigSet('core.editor','"'+NotepadPlusPlusPath+'" -multiInst -notabbar -nosession -noPlugin')
     else if ((CbbEditor.ItemIndex=GE_VisualStudioCode)) and (VisualStudioCodePath<>'') then begin


### PR DESCRIPTION
This implements the suggestion for installer changes presented in the git mailing list[1] and that obviously depend on the (still pending PR) changes on top of 2.34.1, but that has been tested successfully on top of the pre-rebase to 2.34.1 of Git for Windows[2].

Additional restrictions to the code could be added to trully paper over the bug by matching for TERM=xterm-256color and EDITOR=[|vi|vim|rvim|view|rview|vimdiff] if necessary.

[1] https://lore.kernel.org/git/CAPUEspi2PRs+yMUiAmvJK+z=F=kcguHpOL2inAV208yaq2n2Ww@mail.gmail.com/
[2] https://github.com/carenas/git/actions/runs/1502664573