### PR TITLE
installer/portable: drop zmore/bzmore

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -159,6 +159,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/svn' \
 	-e '^/usr/bin/xml.*exe$' \
 	-e '^/usr/bin/xslt.*$' \
+	-e '^/usr/bin/b*zmore$' \
 	-e '^/mingw../bin/.*zstd\.exe$' \
 	-e '^/mingw../share/doc/openssl/' \
 	-e '^/mingw../share/doc/gettext/' \


### PR DESCRIPTION
We do not ship with the pager called `more`, therefore `zmore` and `bzmore` cannot work. Let's stop shipping them.

This addresses https://github.com/git-for-windows/git/issues/3958