### PR TITLE
Check for missing dlls updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,10 +37,14 @@ jobs:
           test -z "$(git log -L :create_sdk_artifact:please.sh ${{github.event.pull_request.base.sha}}.. -- )" ||
           test -z "$(git diff ${{github.event.pull_request.base.sha}}.. -- make-file-list.sh)" ||
           echo "::set-output name=test-sdk-artifacts::true"
+
+          test -z "$(git diff ${{github.event.pull_request.base.sha}}.. -- check-for-missing-dlls.sh)" ||
+          echo "::set-output name=check-for-missing-dlls::true"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       artifacts: ${{ steps.set-matrix.outputs.artifacts }}
       test-sdk-artifacts: ${{ steps.set-matrix.outputs.test-sdk-artifacts }}
+      check-for-missing-dlls: ${{ steps.set-matrix.outputs.check-for-missing-dlls }}
   build-packages:
     needs: determine-packages
     runs-on: windows-latest
@@ -158,3 +162,36 @@ jobs:
         with:
           name: installer-${{ matrix.bitness }}
           path: installer-${{ matrix.bitness }}
+  check-for-missing-dlls:
+    needs: determine-packages
+    if: needs.determine-packages.outputs.test-sdk-artifacts == 'true' || needs.determine-packages.outputs.check-for-missing-dlls == 'true'
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bitness: ['32', '64']
+    steps:
+      - uses: actions/checkout@v3
+      - name: initialize bare SDK clone
+        shell: bash
+        run: |
+          git clone --bare --depth=1 --single-branch --branch=main --filter=blob:none \
+            https://github.com/git-for-windows/git-sdk-${{ matrix.bitness }} .sdk
+      - name: build build-installers-${{ matrix.bitness }} artifact
+        shell: bash
+        run: |
+          INCLUDE_OBJDUMP=t \
+          ./please.sh create-sdk-artifact \
+            --bitness=${{ matrix.bitness }} \
+            --sdk=.sdk \
+            --out=sdk-artifact \
+            build-installers &&
+          cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
+          cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
+          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH
+      - name: check for missing DLLs
+        shell: bash
+        run: ./check-for-missing-dlls.sh
+      - name: check for missing DLLs (MinGit)
+        shell: bash
+        run: MINIMAL_GIT=1 ./check-for-missing-dlls.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,9 +78,22 @@ jobs:
         directory: ${{ fromJSON(needs.determine-packages.outputs.artifacts) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: git-for-windows/setup-git-for-windows-sdk@v1
-        with:
-          flavor: build-installers
+      - name: initialize bare SDK clone
+        shell: bash
+        run: |
+          git clone --bare --depth=1 --single-branch --branch=main --filter=blob:none \
+            https://github.com/git-for-windows/git-sdk-64 .sdk
+      - name: build build-installers-64 artifact
+        shell: bash
+        run: |
+          ./please.sh create-sdk-artifact \
+            --bitness=64 \
+            --sdk=.sdk \
+            --out=sdk-artifact \
+            build-installers &&
+          cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
+          cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
+          cygpath -aw "$PWD/sdk-artifact/mingw64/bin" >>$GITHUB_PATH
       - name: build ${{ matrix.directory }}/
         shell: bash
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   determine-packages:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: determine packages to build
@@ -50,7 +50,7 @@ jobs:
       matrix:
         directory: ${{ fromJSON(needs.determine-packages.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
           flavor: full
@@ -77,7 +77,7 @@ jobs:
       matrix:
         directory: ${{ fromJSON(needs.determine-packages.outputs.artifacts) }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
           flavor: build-installers

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -34,8 +34,9 @@ used_dlls_file=/tmp/used-dlls.$$.txt
 >"$used_dlls_file"
 missing_dlls_file=/tmp/missing-dlls.$$.txt
 >"$missing_dlls_file"
+unused_dlls_file=/tmp/unused-dlls.$$.txt
 tmp_file=/tmp/tmp.$$.txt
-trap "rm \"$used_dlls_file\" \"$missing_dlls_file\" \"$tmp_file\"" EXIT
+trap "rm \"$used_dlls_file\" \"$missing_dlls_file\" \"$unused_dlls_file\" \"$tmp_file\"" EXIT
 
 all_files="$(export ARCH BITNESS && "$thisdir"/make-file-list.sh | tr A-Z a-z | grep -v '/getprocaddr64.exe$')" &&
 usr_bin_dlls="$(echo "$all_files" | grep '^usr/bin/[^/]*\.dll$')" &&
@@ -107,6 +108,7 @@ echo "$all_files" |
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
 		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
-	sed 's/^/unused dll: /' >&2
+	sed 's/^/unused dll: /' |
+	tee "$unused_dlls_file" >&2
 
-test ! -s "$missing_dlls_file"
+test ! -s "$missing_dlls_file" && test ! -s "$unused_dlls_file"

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -95,6 +95,6 @@ echo "$all_files" |
 		-e '^usr/lib/gawk/' \
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
-		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|github\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
+		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' >&2

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -25,9 +25,9 @@ esac
 
 if test -t 2
 then
-	next_line='\033[K\r'
+	print_dir=t
 else
-	next_line='\n'
+	print_dir=
 fi
 
 used_dlls_file=/tmp/used-dlls.$$.txt
@@ -40,7 +40,8 @@ mingw_bin_dlls="$(echo "$all_files" | grep '^mingw'$BITNESS'/bin/[^/]*\.dll$')" 
 dirs="$(echo "$all_files" | sed -n 's/[^/]*\.\(dll\|exe\)$//p' | sort | uniq)" &&
 for dir in $dirs
 do
-	printf "dir: $dir$next_line\\r" >&2
+	test -z "$print_dir" ||
+	printf "dir: $dir\\033[K\\r" >&2
 
 	case "$dir" in
 	usr/*) dlls="$sys_dlls$LF$usr_bin_dlls$LF";;

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -95,6 +95,6 @@ echo "$all_files" |
 		-e '^usr/lib/gawk/' \
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
-		-e '^mingw../libexec/git-core/\(atlassian\|azuredevops\|bitbucket\|github\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
+		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|github\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' >&2

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -34,7 +34,7 @@ used_dlls_file=/tmp/used-dlls.$$.txt
 tmp_file=/tmp/tmp.$$.txt
 trap "rm \"$used_dlls_file\" \"$tmp_file\"" EXIT
 
-all_files="$(export ARCH BITNESS && "$thisdir"/make-file-list.sh | tr A-Z a-z)" &&
+all_files="$(export ARCH BITNESS && "$thisdir"/make-file-list.sh | tr A-Z a-z | grep -v '/getprocaddr64.exe$')" &&
 usr_bin_dlls="$(echo "$all_files" | grep '^usr/bin/[^/]*\.dll$')" &&
 mingw_bin_dlls="$(echo "$all_files" | grep '^mingw'$BITNESS'/bin/[^/]*\.dll$')" &&
 dirs="$(echo "$all_files" | sed -n 's/[^/]*\.\(dll\|exe\)$//p' | sort | uniq)" &&

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -95,6 +95,7 @@ echo "$all_files" |
 		-e '^usr/lib/gawk/' \
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
+		-e '^usr/lib/coreutils/libstdbuf.dll' \
 		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' >&2

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -355,3 +355,5 @@ test -z "$INCLUDE_TMUX" || cat <<EOF
 usr/bin/tmux.exe
 $(ldd /usr/bin/tmux.exe | sed -n 's/.*> \/\(.*msys-event[^ ]*\).*/\1/p')
 EOF
+
+test -z "$INCLUDE_OBJDUMP" || echo usr/bin/objdump.exe

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -156,13 +156,14 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/include/' -e '^/mingw../include/' \
 	-e '^/usr/share/doc/' \
 	-e '^/usr/share/info/' -e '^/mingw../share/info/' \
+	-e '^/mingw32/bin/lib\(ffi\|tasn1\)-.*\.dll$' \
 	-e '^/mingw../share/git-doc/technical/' \
 	-e '^/mingw../lib/cmake/' \
 	-e '^/mingw../itcl/' \
 	-e '^/mingw../t\(cl\|k\)[^/]*/\(demos\|msgs\|encoding\|tzdata\)/' \
 	-e '^/mingw../bin/\(autopoint\|[a-z]*-config\)$' \
 	-e '^/mingw../bin/lib\(asprintf\|brotlienc\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|pcre2-[13p]\|quadmath\|stdc++\|zip\)[^/]*\.dll$' \
-	-e '^/mingw../bin/lib\(atomic\|charset\|ffi\|gomp\|systre\|tasn1\)-[0-9]*\.dll$' \
+	-e '^/mingw../bin/lib\(atomic\|charset\|gomp\|systre\)-[0-9]*\.dll$' \
 	-e '^/mingw../bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\|zip\)[^/]*\.exe$' \
 	-e '^/mingw../bin/recode-sr-latin.exe$' \
 	-e '^/mingw../bin/\(cert\|p11\|psk\|srp\)tool.exe$' \
@@ -230,7 +231,7 @@ else
 		-e '^/mingw../bin/\(gitk\|git-upload-archive\.exe\)$' \
 		-e '^/mingw../bin/libgcc_s_seh-.*\.dll$' \
 		-e '^/mingw../bin/libjemalloc\.dll$' \
-		-e '^/mingw../bin/lib\(gmp\|gomp\|jansson\|metalink\|minizip\)-.*\.dll$' \
+		-e '^/mingw../bin/lib\(ffi\|gmp\|gomp\|jansson\|metalink\|minizip\|tasn1\)-.*\.dll$' \
 		-e '^/mingw../bin/libvtv.*\.dll$' \
 		-e '^/mingw../bin/libpcreposix.*\.dll$' \
 		-e '^/mingw../bin/\(.*\.def\|update-ca-trust\)$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -184,9 +184,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/msys-\('$(if test i686 = "$ARCH"
 	    then
 		echo 'uuid\|'
-	    else
-		echo 'lzma\|'
-	    fi)'fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
+	    fi)'lzma\|fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(hdb\|history8\|kadm5\|kdc\|otp\|sl\).*\.dll$' \
 	-e '^/usr/bin/msys-\(atomic\|blkid\|charset\|gthread\|metalink\|nghttp2\|pcre2-8\|ssh2\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \

--- a/please.sh
+++ b/please.sh
@@ -4454,6 +4454,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 	output_path=
 	force=
 	bitness=auto
+	keep_worktree=
 	while case "$1" in
 	--out|-o)
 		shift
@@ -4487,6 +4488,12 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 		;;
 	--force|-f)
 		force=t
+		;;
+	--keep-worktree)
+		keep_worktree=t
+		;;
+	--no-keep-worktree)
+		keep_worktree=
 		;;
 	-*) die "Unknown option: %s\n" "$1";;
 	*) break;;
@@ -4728,8 +4735,11 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
   <rewriteURI uriStartString="http://docbook.sourceforge.net/release/xsl-ns/current" rewritePrefix="/usr/share/xml/docbook-xsl-ns-1.78.1"/>' \
 			"$output_path/etc/xml/catalog"
 	fi &&
-	rm -r "$(cat "$output_path/.git" | sed 's/^gitdir: //')" &&
-	rm "$output_path/.git" &&
+	if test -z "$keep_worktree"
+	then
+		rm -r "$(cat "$output_path/.git" | sed 's/^gitdir: //')" &&
+		rm "$output_path/.git"
+	fi &&
 	echo "Output written to '$output_path'" >&2 ||
 	die "Could not write artifact at '%s'\n" "$output_path"
 }


### PR DESCRIPTION
This PR brings a couple of enhancements, most notably a CI/PR build definition that ensures that the `check-for-missing-dlls.sh` script is _actually_ run, and it does fail when missing or unused DLLs are detected in the set of files destined to be included in Git for Windows' artifacts.