### PR TITLE
ci: avoid a bogus error when no packages/artifacts need to be built

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
             comm -12 "$2" "$3" >"$4" &&
             cat "$4" &&
             sed -e 's/\/$//' -e 's/.*/"&", /' -e '$s/, $//' <"$4" >list.txt &&
-            echo "::set-output name=$1::[$(tr -d '\n' <list.txt)]"
+            echo "::set-output name=$1::[$(test ! -s list.txt && echo '""' || tr -d '\n' <list.txt)]"
           }
 
           git ls-files \*/PKGBUILD | sed 's|[^/]*$||' | sort >directories.txt &&
@@ -32,6 +32,7 @@ jobs:
   build-packages:
     needs: determine-packages
     runs-on: windows-latest
+    if: needs.determine-packages.outputs.matrix != '[""]'
     strategy:
       fail-fast: false
       matrix:
@@ -58,6 +59,7 @@ jobs:
   build-artifacts:
     needs: determine-packages
     runs-on: windows-latest
+    if: needs.determine-packages.outputs.artifacts != '[""]'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,18 +13,19 @@ jobs:
         id: set-matrix
         shell: bash
         run: |
+          define_matrix () {
+            comm -12 "$2" "$3" >"$4" &&
+            cat "$4" &&
+            sed -e 's/\/$//' -e 's/.*/"&", /' -e '$s/, $//' <"$4" >list.txt &&
+            echo "::set-output name=$1::[$(tr -d '\n' <list.txt)]"
+          }
+
           git ls-files \*/PKGBUILD | sed 's|[^/]*$||' | sort >directories.txt &&
           git diff ${{github.event.pull_request.base.sha}}... --name-only | sed 's|[^/]*$||' | sort -u >touched.txt &&
-          comm -12 directories.txt touched.txt >packages.txt &&
-          cat packages.txt &&
-          sed -e 's/\/$//' -e 's/.*/"&", /' -e '$s/, $//' <packages.txt >list.txt &&
-          echo "::set-output name=matrix::[$(tr -d '\n' <list.txt)]"
+          define_matrix matrix directories.txt touched.txt packages.txt &&
 
           git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&
-          comm -12 releaseable.txt touched.txt >artifacts.txt &&
-          cat artifacts.txt &&
-          sed -e 's/\/$//' -e 's/.*/"&", /' -e '$s/, $//' <artifacts.txt >list.txt &&
-          echo "::set-output name=artifacts::[$(tr -d '\n' <list.txt)]"
+          define_matrix artifacts releaseable.txt touched.txt artifacts.txt
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       artifacts: ${{ steps.set-matrix.outputs.artifacts }}


### PR DESCRIPTION
Avoid [a bogus error](https://github.com/git-for-windows/build-extra/actions/runs/1780156306):

> Error when evaluating 'strategy' for job 'build-artifacts'. .github/workflows/main.yml (Line: 63, Col: 20): Matrix vector 'directory' does not contain any values