### PR TITLE
Fix the `check-for-missing-dlls` build

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -5,6 +5,14 @@ die () {
 	exit 1
 }
 
+while case "$1" in
+--mingit) MINIMAL_GIT=1; export MINIMAL_GIT;;
+-*) die "Unknown option: $1";;
+*) break;;
+esac; do shift; done
+
+test $# = 0 || die "$0 does not take arguments"
+
 thisdir="$(cd "$(dirname "$0")" && pwd)" ||
 die "Could not determine script directory"
 

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -64,6 +64,11 @@ then
 	die "Could not exclude missing dashed versions of the built-in commands"
 fi
 
+# Newer `git.exe` no longer link to `libssp-0.dll` that has been made obsolete
+# by recent GCC updates
+EXCLUDE_LIBSSP=
+grep -q libssp "/mingw$BITNESS/bin/git.exe" || EXCLUDE_LIBSSP='\|ssp'
+
 this_script_dir="$(cd "$(dirname "$0")" && pwd -W)" ||
 die "Could not determine this script's dir"
 
@@ -178,7 +183,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/mingw../t\(cl\|k\)[^/]*/\(demos\|msgs\|encoding\|tzdata\)/' \
 	-e '^/mingw../bin/\(autopoint\|[a-z]*-config\)$' \
 	-e '^/mingw../bin/lib\(asprintf\|brotlienc\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|pcre2-[13p]\|quadmath\|stdc++\|zip\)[^/]*\.dll$' \
-	-e '^/mingw../bin/lib\(atomic\|charset\|gomp\|systre\)-[0-9]*\.dll$' \
+	-e '^/mingw../bin/lib\(atomic\|charset\|gomp\|systre'"$EXCLUDE_LIBSSP"'\)-[0-9]*\.dll$' \
 	-e '^/mingw../bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\|zip\)[^/]*\.exe$' \
 	-e '^/mingw../bin/recode-sr-latin.exe$' \
 	-e '^/mingw../bin/\(cert\|p11\|psk\|srp\)tool.exe$' \


### PR DESCRIPTION
With the upgrade to mingw-w64-git v2.39.0-rc0, this build started failing, see e.g. [here](https://github.com/git-for-windows/git-sdk-64/actions/runs/3537444656/jobs/5937421607).

The culprit is that pesky `libssp-0.dll` which used to be required for `-fstack-protector` (i.e. GCC's stack-smashing protector), but is no longer needed _when compiling with a newer mingw-w64-gcc_.

The fix is a little tricky because we essentially have to make sure that `git.exe` does not require the `libssp-0.dll` before excluding that file.