### PR TITLE
Link PCRE2 changelog in release notes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -47,7 +47,7 @@ This package contains software from a number of other projects including Bash, z
 * Comes with [cURL v7.83.1](https://curl.haxx.se/changes.html#7_83_1).
 * Many anti-malware products seem to have problems with our MSYS2 runtime, leading to problems running e.g. `git subtree`. We [added a workaround](https://github.com/git-for-windows/msys2-runtime/pull/37) that hopefully helps in most of these scenarios.
 * Comes with MSYS2 runtime (Git for Windows flavor) based on [Cygwin 3.3.5](https://cygwin.com/pipermail/cygwin-announce/2022-May/010565.html).
-* Comes with [PCRE2 v10.40](https://api.github.com/repos/PhilipHazel/pcre2/releases/latest).
+* Comes with [PCRE2 v10.40](https://raw.githubusercontent.com/PCRE2Project/pcre2/pcre2-10.40/ChangeLog).
 * Comes with [Git LFS v3.2.0](https://github.com/git-lfs/git-lfs/releases/tag/v3.2.0).
 * Comes with [GNU TLS v3.7.6](https://lists.gnupg.org/pipermail/gnutls-help/2022-May/004744.html).
 * SSH's CBC ciphers, which were re-enabled in 2017 to better support Azure Repos [have again been disabled by default](https://github.com/git-for-windows/build-extra/pull/421) because Azure Repos does not require them any longer.

--- a/please.sh
+++ b/please.sh
@@ -3478,7 +3478,7 @@ upgrade () { # [--directory=<artifacts-directory>] [--only-mingw] [--no-build] [
 		die "Could not update $sdk32$pkgpath"
 		;;
 	mingw-w64-pcre2)
-		repo=PhilipHazel/pcre2
+		repo=PCRE2Project/pcre2
 		url=https://api.github.com/repos/$repo/releases/latest
 		release="$(curl --netrc -Ls $url)"
 		test -n "$release" ||

--- a/please.sh
+++ b/please.sh
@@ -3483,8 +3483,9 @@ upgrade () { # [--directory=<artifacts-directory>] [--only-mingw] [--no-build] [
 		release="$(curl --netrc -Ls $url)"
 		test -n "$release" ||
 		die "Could not determine the latest version of %s\n" "$package"
-		version="$(echo "$release" |
-			sed -n 's/^  "tag_name": "pcre2-\(.*\)",\?$/\1/p')"
+		tag="$(echo "$release" |
+			sed -n 's/^  "tag_name": "\(.*\)",\?$/\1/p')"
+		version=${tag#pcre2-}
 		test -n "$version" ||
 		die "Could not determine version of %s\n" "$package"
 
@@ -3497,6 +3498,7 @@ upgrade () { # [--directory=<artifacts-directory>] [--only-mingw] [--no-build] [
 		 create_bundle_artifact) ||
 		exit
 
+		url=https://raw.githubusercontent.com/$repo/$tag/ChangeLog
 		v="v$version${force_pkgrel:+ ($force_pkgrel)}" &&
 		release_notes_feature="Comes with [PCRE2 $v]($url)."
 		;;


### PR DESCRIPTION
The release notes for v2.37.0-rc0 link to [api.github.com](https://api.github.com/repos/PhilipHazel/pcre2/releases/latest), that's not designed for human consumption. We can do better.