### PR TITLE
git-extra: set the config color.ui also in existing /etc/gitconfig

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,6 +75,18 @@ jobs:
         with:
           name: ${{ env.artifacts }}
           path: ${{ env.artifacts }}
+      - name: ensure that the Git worktree is still clean
+        shell: bash
+        run: |
+          cd "${{ matrix.directory }}" &&
+          if ! git update-index --ignore-submodules --refresh ||
+            ! git diff-files --ignore-submodules ||
+            ! git diff-index --cached --ignore-submodules HEAD
+          then
+            echo "::error::Uncommitted changes after build!" >&2
+            git diff
+            exit 1
+          fi
   build-artifacts:
     needs: determine-packages
     runs-on: windows-latest

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -20,7 +20,7 @@ pkgver() {
     sed -n -e '1,/^@@/d' -e '/^[-+]pkgver=/d' -e '/^[-+]/p')" ||
   rev="$(git rev-list -1 $rev^ -- .)"
   printf "%s.%s.%s" "${_ver_base}" "$(git rev-list --count $rev -- .)" \
-    "$(git rev-parse --short $rev)"
+    "$(git rev-parse --short=9 $rev)"
 }
 source=('inputrc'
         'vimrc'

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=('git-extra')
 _ver_base=1.1
-pkgver=1.1.609.6752ff0
+pkgver=1.1.612.56636bbd4
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('i686' 'x86_64')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -272,6 +272,17 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	! grep -q '^	sslCAinfo = /ssl/certs/ca-bundle.crt$' /etc/gitconfig ||
 	sed -i -e 's/^	sslCAinfo = \/ssl\/certs\/ca-bundle\.crt$/#&/' /etc/gitconfig
 
+	# We no longer want to configure `color.diff`, `color.status` and `color.branch`
+	# by default.
+	test ! -f /etc/gitconfig || # just a little defensive programming
+	test -z "$(sed -n '/^\[color\]/{N;/\(diff\|status\|branch\) = auto/p}' </etc/gitconfig)" || {
+		git config -f /etc/gitconfig color.ui auto &&
+		for key in diff status branch
+		do
+			git config -f /etc/gitconfig --unset color.$key # ignore errors, e.g. if already unset
+		done
+	}
+
 	# Previously, we made sure that `/ssl` is a symbolic link pointing to
 	# `/usr/ssl` so that the http.sslCAInfo setting could be shared between
 	# the MSYS and the MINGW variants of `git.exe`.

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -238,6 +238,17 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	! grep -q '^	sslCAinfo = /ssl/certs/ca-bundle.crt$' /etc/gitconfig ||
 	sed -i -e 's/^	sslCAinfo = \/ssl\/certs\/ca-bundle\.crt$/#&/' /etc/gitconfig
 
+	# We no longer want to configure `color.diff`, `color.status` and `color.branch`
+	# by default.
+	test ! -f /etc/gitconfig || # just a little defensive programming
+	test -z "$(sed -n '/^\[color\]/{N;/\(diff\|status\|branch\) = auto/p}' </etc/gitconfig)" || {
+		git config -f /etc/gitconfig color.ui auto &&
+		for key in diff status branch
+		do
+			git config -f /etc/gitconfig --unset color.$key # ignore errors, e.g. if already unset
+		done
+	}
+
 	# Previously, we made sure that `/ssl` is a symbolic link pointing to
 	# `/usr/ssl` so that the http.sslCAInfo setting could be shared between
 	# the MSYS and the MINGW variants of `git.exe`.


### PR DESCRIPTION
This is a follow-up for https://github.com/git-for-windows/build-extra/pull/442 (which did not fix our problem completely).

It supersedes https://github.com/git-for-windows/build-extra/pull/447, using a branch in the same repository so that we can branch-deploy.