### PR TITLE
Make building Git artifacts more robust

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3747,7 +3747,7 @@ finalize () { # [--delete-existing-tag] <what, e.g. release-notes>
 
 	case "$branch_to_use" in
 	*@*)
-		git "$dir_option" fetch --tags \
+		git "$dir_option" fetch --tags --prune-tags \
 			"${branch_to_use#*@}" "${branch_to_use%%@*}" ||
 		die "Could not fetch '%s' from '%s'\n" \
 			"${branch_to_use%%@*}" "${branch_to_use#*@}"


### PR DESCRIPTION
Every once in a while, the Git maintainer rotates GPG keys and the `junio-gpg-pub` tag gets force-pushed. As a consequence, the subsequent fetches from forks that have not updated the tag yet will fail, as was
the case when [trying to build Git for Windows v2.37.0-rc0](https://dev.azure.com/git-for-windows/git/_build/results?buildId=100997&view=logs&j=5437d6e9-5c1a-5300-9fd3-4614558e3141&t=025cebf6-6a22-5c04-7eaa-c59935a42109&l=612):

```
[...]
+ case "$branch_to_use" in
+ git '--git-dir=D:\a\1\s\git-sdk-64-build-installers/usr/src/MINGW-packages/mingw-w64-git/src/git/.git' fetch --tags https://github.com/mjcheetham/git rebase-to-2.37.0-rc0
From https://github.com/mjcheetham/git
 * branch                  rebase-to-2.37.0-rc0 -> FETCH_HEAD
 ! [rejected]              junio-gpg-pub -> junio-gpg-pub  (would clobber existing tag)
+ die 'Could not fetch '\''%s'\'' from '\''%s'\''\n' rebase-to-2.37.0-rc0 https://github.com/mjcheetham/git
+ printf 'Could not fetch '\''%s'\'' from '\''%s'\''\n' rebase-to-2.37.0-rc0 https://github.com/mjcheetham/git
Could not fetch 'rebase-to-2.37.0-rc0' from 'https://github.com/mjcheetham/git'
```

To avoid that, let's use the `--prune-tags` option, which according to [the option's usage string](https://github.com/git/git/blob/6afdb07b7b918ed9282ea6e955f53369df862be8/builtin/fetch.c#L170) asks `git fetch` to "prune local tags no
longer on remote and clobber changed tags".