### PR TITLE
mingw-w64-git-cv2pdb: add ARM64 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,11 +56,22 @@ jobs:
       fail-fast: false
       matrix:
         directory: ${{ fromJSON(needs.determine-packages.outputs.matrix) }}
+    env:
+      HOME: "${{github.workspace}}\\home"
     steps:
       - uses: actions/checkout@v3
       - uses: git-for-windows/setup-git-for-windows-sdk@v1
         with:
           flavor: full
+      - name: configure build
+        shell: bash
+        run: |
+          USER_NAME="$GITHUB_ACTOR" &&
+          USER_EMAIL="$GITHUB_ACTOR@users.noreply.github.com" &&
+          mkdir -p "$HOME" &&
+          git config --global user.name "$USER_NAME" &&
+          git config --global user.email "$USER_EMAIL" &&
+          echo "PACKAGER=$USER_NAME <$USER_EMAIL>" >>$GITHUB_ENV &&
       - name: build ${{ matrix.directory }}
         shell: bash
         run: |

--- a/mingw-w64-cv2pdb/PKGBUILD
+++ b/mingw-w64-cv2pdb/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cv2pdb
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.50
+pkgver=0.51.8.g9286b93
 pkgrel=1
 pkgdesc="Converter of DWARF debug information to PDB files (mingw-w64)"
 arch=('any')
@@ -24,6 +24,7 @@ die () {
 case "$CARCH" in
 i686) WARCH=Win32; OUTDIR=bin/Release;;
 x86_64) WARCH=x64; OUTDIR=bin/Release_x64;;
+aarch64) WARCH=ARM64; OUTDIR=bin/Release_ARM64;;
 *) die "Unsupported architecture: $CARCH"
 esac
 


### PR DESCRIPTION
Needs https://github.com/rainers/cv2pdb/pull/81 to add ARM64 support (merged ✅)

Tested with `MINGW_ARCH=clangarm64 makepkg-mingw -i` and things work as expected:

```
$ cv2pdb --help
Convert DMD CodeView/DWARF debug information to PDB files, Version 0.52
Copyright (c) 2009-2012 by Rainer Schuetze, All Rights Reserved

License for redistribution is given by the Artistic License 2.0
see file LICENSE for further details

usage: --help [-D<version>|-C|-n|-e|-s<C>|-p<embedded-pdb>] <exe-file> [new-exe-file] [pdb-file]
```