### PR TITLE
git-extra(vimrc): only default to UTF-8, don't enforce it

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -57,7 +57,7 @@ source=('inputrc'
         'git-askpass.h'
         'git-askpass.rc')
 sha256sums=('8ed76d1cb069ac8568f21c431f5e23caebea502d932ab4cdff71396f4f0d5b72'
-            'ab571470d4f05748582cec1280efe0d984383819e26c14f1a8fe7a75dbc06253'
+            'e36a3b93b8a33b0a74619f2449ed6d56ed54e4e2938b97070bce4926f1f44054'
             '640d04d2a2da709419188a986d5e5550ad30df23c7ea9be1a389c37a6b917994'
             '17c90698d4dd52dd9f383e72aee54ecea0f62520baf56722de5c83285507c0d9'
             '3cd83627f1d20e1108533419fcf33c657cbcf777c3dc39fa7f13748b7d63858a'

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -36,7 +36,7 @@ endif
 " Only do this part when compiled with support for autocommands.
 if has("autocmd")
     " Set UTF-8 as the default encoding for commit messages
-    autocmd BufReadPre COMMIT_EDITMSG,MERGE_MSG,git-rebase-todo setlocal fileencodings=utf-8
+    autocmd BufReadPre COMMIT_EDITMSG,MERGE_MSG,git-rebase-todo setlocal fileencoding=utf-8
 
     " Remember the positions in files with some git-specific exceptions"
     autocmd BufReadPost *


### PR DESCRIPTION
As reported in https://github.com/git-for-windows/git/issues/3725, by mistake we set `fileencodings` instead of `fileencoding` (note the `s` at the end).