### PR TITLE
mingit: do include `ssh-sk-helper.exe`

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -296,7 +296,8 @@ else
 		-e '^/usr/bin/msys-\(cilkrts\|kafs\|ssl\)-.*\.dll$' \
 		-e '^/usr/bin/msys-sqlite3[a-z].*\.dll$' \
 		-e '^/usr/bin/msys-\(gomp.*\|vtv.*\)-.*\.dll$' \
-		-e '^/usr/lib/\(awk\|coreutils\|gawk\|openssl\|pkcs11\|ssh\)/' \
+		-e '^/usr/lib/\(awk\|coreutils\|gawk\|openssl\|pkcs11\)/' \
+		-e '^/usr/lib/ssh/sftp' \
 		-e '^/usr/libexec/\(bigram\|code\|frcode\)\.exe$' \
 		-e '^/usr/share/\(cygwin\|git\)/' \
 		-e '^/usr/ssl/misc/' \


### PR DESCRIPTION
Without this, the intended new feature to support USB security keys via Windows Hello won't work.

This fix will also pacify the [`check-for-missing-dlls`](https://github.com/git-for-windows/git-sdk-32/actions/runs/3413840461/jobs/5681027911) [runs](https://github.com/git-for-windows/git-sdk-64/actions/runs/3402792843/jobs/5658882619) which currently point out [that `msys-fido2-1.dll` is unused in MinGit](https://github.com/git-for-windows/git-sdk-64/actions/runs/3402792843/jobs/5658882619#step:6:9), which is now no longer true.