### PR TITLE
Accommodate Azure Blobs size limitations

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -4858,6 +4858,7 @@ build_mingw_w64_git () { # [--only-32-bit] [--only-64-bit] [--skip-test-artifact
 	 MAKEFLAGS=${MAKEFLAGS:--j$(nproc)} makepkg-mingw -s --noconfirm $force -p PKGBUILD.$tag &&
 	 if test -n "$src_pkg"
 	 then
+		git -C git repack -adf &&
 		MAKEFLAGS=${MAKEFLAGS:--j$(nproc)} MINGW_ARCH=mingw64 makepkg-mingw $force --allsource -p PKGBUILD.$tag
 	 fi) ||
 	die "Could not build mingw-w64-git\n"


### PR DESCRIPTION
While publishing Git for Windows v2.37.3, the deployment to the Pacman repository failed in the first attempt. The reason was that the source package was larger than 256MB, which is not supported on Azure Blobs.

Let's reduce the size of the source package.

I verified in https://github.com/dscho/git-sdk-32/actions/runs/2964263305 that the source package is indeed smaller, around 150MB. The cost is non-negligible, though: [5 extra minutes](https://github.com/dscho/git-sdk-32/runs/8114640526?check_suite_focus=true#step:9:3402), press the gear and then select "Show timestamps" to verify this for yourself.