### PR TITLE
Force Pacman source package to use .src.tar.gz extension

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -50,6 +50,8 @@ unset ORIGINAL_PATH
 # Do not follow MSYS2's switch to zstd, at least for now
 PKGEXT='.pkg.tar.xz'
 export PKGEXT
+SRCEXT='.src.tar.gz'
+export SRCEXT
 
 # In MinGit, there is no `cygpath`...
 # We really only use -w, -am and -au in please.sh, so that's what we


### PR DESCRIPTION
At some point between April 8 and April 11, 2022, the default file extension for source packages created with `makepkg-mingw --allsource` changed from `.src.tar.gz` to `.src.zst`. This broke the subsequent checks in `please.sh build_mingw_w64_git --build-src-pkg` for the source package, as a file with the expected `.src.tar.gz` extension was not found. The result is that this issue blocks _any_ successful completion of the "[Git Artifacts](https://dev.azure.com/git-for-windows/git/_build?definitionId=34&_a=summary)" pipeline, and therefore needs to be fixed before `v2.36.0`.

Like what was done to force the `tar.xz` default on normal packages with `PKGEXT` (c804266 (Force the Pacman packages back to use xz, 2020-01-22)), we set the `SRCEXT` to `.src.tar.gz` to force the file format we want.

* Last passing build (Apr 8): https://dev.azure.com/git-for-windows/git/_build/results?buildId=97561&view=results
* First failing build (Apr 11): https://dev.azure.com/git-for-windows/git/_build/results?buildId=97648&view=results
  * Note that the step where the src package isn't found is _not_ the one that fails (the file isn't found in "Build 64-bit mingw-w64-git"); however, because the necessary artifacts aren't packaged for subsequent steps, they fail.
* Passing build w/ fix: https://dev.azure.com/git-for-windows/git/_build/results?buildId=97893&view=results