### PR TITLE
git-extra: disable CBC ciphers in ssh_config again

### DIFF
--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -187,11 +187,9 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 		! grep -q '^Ciphers [a-z].*cbc' /etc/ssh/ssh_config ||
 		sed -i -e 's/^Ciphers [a-z].*cbc/#   &/' /etc/ssh/ssh_config
 
-		grep -q '^Ciphers\s\++' /etc/ssh/ssh_config ||
-		printf '%s\n%s\n' \
-			'# Added by git-extra' \
-			'Ciphers +aes128-cbc,3des-cbc,aes256-cbc,aes192-cbc' \
-			>>/etc/ssh/ssh_config
+		# Revert change by prior versions of git-extra.
+		! grep -q '^Ciphers\s\++' /etc/ssh/ssh_config ||
+		sed -i -e '/^# Added by git-extra/{N;/^\(.*\n\)\?Ciphers +[a-z].*cbc/d}' /etc/ssh/ssh_config
 
 		grep -q '^Host\s\+ssh\.dev\.azure\.com' /etc/ssh/ssh_config ||
 		printf '%s\n%s\n\t%s\n\t%s\n' \


### PR DESCRIPTION
We had to re-enable them in b46fba6f4 (git-extra: re-enable some SSHv1 protocols, 2017-10-12) after an OpenSSH upgrade disabled them.

The reason why we had to re-enable those ciphers is gone now, though: Azure Repos understand newer (safer) ciphers.