### PR TITLE
installer/portable/mingit: gracefully omit missing dashed executables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,9 @@ jobs:
             echo "::set-output name=$1::[$(test ! -s list.txt && echo '""' || tr -d '\n' <list.txt)]"
           }
 
-          git diff ${{github.event.pull_request.base.sha}}... --name-only | sed 's|[^/]*$||' | sort -u >touched.txt &&
+          git diff ${{github.event.pull_request.base.sha}}... --name-only |
+            sed 's|[^/]*$||' |
+            sort -u >touched.txt &&
 
           git ls-files \*/PKGBUILD | sed 's|[^/]*$||' | sort >directories.txt &&
           define_matrix matrix directories.txt touched.txt packages.txt &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,9 @@ jobs:
             echo "::set-output name=$1::[$(test ! -s list.txt && echo '""' || tr -d '\n' <list.txt)]"
           }
 
-          git ls-files \*/PKGBUILD | sed 's|[^/]*$||' | sort >directories.txt &&
           git diff ${{github.event.pull_request.base.sha}}... --name-only | sed 's|[^/]*$||' | sort -u >touched.txt &&
+
+          git ls-files \*/PKGBUILD | sed 's|[^/]*$||' | sort >directories.txt &&
           define_matrix matrix directories.txt touched.txt packages.txt &&
 
           git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,11 @@ jobs:
           }
 
           git diff ${{github.event.pull_request.base.sha}}... --name-only |
-            sed 's|[^/]*$||' |
+            sed \
+              -e '/^make-file-list\.sh$/ainstaller/' \
+              -e '/^make-file-list\.sh$/aportable/' \
+              -e '/^make-file-list\.sh$/amingit/' \
+              -e 's|[^/]*$||' |
             sort -u >touched.txt &&
 
           git ls-files \*/PKGBUILD | sed 's|[^/]*$||' | sort >directories.txt &&


### PR DESCRIPTION
The "dashed executables" of Git are hard-linked versions of the `git` executable which are provided for built-in commands, for backwards-compatibility.

Since 7cedbf7a5 (sdk init git: skip hard-linking the built-ins by default, 2020-12-01), we skip building (and hence installing) these
dashed executables.

Let's handle this situtation gracefully.

This fixes https://github.com/git-for-windows/git/issues/3888