### PR TITLE
ci: fix building portable/ and msi/

### DIFF
--- a/msi/release.sh
+++ b/msi/release.sh
@@ -181,7 +181,7 @@ cat <<EOF
     </Fragment>
 </Wix>
 EOF
-) | sed -e 's/\(<File \(Id=".*" \)\?Source="\)\(.*\(compat-\)\?\(ba\)\?sh\.exe\|.*git.*\.exe\)\([^>]\)* \/>/\1\3" BindPath="[BindImagePaths]\6 \/>/' \
+) | sed -e 's/\(<File \(Id=".*" \)\?Source="\)\(.*\(compat-\)\?\(ba\)\?sh\.exe\|.*git.*\.exe\)\("[^>]\)* \/>/\1\3" BindPath="[BindImagePaths]\6 \/>/' \
 	-e 's/\(<File \)\(DoNotBind\) \([^>]*\)>/\1\3>/' >GitComponents.wxs
 
 # Make the .msi file

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -41,6 +41,8 @@ die () {
 }
 
 parse_version () {
+	test 0-test != "$1" || set 0.0.0
+
 	echo "$1" | grep -Px '\d+(\.(0|[1-9]+)){2,3}' ||
 	die "
 Either the version format was incorrect or no version was specified.

--- a/msi/release.sh
+++ b/msi/release.sh
@@ -72,7 +72,7 @@ do
 	-h|--help)
 		usage
 		;;
-	-o=*|--outputDir=*)
+	-o=*|--output=*|--outputDir=*)
 		TARGET="${1#*=}"
 		shift
 		;;

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -124,10 +124,10 @@ case "$LIST" in
 	;;
 esac
 
-rm -rf "$SCRIPT_PATH/root/mingw$BITNESS/libexec/git-core" &&
-mkdir -p "$SCRIPT_PATH/root/mingw$BITNESS/libexec/git-core" &&
-ln $(echo "$LIST" | sed -n "s|^mingw$BITNESS/bin/[^/]*\.dll$|/&|p") \
-	"$SCRIPT_PATH/root/mingw$BITNESS/libexec/git-core/" ||
+git_core="$SCRIPT_PATH/root/mingw$BITNESS/libexec/git-core" &&
+rm -rf "$git_core" &&
+mkdir -p "$git_core" &&
+ln $(echo "$LIST" | sed -n "s|^mingw$BITNESS/bin/[^/]*\.dll$|/&|p") "$git_core" ||
 die "Could not copy .dll files into libexec/git-core/"
 
 test -z "$include_pdbs" || {

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -127,7 +127,13 @@ esac
 git_core="$SCRIPT_PATH/root/mingw$BITNESS/libexec/git-core" &&
 rm -rf "$git_core" &&
 mkdir -p "$git_core" &&
-ln $(echo "$LIST" | sed -n "s|^mingw$BITNESS/bin/[^/]*\.dll$|/&|p") "$git_core" ||
+if test "$(stat -c %D /mingw$BITNESS/bin)" = "$(stat -c %D "$git_core")"
+then
+	ln_or_cp=ln
+else
+	ln_or_cp=cp
+fi &&
+$ln_or_cp $(echo "$LIST" | sed -n "s|^mingw$BITNESS/bin/[^/]*\.dll$|/&|p") "$git_core" ||
 die "Could not copy .dll files into libexec/git-core/"
 
 test -z "$include_pdbs" || {


### PR DESCRIPTION
In [an unrelated PR](https://github.com/git-for-windows/build-extra/pull/394), the CI failed in three jobs: one job failed as expected (because something needs to change elsewhere before it can possibly succeed), but two jobs failed unexpectedly. This PR fixes those two.