### PR TITLE
portable + installer: add CLANGARM64 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,7 +112,8 @@ jobs:
             build-installers &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
-          cygpath -aw "$PWD/sdk-artifact/mingw64/bin" >>$GITHUB_PATH
+          cygpath -aw "$PWD/sdk-artifact/mingw64/bin" >>$GITHUB_PATH &&
+          echo "MSYSTEM=MINGW64" >>$GITHUB_ENV
       - name: build ${{ matrix.directory }}/
         shell: bash
         run: |
@@ -166,7 +167,8 @@ jobs:
           esac &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
-          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH
+          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH &&
+          echo "MSYSTEM=MINGW${{ matrix.bitness }}" >>$GITHUB_ENV
       - name: build installer
         if: matrix.artifact == 'build-installers'
         shell: bash
@@ -202,7 +204,8 @@ jobs:
             build-installers &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
-          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH
+          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH &&
+          echo "MSYSTEM=MINGW${{ matrix.bitness }}" >>$GITHUB_ENV
       - name: check for missing DLLs
         shell: bash
         run: ./check-for-missing-dlls.sh

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ edit-git-bash.exe
 /portable/root/bin/
 /portable/root/cmd/
 /portable/root/etc/
+/portable/root/clangarm64/
 /portable/root/mingw32/
 /portable/root/mingw64/
 /portable/root/post-install.bat

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('git-extra')
 _ver_base=1.1
-pkgver=1.1.612.56636bbd4
+pkgver=1.1.614.d551cf0cc
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('i686' 'x86_64')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -52,7 +52,7 @@ GITATTRIBUTES
 		-e 's/^\*\.DOT\(.*\)/&\n*.dotm\1\n*.DOTM\1/' \
 		"$ETC_GITATTRIBUTES"
 
-	for dir in mingw32 mingw64
+	for dir in mingw32 mingw64 clangarm64
 	do
 		# Drop git-wrapper in place of builtins "to save space"
 		git_wrapper=/$dir/share/git/git-wrapper.exe

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -18,7 +18,7 @@ GITATTRIBUTES
 		-e 's/^\*\.DOT\(.*\)/&\n*.dotm\1\n*.DOTM\1/' \
 		"$ETC_GITATTRIBUTES"
 
-	for dir in mingw32 mingw64
+	for dir in mingw32 mingw64 clangarm64
 	do
 		# Drop git-wrapper in place of builtins "to save space"
 		git_wrapper=/$dir/share/git/git-wrapper.exe

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -4,8 +4,8 @@
 
 #include "config.iss"
 
-#if !defined(APP_VERSION) || !defined(BITNESS)
-#error "config.iss should define APP_VERSION and BITNESS"
+#if !defined(APP_VERSION) || !defined(BITNESS) || !defined(MINGW_BITNESS)
+#error "config.iss should define APP_VERSION, BITNESS and MINGW_BITNESS"
 #endif
 
 #define APP_NAME      'Git'
@@ -13,7 +13,6 @@
 #undef APP_VERSION
 #define APP_VERSION   'Snapshot'
 #endif
-#define MINGW_BITNESS 'mingw'+BITNESS
 #define APP_CONTACT_URL 'https://github.com/git-for-windows/git/wiki/Contact'
 #define APP_URL       'https://gitforwindows.org/'
 #define APP_BUILTINS  'share\git\builtins.txt'

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -111,19 +111,20 @@ case "$displayver" in
 esac
 
 # Evaluate architecture
-ARCH="$(uname -m)"
-
-case "$ARCH" in
-i686)
+case "$MSYSTEM" in
+MINGW32)
 	BITNESS=32
+	ARCH=i686
 	;;
-x86_64)
+MINGW64)
 	BITNESS=64
+	ARCH=x86_64
 	;;
 *)
-	die "Unhandled architecture: $ARCH"
+	die "Unhandled MSYSTEM: $MSYSTEM"
 	;;
 esac
+MSYSTEM_LOWER=${MSYSTEM,,}
 
 echo "Generating release notes to be included in the installer ..."
 ../render-release-notes.sh --css usr/share/git/ ||
@@ -152,7 +153,7 @@ then
 	LIST=
 else
 	echo "Generating file list to be included in the installer ..."
