### PR TITLE
create-sdk-artifact build-installers: make sure that `/tmp/` exists

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&
           define_matrix artifacts releaseable.txt touched.txt artifacts.txt
 
-          test -z "$(git log -L :create_sdk_artifact:please.sh ${{github.event.pull_request.base.sha}}.. -- )" ||
+          test -z "$(git log -L :create_sdk_artifact:please.sh ${{github.event.pull_request.base.sha}}.. -- )" &&
           test -z "$(git diff ${{github.event.pull_request.base.sha}}.. -- make-file-list.sh)" ||
           echo "::set-output name=test-sdk-artifacts::true"
 

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -289,7 +289,8 @@ fi
 # 3. Construct DeleteOpenSSHFiles function signature to be used in install.iss
 # 4. Assemble function body and compile flag to be used as guard in install.iss
 echo "$LIST" | sort >sorted-file-list.txt
-pacman -Ql openssh | sed -n 's|^openssh /\(.*[^/]\)$|\1|p' | sort >sorted-openssh-file-list.txt
+pacman -Ql openssh 2>pacman.stderr | sed -n 's|^openssh /\(.*[^/]\)$|\1|p' | sort >sorted-openssh-file-list.txt
+grep -v 'database file for .* does not exist' <pacman.stderr >&2
 openssh_deletes="$(comm -12 sorted-file-list.txt sorted-openssh-file-list.txt |
 	sed -e 'y/\//\\/' -e "s|.*|    if not DeleteFile(AppDir+'\\\\&') then\n        Result:=False;|")"
 inno_defines="$inno_defines$LF[Code]${LF}function DeleteOpenSSHFiles():Boolean;${LF}var$LF    AppDir:String;${LF}begin$LF    AppDir:=ExpandConstant('{app}');$LF    Result:=True;"

--- a/please.sh
+++ b/please.sh
@@ -4603,6 +4603,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 		/usr/bin/dirname.exe
 		/usr/bin/grep.exe
 		/usr/bin/ls.exe
+		/usr/bin/rm.exe
 		/usr/bin/sed.exe
 		/usr/bin/sort.exe
 		/usr/bin/uniq.exe

--- a/please.sh
+++ b/please.sh
@@ -4617,6 +4617,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 		# Files to include into the installer/Portable Git/MinGit
 		EOF
 		git -C "$output_path" checkout -- &&
+		mkdir -p "$output_path/tmp" &&
 		printf 'export MSYSTEM=MINGW%s\nexport PATH=/mingw%s/bin:/usr/bin/:/usr/bin/core_perl:/c/WINDOWS/system32:/c/WINDOWS:/c/WINDOWS/System32/Wbem\n' "$bitness" "$bitness" >"$output_path/etc/profile" &&
 		mkdir -p "$output_path/mingw$bitness/bin" &&
 		case $bitness in

--- a/please.sh
+++ b/please.sh
@@ -4647,7 +4647,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 			git -C "$git_sdk_path" show HEAD:.sparse/makepkg-git >>"$sparse_checkout_file" &&
 			printf '\n' >>"$sparse_checkout_file" &&
 			git -C "$git_sdk_path" show HEAD:.sparse/makepkg-git-i686 >>"$sparse_checkout_file" &&
-			printf '\n' >>"$sparse_checkout_file" &&
+			printf '\n# markdown, to render the release notes\n/usr/bin/markdown\n\n' >>"$sparse_checkout_file" &&
 			BITNESS=64 ARCH=x86_64 "$output_path/git-cmd.exe" --command=usr\\bin\\sh.exe -l \
 			"${this_script_path%/*}/make-file-list.sh" | sed -e 's|[][]|\\&|g' -e 's|^|/|' >>"$sparse_checkout_file"
 			;;


### PR DESCRIPTION
I stupidly introduced a bug by pushing directly to `main` ;-) And now I am going to fix the same bug.