### PR TITLE
Preserve /etc/ssh/ssh_config between installations

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2679,6 +2679,15 @@ begin
         end else if FileExists(UninstallAppPath+'\etc\gitconfig') and
             (not FileCopy(UninstallAppPath+'\etc\gitconfig',ExpandConstant('{tmp}\gitconfig.system'),True)) then
             LogError('Could not save system config; continuing anyway');
+
+        // Save a copy of the system ssh config so that we can copy it back later
+        if FileExists(UninstallAppPath+'\{#MINGW_BITNESS}\etc\ssh\ssh_config') then begin
+            if (not FileCopy(UninstallAppPath+'\{#MINGW_BITNESS}\etc\ssh\ssh_config',ExpandConstant('{tmp}\ssh_config.system'),True)) then
+                LogError('Could not save system ssh config; continuing anyway');
+        // Save a copy of the system ssh config so that we can copy it back later
+        end else if FileExists(UninstallAppPath+'\etc\ssh\ssh_config') and
+            (not FileCopy(UninstallAppPath+'\etc\ssh\ssh_config',ExpandConstant('{tmp}\ssh_config.system'),True)) then
+            LogError('Could not save system ssh config; continuing anyway');
     end;
 
     if UninstallString<>'' then begin
@@ -3048,6 +3057,14 @@ begin
             LogError('Failed to create \{#ETC_GITCONFIG_DIR}; continuing anyway')
         else
             FileCopy(ExpandConstant('{tmp}\gitconfig.system'),AppDir+'\{#ETC_GITCONFIG_DIR}\gitconfig',True)
+    end;
+
+    // Copy previous system wide ssh_config file, if any
+    if FileExists(ExpandConstant('{tmp}\ssh_config.system')) then begin
+        if (not ForceDirectories(AppDir+'\{#ETC_SSHCONFIG_DIR}')) then
+            LogError('Failed to create \{#ETC_SSHCONFIG_DIR}; continuing anyway')
+        else
+            FileCopy(ExpandConstant('{tmp}\ssh_config.system'),AppDir+'\{#ETC_SSHCONFIG_DIR}\ssh_config',True)
     end;
 
     {

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -326,12 +326,14 @@ test -z "$arm64_artifacts_directory" || {
 die "Could not include ARM64 artifacts"
 
 etc_gitconfig_dir="${etc_gitconfig%/gitconfig}"
+etc_sshconfig_dir="${${etc_gitconfig%/ssh%/ssh_config}"
 printf "%s\n%s\n%s\n%s\n%s%s" \
 	"#define APP_VERSION '$displayver'" \
 	"#define FILENAME_VERSION '$version'" \
 	"#define BITNESS '$BITNESS'" \
 	"#define SOURCE_DIR '$(cygpath -aw /)'" \
 	"#define ETC_GITCONFIG_DIR '${etc_gitconfig_dir//\//\\}'" \
+	"#define ETC_SSHCONFIG_DIR '${etc_sshconfig_dir//\//\\}'" \
 	"$inno_defines" \
 	>config.iss
 


### PR DESCRIPTION
Currently any user configuration of /etc/ssh/ssh_config is lost whenever the user installs a new copy of Git. This is undesirable.

What occurs is the following:

1. ssh_config is included in the [Files] list for install.iss
2. The uninstall executable for the previuos version of Git is invoked before install.
3. The uninstall executable removes all files in the [Files] section, including /etc/ssh_config

We can follow the same pattern that gitconfig follows, which is to back up the current config to the tmp file system, and then
restore it upon install. This code implements this behavior.