### PR TITLE
Automate adding release notes

### DIFF
--- a/.github/workflows/add-release-note.yml
+++ b/.github/workflows/add-release-note.yml
@@ -1,0 +1,47 @@
+name: Add Release Note
+run-name: 'Add Release Note (${{ inputs.type }}): ${{ inputs.message }}'
+
+on:
+  workflow_dispatch:
+    inputs:
+      type:
+        description: The type of release note (must be blurb, feature or bug)
+        required: true
+        type: string
+      message:
+        description: The release note
+        required: true
+        type: string
+
+jobs:
+  add-release-note:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Configure Git author
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const username = '${{ github.triggering_actor }}'
+            const email = `${username}@users.noreply.github.com`
+            const { data: { name } } = await github.rest.users.getByUsername({ username })
+            core.exportVariable('GIT_AUTHOR_NAME', name)
+            core.exportVariable('GIT_AUTHOR_EMAIL', email)
+            core.exportVariable('GIT_COMMITTER_NAME', name)
+            core.exportVariable('GIT_COMMITTER_EMAIL', email)
+      - name: Partial & sparse clone
+        run: |
+          git clone --depth=1 --filter=blob:none --no-checkout --single-branch \
+            -b ${{ github.ref_name }} https://github.com/${{ github.repository }} . &&
+          # need only `add-release-notes.js` and `ReleaseNotes.md`, really
+          git sparse-checkout set . &&
+          git checkout
+      - name: Add release note
+        env:
+          TYPE: ${{ github.event.inputs.type }}
+          MESSAGE: ${{ github.event.inputs.message }}
+        run: node ./add-release-note.js --commit "$TYPE" "$MESSAGE"
+      - name: Push updates
+        run: |
+          git -c http.extraHeader="Authorization: Basic $(printf 'x-access-token:${{ secrets.GITHUB_TOKEN }}' | base64 -w 0)" push origin HEAD

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -53,6 +53,7 @@ This package contains software from a number of other projects including Bash, z
 * Portable Git no longer configures `color.diff`, `color.status` and `color.branch` individually, but [configures `color.ui` instead](https://github.com/git-for-windows/build-extra/pull/442), which makes it easier to override the default.
 * Comes with [GNU TLS v3.7.8](https://lists.gnupg.org/pipermail/gnutls-help/2022-September/004765.html).
 * Comes with [Git Credential Manager Core v2.0.877](https://github.com/GitCredentialManager/git-credential-manager/releases/tag/v2.0.877).
+* Comes with [MinTTY v3.6.2](https://github.com/mintty/mintty/releases/tag/3.6.2).
 
 ### Bug Fixes
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -49,11 +49,11 @@ This package contains software from a number of other projects including Bash, z
 * The Portable Git edition (which comes as a self-extracting 7-Zip archive) [now uses the latest 7-Zip version to self-extract](https://github.com/git-for-windows/build-extra/commit/0240a09014a4fcfd9f487e50d7a09464a2e428b8).
 * Comes with [OpenSSH v9.1p1](https://www.openssh.com/txt/release-9.1).
 * It [is now possible](https://github.com/git-for-windows/MSYS2-packages/commit/6823ee7b329b53f38747f64db8fb8d6de077a0e4) to generate and use [SSH keys protected by security keys](https://man.openbsd.org/ssh-keygen#FIDO_AUTHENTICATOR) (AKA FIDO devices) via Windows Hello, e.g. via `ssh-keygen.exe -t ecdsa-sk`.
-* Comes with [Bash v5.2 patchlevel 009 ](https://tiswww.case.edu/php/chet/bash/NEWS).
 * Portable Git no longer configures `color.diff`, `color.status` and `color.branch` individually, but [configures `color.ui` instead](https://github.com/git-for-windows/build-extra/pull/442), which makes it easier to override the default.
 * Comes with [GNU TLS v3.7.8](https://lists.gnupg.org/pipermail/gnutls-help/2022-September/004765.html).
 * Comes with [Git Credential Manager Core v2.0.877](https://github.com/GitCredentialManager/git-credential-manager/releases/tag/v2.0.877).
 * Comes with [MinTTY v3.6.2](https://github.com/mintty/mintty/releases/tag/3.6.2).
+* Comes with [Bash v5.2 patchlevel 12](https://github.com/git-for-windows/git/issues/4133).
 
 ### Bug Fixes
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -53,7 +53,7 @@ This package contains software from a number of other projects including Bash, z
 * Comes with [GNU TLS v3.7.8](https://lists.gnupg.org/pipermail/gnutls-help/2022-September/004765.html).
 * Comes with [Git Credential Manager Core v2.0.877](https://github.com/GitCredentialManager/git-credential-manager/releases/tag/v2.0.877).
 * Comes with [MinTTY v3.6.2](https://github.com/mintty/mintty/releases/tag/3.6.2).
-* Comes with [Bash v5.2 patchlevel 12](https://github.com/git-for-windows/git/issues/4133).
+* Comes with [Bash v5.2 patchlevel 12](https://tiswww.case.edu/php/chet/bash/NEWS).
 
 ### Bug Fixes
 

--- a/add-release-note.js
+++ b/add-release-note.js
@@ -43,6 +43,12 @@ const addReleaseNote = (type, message) => {
     else current.push(line)
   }
 
+  // Remove any superseded entries
+  if (type === 'feature') {
+    const match = message.match(/^(Comes with \[[^\]]+ )(v|patch level)/)
+    if (match) sections.feature = sections.feature.filter(e => !e.startsWith(`* ${match[1]}`))
+  }
+
   // Add the message to the section
   sections[type].push(type === 'blurb' ? message : `* ${message}`)
 

--- a/add-release-note.js
+++ b/add-release-note.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+
+/**
+ * Adds an entry to the `ReleaseNotes.md` file
+ *
+ * The `type` parameter must be one of `feature` (referring to the "New
+ * Features" section), `bug` (referring to the "Bug Fixes" section) or `blurb`
+ * (referring to the space before the "New Features" and "Bug Fixes" sections).
+ *
+ * @param {string} type
+ * @param {string} message
+ */
+const addReleaseNote = (type, message) => {
+  const sections = {
+    blurb: [],
+    feature: [],
+    bug: []
+  }
+  if (!sections[type]) throw new Error(`Unhandled type '${type}' (must be one of "${Object.keys(sections).join('", "')}")`)
+
+  // Read in the file contents
+  const path = `${__dirname}/ReleaseNotes.md`
+  const contents = fs.readFileSync(path)
+
+  const entries = contents.toString().split(/(\n## Changes since Git for Windows v)(\d+(?:\.\d+)*)( \()([A-Z][a-z]+ \d+[a-z]* \d{4})(\))/g)
+  const [, currentVersion, currentDate ] = entries[0].match(/^# Git for Windows v(\d+(?:\.\d+)*) Release Notes\nLatest update: ([A-Z][a-z]+ \d+[a-z]* \d{4})/)
+  const latestVersion = entries[2]
+  const latestDate = entries[4]
+
+  // If no section exists for the latest version yet, add one
+  if (true && latestVersion !== currentVersion || latestDate !== currentDate) {
+    entries.splice(1, 0, '\n## Changes since Git for Windows v', currentVersion, ' (', currentDate, ')', '\n')
+  }
+
+  // Parse the latest section
+  let current = sections.blurb
+  for (const line of entries[6].split('\n')) {
+    if (line === '') continue
+    if (line === '### New Features') current = sections.feature
+    else if (line === '### Bug Fixes') current = sections.bug
+    else current.push(line)
+  }
+
+  // Add the message to the section
+  sections[type].push(type === 'blurb' ? message : `* ${message}`)
+
+  // Put it all back together
+  const blurb = sections.blurb.length ? `\n${sections.blurb.join('\n\n')}\n` : ''
+  const feature = sections.feature.length ? `\n### New Features\n\n${sections.feature.join('\n')}\n` : ''
+  const bug = sections.bug.length ? `\n### Bug Fixes\n\n${sections.bug.join('\n')}\n` : ''
+  entries[6] = `\n${blurb}${feature}${bug}`
+
+  // Write the updated `ReleaseNotes.md`
+  fs.writeFileSync(path, entries.join(''))
+}
+
+const main = async () => {
+  if (process.argv.length !== 4) {
+    throw new Error(`Usage: ${process.argv[1]} ( blurb | feature | bug ) <message>\n`)
+  }
+  const [, , type, message] = process.argv
+  addReleaseNote(type, message)
+}
+
+main().catch(e => {
+  process.stderr.write(`${e.message}\n`)
+  process.exit(1)
+})

--- a/add-release-note.js
+++ b/add-release-note.js
@@ -50,7 +50,12 @@ const addReleaseNote = (type, message) => {
   }
 
   // Add the message to the section
-  sections[type].push(type === 'blurb' ? message : `* ${message}`)
+  if (type === 'feature' && message.startsWith('Comes with [Git v')) {
+    // Make sure that the Git version is always reported first
+    sections.feature.unshift(`* ${message}`)
+  } else {
+    sections[type].push(type === 'blurb' ? message : `* ${message}`)
+  }
 
   // Put it all back together
   const blurb = sections.blurb.length ? `\n${sections.blurb.join('\n\n')}\n` : ''


### PR DESCRIPTION
Implementing this as a relatively easy-to-use workflow is step 1. At some stage, I want to end up with a solution where a member of the Git for Windows team can simply add a comment of the form `/relnote <type> <message>` to a PR and have this workflow triggered automatically.

[This](https://github.com/dscho/build-extra/actions/runs/3548059031) is the workflow that added the release note about MinTTY, and [this](https://github.com/dscho/build-extra/actions/runs/3548082900) is the one that talks about Bash v5.2 patchlevel 12.