### PR TITLE
Release Notes: copy-edit the Bash/Vista/Windows 7/Windows 8 bits

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -46,7 +46,9 @@ This package contains software from a number of other projects including Bash, z
 
 We updated the included Bash to version 5.1 (previously 4.4). Please check your shell scripts for potential compatibility issues.
 
-Git for Windows will also stop supporting Windows Vista soon. Around the beginning of 2023, Git for Windows will drop support for Windows 7 and for Windows 8, following [Cygwin's and MSYS2's lead](https://www.msys2.org/docs/windows_support/) (Git for Windows relies on MSYS2 for components such as Bash and Perl).
+Also, as previously announced, Git for Windows dropped support for Windows Vista.
+
+Around the beginning of 2023, Git for Windows will drop support for Windows 7 and for Windows 8, following [Cygwin's and MSYS2's lead](https://www.msys2.org/docs/windows_support/) (Git for Windows relies on MSYS2 for components such as Bash and Perl).
 
 ### New Features
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -42,6 +42,12 @@ This package contains software from a number of other projects including Bash, z
 
 ## Changes since Git for Windows v2.37.1 (July 12th 2022)
 
+### (Upcoming) breaking changes
+
+We updated the included Bash to version 5.1 (previously 4.4). Please check your shell scripts for potential compatibility issues.
+
+Git for Windows will also stop supporting Windows Vista soon. Around the beginning of 2023, Git for Windows will drop support for Windows 7 and for Windows 8, following [Cygwin's and MSYS2's lead](https://www.msys2.org/docs/windows_support/) (Git for Windows relies on MSYS2 for components such as Bash and Perl).
+
 ### New Features
 
 * Comes with [tig v2.5.6](https://github.com/jonas/tig/releases/tag/tig-2.5.6).

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -96,7 +96,6 @@ WizardImageBackColor=clWhite
 WizardImageStretch=no
 WizardImageFile={#SourcePath}\git.bmp
 WizardSmallImageFile={#SourcePath}\gitsmall.bmp
-MinVersion=6.0
 
 [Types]
 ; Define a custom type to avoid getting the three default types.


### PR DESCRIPTION
For a while now, we announced that Bash will be upgraded. I just did that, the next snapshot will have that change.

Let's mention that in the release notes.

While at it, also drop Windows Vista support as announced earlier, and mention that Git for Windows will drop Windows 7/Windows 8 support soon as well.