### PR TITLE
A couple of `create-sdk-artifact` improvements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,9 +26,14 @@ jobs:
 
           git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&
           define_matrix artifacts releaseable.txt touched.txt artifacts.txt
+
+          test -z "$(git log -L :create_sdk_artifact:please.sh ${{github.event.pull_request.base.sha}}.. -- )" ||
+          test -z "$(git diff ${{github.event.pull_request.base.sha}}.. -- make-file-list.sh)" ||
+          echo "::set-output name=test-sdk-artifacts::true"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       artifacts: ${{ steps.set-matrix.outputs.artifacts }}
+      test-sdk-artifacts: ${{ steps.set-matrix.outputs.test-sdk-artifacts }}
   build-packages:
     needs: determine-packages
     runs-on: windows-latest
@@ -80,3 +85,56 @@ jobs:
         with:
           name: ${{ env.artifacts }}
           path: ${{ env.artifacts }}
+  sdk-artifacts:
+    needs: determine-packages
+    if: needs.determine-packages.outputs.test-sdk-artifacts == 'true'
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: ['minimal', 'makepkg-git', 'build-installers', 'full']
+        bitness: ['32', '64']
+        exclude:
+          - artifact: minimal
+            bitness: 32
+          - artifact: makepkg-git
+            bitness: 32
+    steps:
+      - uses: actions/checkout@v3
+      - name: initialize bare SDK clone
+        shell: bash
+        run: |
+          case "${{ matrix.artifact }}" in
+          full) partial=;;
+          *) partial=--filter=blob:none;;
+          esac &&
+          git clone --bare --depth=1 --single-branch --branch=main $partial \
+            https://github.com/git-for-windows/git-sdk-${{ matrix.bitness }} .sdk
+      - name: build ${{ matrix.artifact }} artifact
+        shell: bash
+        run: |
+          case "${{ matrix.artifact }}" in
+          full)
+            GIT_CONFIG_PARAMETERS="'checkout.workers=8'" \
+            git --git-dir=.sdk worktree add --detach sdk-artifact
+            ;;
+          *)
+            ./please.sh create-sdk-artifact \
+              --bitness=${{ matrix.bitness }} \
+              --sdk=.sdk \
+              --out=sdk-artifact \
+              ${{ matrix.artifact }}
+            ;;
+          esac &&
+          cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
+          cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
+          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH
+      - name: build installer
+        if: matrix.artifact == 'build-installers'
+        shell: bash
+        run: ./installer/release.sh --output=$PWD/installer-${{ matrix.bitness }} 0-test
+      - uses: actions/upload-artifact@v2
+        if: matrix.artifact == 'build-installers'
+        with:
+          name: installer-${{ matrix.bitness }}
+          path: installer-${{ matrix.bitness }}

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -277,7 +277,7 @@ else
 		-e "^\\($(echo $EXTRA_FILE_EXCLUDES |
 			sed 's/ /\\|/g')\\)\$"
 fi |
-grep --perl-regexp -v -e '^/usr/(lib|share)/terminfo/(?!.*/(cygwin|dumb|screen.*|xterm.*)$)' |
+LC_CTYPE=C.UTF-8 grep --perl-regexp -v -e '^/usr/(lib|share)/terminfo/(?!.*/(cygwin|dumb|screen.*|xterm.*)$)' |
 sed 's/^\///' | sort | uniq
 
 test -z "$PACKAGE_VERSIONS_FILE" ||

--- a/please.sh
+++ b/please.sh
@@ -4502,6 +4502,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 	mode=
 	case "$1" in
 	minimal|git-sdk-minimal) mode=minimal-sdk;;
+	full) mode=full-sdk;;
 	minimal-sdk|makepkg-git|build-installers|full-sdk) mode=$1;;
 	*) die "Unhandled artifact: '%s'\n" "$1";;
 	esac

--- a/please.sh
+++ b/please.sh
@@ -4600,6 +4600,9 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 		/usr/bin/msys-pcre*.dll
 		/usr/bin/msys-gcc_s-*.dll
 
+		# markdown, to render the release notes
+		/usr/bin/markdown
+
 		# Files to include into the installer/Portable Git/MinGit
 		EOF
 		git -C "$output_path" checkout -- &&


### PR DESCRIPTION
The `create-sdk-artifact` subcommand of the `please.sh` script is designed to help Git for Windows generate the various subsets of its SDK that are used in the automation that helps run this project relatively smoothly.

With this PR, we make this a bit smoother, most importantly by ensuring via CI/PR builds that whenever the code is changed, the SDK artifacts still build.