-	LIST="$(ARCH=$ARCH BITNESS=$BITNESS \
+	LIST="$(ARCH=$ARCH \
 		ETC_GITCONFIG="$etc_gitconfig" \
 		PACKAGE_VERSIONS_FILE=package-versions.txt \
 		INCLUDE_GIT_UPDATE=1 \
@@ -168,12 +169,12 @@ test -z "$cmd_git" || {
 die "Could not execute 'git version'"
 
 printf '; List of files\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-	"Source: \"mingw$BITNESS\\bin\\blocked-file-util.exe\"; Flags: dontcopy" \
+	"Source: \"$MSYSTEM_LOWER\\bin\\blocked-file-util.exe\"; Flags: dontcopy" \
 	"Source: \"{#SourcePath}\\package-versions.txt\"; DestDir: {app}\\etc; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
 	"Source: \"{#SourcePath}\\..\\ReleaseNotes.css\"; DestDir: {app}\\usr\\share\\git; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
 	"Source: \"cmd\\git.exe\"; DestDir: {app}\\bin; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
-	"Source: \"mingw$BITNESS\\share\\git\\compat-bash.exe\"; DestName: bash.exe; DestDir: {app}\\bin; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
-	"Source: \"mingw$BITNESS\\share\\git\\compat-bash.exe\"; DestName: sh.exe; DestDir: {app}\\bin; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
+	"Source: \"$MSYSTEM_LOWER\\share\\git\\compat-bash.exe\"; DestName: bash.exe; DestDir: {app}\\bin; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
+	"Source: \"$MSYSTEM_LOWER\\share\\git\\compat-bash.exe\"; DestName: sh.exe; DestDir: {app}\\bin; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore" \
 	"Source: \"{#SourcePath}\\..\\post-install.bat\"; DestName: post-install.bat; DestDir: {app}; Flags: replacesameversion restartreplace" \
 >file-list.iss ||
 die "Could not write to file-list.iss"
@@ -328,10 +329,11 @@ test -z "$arm64_artifacts_directory" || {
 die "Could not include ARM64 artifacts"
 
 etc_gitconfig_dir="${etc_gitconfig%/gitconfig}"
-printf "%s\n%s\n%s\n%s\n%s%s" \
+printf "%s\n%s\n%s\n%s\n%s\n%s%s" \
 	"#define APP_VERSION '$displayver'" \
 	"#define FILENAME_VERSION '$version'" \
 	"#define BITNESS '$BITNESS'" \
+	"#define MINGW_BITNESS '$MSYSTEM_LOWER'" \
 	"#define SOURCE_DIR '$(cygpath -aw /)'" \
 	"#define ETC_GITCONFIG_DIR '${etc_gitconfig_dir//\//\\}'" \
 	"$inno_defines" \

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -78,13 +78,6 @@ do
 	--include-pdbs)
 		include_pdbs=t
 		;;
-	--include-arm64-artifacts=*)
-		case "${1#*=}" in
-		/*) ;; # absolute path, okay
-		*) die "Need an absolute path: $1";;
-		esac
-		arm64_artifacts_directory="${1#*=}"
-		;;
 	*)
 		break
 	esac
@@ -119,6 +112,11 @@ MINGW32)
 MINGW64)
 	BITNESS=64
 	ARCH=x86_64
+	;;
+CLANGARM64)
+	BITNESS=64
+	ARCH=aarch64
+	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX 'arm64'"
 	;;
 *)
 	die "Unhandled MSYSTEM: $MSYSTEM"
@@ -316,17 +314,6 @@ test -z "$include_pdbs" || {
 		>> file-list.iss
 } ||
 die "Could not include .pdb files"
-
-test -z "$arm64_artifacts_directory" || {
-	echo "Including ARM64 artifacts from $arm64_artifacts_directory" &&
-	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX 'arm64'" &&
-	mixed="$(cygpath -m "$arm64_artifacts_directory")" &&
-	find "$arm64_artifacts_directory" -type f |
-	sed -e "s|^$arm64_artifacts_directory\\(/.*\)\?/\([^/]*\)$|Source: \"$mixed\\1/\\2\"; DestDir: {app}/arm64\\1; Flags: replacesameversion restartreplace; AfterInstall: DeleteFromVirtualStore|" \
-		-e 's|/|\\|g' \
-		>> file-list.iss
-} ||
-die "Could not include ARM64 artifacts"
 
 etc_gitconfig_dir="${etc_gitconfig%/gitconfig}"
 printf "%s\n%s\n%s\n%s\n%s\n%s%s" \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -17,6 +17,10 @@ i686)
 	MSYSTEM_LOWER=mingw32
 	PACMAN_ARCH=i686
 	;;
+aarch64)
+	MSYSTEM_LOWER=clangarm64
+	PACMAN_ARCH=clang-aarch64
+	;;
 *)
 	die "Architecture ${ARCH} not supported"
 	;;
@@ -104,7 +108,7 @@ pacman_list () {
 		done |
 		grep -v "^\\($(echo $PACKAGE_EXCLUDES | sed \
 			-e 's/ /\\|/g' \
-			-e 's/mingw-w64-/&\\(i686\\|x86_64\\)-/g')\\)\$" |
+			-e 's/mingw-w64-/&\\(i686\\|x86_64\\|clang-aarch64\\)-/g')\\)\$" |
 		sort |
 		uniq) &&
 

--- a/please.sh
+++ b/please.sh
@@ -1419,6 +1419,8 @@ prerelease () { # [--installer | --portable | --mingit | --mingit-busybox] [--on
 	portable_root=/usr/src/build-extra/portable/root/
 	rm -rf "$sdk$portable_root"/mingw64/libexec/git-core ||
 	die "Could not ensure that portable Git in '%s' is cleaned\n" "$sdk"
+	rm -rf "$sdk$portable_root"/clangarm64/libexec/git-core ||
+	die "Could not ensure that portable Git in '%s' is cleaned\n" "$sdk"
 	test -n "$only_64_bit" ||
 	rm -rf "$sdk32$portable_root"/mingw32/libexec/git-core ||
 	die "Could not ensure that portable Git in '%s' is cleaned\n" "$sdk32"

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -22,9 +22,6 @@ do
 	--include-pdbs)
 		include_pdbs=t
 		;;
-	--include-arm64-artifacts=*)
-		arm64_artifacts_directory="${1#*=}"
-		;;
 	-*)
 		die "Unknown option: $1"
 		;;
@@ -51,6 +48,12 @@ MINGW64)
 	BITNESS=64
 	ARCH=x86_64
 	ARTIFACT_SUFFIX=64
+	MD_ARG=256M
+	;;
+CLANGARM64)
+	BITNESS=64
+	ARCH=aarch64
+	ARTIFACT_SUFFIX=ARM64
 	MD_ARG=256M
 	;;
 *)
@@ -148,17 +151,7 @@ test -z "$include_pdbs" || {
 die "Could not unpack .pdb files"
 
 TITLE="$BITNESS-bit"
-
-# ARM64 Windows handling
-if test -n "$arm64_artifacts_directory"
-then
-	echo "Including ARM64 artifacts from $arm64_artifacts_directory" &&
-	TARGET="$output_directory"/PortableGit-"$VERSION"-arm64.7z.exe &&
-	TITLE="ARM64" &&
-	rm -rf "$SCRIPT_PATH/root/arm64" &&
-	cp -ar "$arm64_artifacts_directory" "$SCRIPT_PATH/root/arm64" ||
-	die "Could not copy ARM64 artifacts from $arm64_artifacts_directory"
-fi
+test $ARCH == "aarch64" && TITLE="ARM64"
 
 # 7-Zip will strip absolute paths completely... therefore, we can add another
 # root directory like this:

--- a/portable/release.sh
+++ b/portable/release.sh
@@ -40,23 +40,27 @@ die "Usage: $0 [--output=<directory>] <version> [optional components]"
 test -d "$output_directory" ||
 die "Directory inaccessible: '$output_directory'"
 
-ARCH="$(uname -m)"
-case "$ARCH" in
-i686)
+case "$MSYSTEM" in
+MINGW32)
 	BITNESS=32
+	ARCH=i686
+	ARTIFACT_SUFFIX=32
 	MD_ARG=128M
 	;;
-x86_64)
+MINGW64)
 	BITNESS=64
+	ARCH=x86_64
+	ARTIFACT_SUFFIX=64
 	MD_ARG=256M
 	;;
 *)
-	die "Unhandled architecture: $ARCH"
+	die "Unhandled MSYSTEM: $MSYSTEM"
 	;;
 esac
+MSYSTEM_LOWER=${MSYSTEM,,}
 VERSION=$1
 shift
-TARGET="$output_directory"/PortableGit-"$VERSION"-"$BITNESS"-bit.7z.exe
+TARGET="$output_directory"/PortableGit-"$VERSION"-"$ARTIFACT_SUFFIX"-bit.7z.exe
 OPTS7="-m0=lzma -mx=9 -md=$MD_ARG -mfb=273 -ms=256M "
 TMPPACK=/tmp.7z
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
@@ -89,8 +93,8 @@ mkdir -p "$SCRIPT_PATH/root/bin" ||
 die "Could not make bin/ directory"
 
 cp /cmd/git.exe "$SCRIPT_PATH/root/bin/git.exe" &&
-cp /mingw$BITNESS/share/git/compat-bash.exe "$SCRIPT_PATH/root/bin/bash.exe" &&
-cp /mingw$BITNESS/share/git/compat-bash.exe "$SCRIPT_PATH/root/bin/sh.exe" ||
+cp /$MSYSTEM_LOWER/share/git/compat-bash.exe "$SCRIPT_PATH/root/bin/bash.exe" &&
+cp /$MSYSTEM_LOWER/share/git/compat-bash.exe "$SCRIPT_PATH/root/bin/sh.exe" ||
 die "Could not install bin/ redirectors"
 
 cp "$SCRIPT_PATH/../post-install.bat" "$SCRIPT_PATH/root/" ||
@@ -102,7 +106,7 @@ etc_gitconfig="${etc_gitconfig#/}" ||
 die "Could not determine the path of the system config"
 
 # Make a list of files to include
-LIST="$(ARCH=$ARCH BITNESS=$BITNESS ETC_GITCONFIG="$etc_gitconfig" \
+LIST="$(ARCH=$ARCH ETC_GITCONFIG="$etc_gitconfig" \
 	PACKAGE_VERSIONS_FILE="$SCRIPT_PATH"/root/etc/package-versions.txt \
 	sh "$SCRIPT_PATH"/../make-file-list.sh "$@" |
 	grep -v "^$etc_gitconfig$")" ||
@@ -124,16 +128,16 @@ case "$LIST" in
 	;;
 esac
 
-git_core="$SCRIPT_PATH/root/mingw$BITNESS/libexec/git-core" &&
+git_core="$SCRIPT_PATH/root/$MSYSTEM_LOWER/libexec/git-core" &&
 rm -rf "$git_core" &&
 mkdir -p "$git_core" &&
-if test "$(stat -c %D /mingw$BITNESS/bin)" = "$(stat -c %D "$git_core")"
+if test "$(stat -c %D /$MSYSTEM_LOWER/bin)" = "$(stat -c %D "$git_core")"
 then
 	ln_or_cp=ln
 else
 	ln_or_cp=cp
 fi &&
-$ln_or_cp $(echo "$LIST" | sed -n "s|^mingw$BITNESS/bin/[^/]*\.dll$|/&|p") "$git_core" ||
+$ln_or_cp $(echo "$LIST" | sed -n "s|^$MSYSTEM_LOWER/bin/[^/]*\.dll$|/&|p") "$git_core" ||
 die "Could not copy .dll files into libexec/git-core/"
 
 test -z "$include_pdbs" || {


### PR DESCRIPTION
~Needs https://github.com/git-for-windows/MINGW-packages/pull/56~ ✅ merged
~Needs https://github.com/git-for-windows/MINGW-packages/pull/59~ ✅ merged
~Needs https://github.com/git-for-windows/MINGW-packages/pull/58~ ✅ merged
~Needs https://github.com/git-for-windows/setup-git-for-windows-sdk/pull/397~ ✅ merged
~Needs https://github.com/git-for-windows/git/pull/3916~ ✅ merged
~Needs https://github.com/msys2/MINGW-packages/pull/13787~ ✅ merged
~Needs https://github.com/git-for-windows/MINGW-packages/pull/57~ ✅ merged
~Needs https://github.com/git-for-windows/build-extra/pull/440~ ✅ merged

## How to test

On an ARM64 device, do the following:

- Install the `git-sdk-64`
- Make sure you create the `clangarm64` folder and start the SDK with `MSYSTEM=clangarm64`, as well as install tools like the Clang compiler. Note that the Git SDK GitHub Action will do that for you soon - see https://github.com/git-for-windows/setup-git-for-windows-sdk/pull/397/files for all details, including a list of the dependencies you need.
- Download this ZIP file below with the Git artifacts: [git-artifacts-zst.zip](https://github.com/git-for-windows/build-extra/files/9896613/git-artifacts-zst.zip) (created with https://github.com/git-for-windows/MINGW-packages/pull/56)
- Download this ZIP file with the `curl`/`openssl`/`xpdf-tools`/`wintoast` dependencies for `clangarm64`: [git-build-extra-artifacts-zst.zip](https://github.com/git-for-windows/build-extra/files/9896791/git-build-extra-artifacts-zst.zip)

Then run the following command for **portable**:

```
/usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=2.39.0 --portable -o artifacts \
--pkg=/mingw-w64-clang-aarch64-git-2.39.0.1.de9501c66f-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-git-doc-html-2.39.0.1.de9501c66f-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-xpdf-tools-4.00-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-curl-7.86.0-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-openssl-1.1.1.s-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-wintoast-1.0.0.181.9b0663d-1-any.pkg.tar.zst
```

... or this command for **installer**:

```
/usr/src/build-extra/please.sh make_installers_from_mingw_w64_git --version=2.39.0 --installer -o artifacts \
--pkg=/mingw-w64-clang-aarch64-git-2.39.0.1.de9501c66f-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-git-doc-html-2.39.0.1.de9501c66f-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-xpdf-tools-4.00-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-curl-7.86.0-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-openssl-1.1.1.s-1-any.pkg.tar.zst \
--pkg=/mingw-w64-clang-aarch64-wintoast-1.0.0.181.9b0663d-1-any.pkg.tar.zst
```