### PR TITLE
Move Git Credential Manager out of Git's exec path

### DIFF
--- a/mingw-w64-git-credential-manager/PKGBUILD
+++ b/mingw-w64-git-credential-manager/PKGBUILD
@@ -27,8 +27,8 @@ sha256sums=('2803bf5cc205a5923395e4b9ed8931387dc52eeb878b3acc9775de732b221116'
 package() {
   prefix="$pkgdir/${MINGW_PREFIX}"
   srcdir2="${srcdir}/"
-  install -d -m755 "${prefix}"/libexec/git-core
-  install -m755 "$srcdir2"/*.{dll,exe,config} "${prefix}"/libexec/git-core
+  install -d -m755 "${prefix}"/bin
+  install -m755 "$srcdir2"/*.{dll,exe,config} "${prefix}"/bin
   install -d -m755 "${prefix}"/doc/git-credential-manager
   install -m644 "$srcdir2"/git-credential-manager-${_realtag#v}/{README.md,LICENSE,NOTICE} "${prefix}"/doc/git-credential-manager
 }


### PR DESCRIPTION
At long last, we do the same with Git Credential Manager as did with Git LFS in a57279dd9: we move its executables into the regular `/mingw64/bin/` directory (or `/mingw32/bin/` in i686 setups).

This provides for a cleaner separation between the non-built-in Git commands that are part of core Git (which are supposed to live in Git's exec path) and third-party commands such as Git LFS, Git Credential Manager, or even Git for Windows' `git update-git-for-windows` and `git credential-helper-selector`.

It will also open the door for addressing https://github.com/git-for-windows/git/discussions/3668 by teaching Git an option to override the standard `PATH` search behavior for third-party Git commands only (current idea is to look through `PATH` and not use the first, but the one with the most recent `ctime`).