### PR TITLE
aliases.sh: allow pipe to work

### DIFF
--- a/git-extra/aliases.sh
+++ b/git-extra/aliases.sh
@@ -15,7 +15,9 @@ xterm*)
 		case "$(type -p "$name".exe 2>/dev/null)" in
 		''|/usr/bin/*) continue;;
 		esac
-		alias $name="winpty $name.exe"
+		# The -Xallow-non-tty undocumented switch allows
+		# for pipe '|' to work as expected with those commands
+		alias $name="winpty -Xallow-non-tty $name.exe"
 	done
 	;;
 esac


### PR DESCRIPTION
After investigating for a while why [this issue, by which I have been affected recently, happened](https://github.com/pinojs/pino-pretty/issues/305), I found out that we could avoid this `pipe` problem.

this is how typically it materializes :
```
$ node -e 'console.log(666)'
666

$ node -e 'console.log(666)' | pino-pretty
stdout is not a tty

$ node.exe -e 'console.log(666)' | pino-pretty
666
```

We just need to use the [undocumented](https://github.com/rprichard/winpty/blob/7e59fe2d09adf0fa2aa606492e7ca98efbc5184e/src/unix-adapter/main.cc#L502) switch from `winpty` to allow for the pipe to another command to actually work without getting into `stdout is not a tty`. It also still provides the value of `winpty`, e.g. for running an interactive shell

This PR just adds the switch, which should allow both of those commands to work in the intended manner:
```
$ node.exe -e 'console.log(666)' | pino-pretty
666

$ node -e 'console.log(666)' | pino-pretty
666
```