### PR TITLE
Update `sdk-installer` to support arm64 SDK

### DIFF
--- a/sdk-installer/release.sh
+++ b/sdk-installer/release.sh
@@ -21,6 +21,10 @@ MINGW64)
 	SDK_ARCH=64
 	SDK_TITLE="64-bit"
 	;;
+CLANGARM64)
+	SDK_ARCH=arm64
+	SDK_TITLE=arm64
+	;;
 *)
 	die "Unhandled MSYSTEM: $MSYSTEM"
 	;;

--- a/sdk-installer/release.sh
+++ b/sdk-installer/release.sh
@@ -7,6 +7,21 @@ die () {
 	exit 1
 }
 
+output_directory="$HOME"
+while case "$1" in
+--output=*)
+	output_directory="$(cd "${1#*=}" && pwd)" ||
+	die "Directory inaccessible: '${1#*=}'"
+	;;
+--output)
+	shift
+	output_directory="$(cd "$1" && pwd)" ||
+	die "Directory inaccessible: '$1'"
+	;;
+-*) die "Unknown option: %s\n" "$1";;
+*) break;;
+esac; do shift; done
+
 test "$#" = 1 ||
 die "Usage: $0 <version>"
 
@@ -32,7 +47,7 @@ MSYSTEM_LOWER=${MSYSTEM,,}
 GIT_SDK_URL=https://github.com/git-for-windows/git-sdk-$SDK_ARCH 
 
 FAKEROOTDIR="$(cd "$(dirname "$0")" && pwd)/root"
-TARGET="$HOME"/git-sdk-installer-"$1"-$SDK_ARCH.7z.exe
+TARGET="$output_directory"/git-sdk-installer-"$1"-$SDK_ARCH.7z.exe
 OPTS7="-m0=lzma -mx=9 -md=64M"
 TMPPACK=/tmp.7z
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"

--- a/sdk-installer/release.sh
+++ b/sdk-installer/release.sh
@@ -12,27 +12,29 @@ die () {
 	exit 1
 }
 
-ARCH="$(uname -m)"
-case "$ARCH" in
-i686)
-	BITNESS=32
+case "$MSYSTEM" in
+MINGW32)
+	SDK_ARCH=32
+	SDK_TITLE="32-bit"
 	;;
-x86_64)
-	BITNESS=64
+MINGW64)
+	SDK_ARCH=64
+	SDK_TITLE="64-bit"
 	;;
 *)
-	die "Unhandled architecture: $ARCH"
+	die "Unhandled MSYSTEM: $MSYSTEM"
 	;;
 esac
+MSYSTEM_LOWER=${MSYSTEM,,}
 
-GIT_SDK_URL=https://github.com/git-for-windows/git-sdk-$BITNESS 
+GIT_SDK_URL=https://github.com/git-for-windows/git-sdk-$SDK_ARCH 
 
 FAKEROOTDIR="$(cd "$(dirname "$0")" && pwd)/root"
-TARGET="$HOME"/git-sdk-installer-"$1"-$BITNESS.7z.exe
+TARGET="$HOME"/git-sdk-installer-"$1"-$SDK_ARCH.7z.exe
 OPTS7="-m0=lzma -mx=9 -md=64M"
 TMPPACK=/tmp.7z
 SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)"
-BIN_DIR=/mingw$BITNESS/bin
+BIN_DIR=/$MSYSTEM_LOWER/bin
 
 echo "Enumerating required files..." >&2
 # First, enumerate the .dll files needed by the .exe files, then, enumerate all
@@ -65,8 +67,8 @@ rm -rf "$FAKEROOTDIR" &&
 mkdir -p "$FAKEROOTDIR/mini$BIN_DIR" ||
 die "Could not create $FAKEROOTDIR$BIN_DIR directory"
 
-sed -e "s|@@ARCH@@|$ARCH|g" \
-	-e "s|@@BITNESS@@|$BITNESS|g" \
+sed -e "s|@@SDK_ARCH@@|$SDK_ARCH|g" \
+	-e "s|@@MSYSTEM_LOWER@@|$MSYSTEM_LOWER|g" \
 	-e "s|@@GIT_SDK_URL@@|$GIT_SDK_URL|g" \
 <"$SCRIPT_PATH"/setup-git-sdk.bat >"$FAKEROOTDIR"/setup-git-sdk.bat ||
 die "Could not generate setup script"
@@ -82,15 +84,15 @@ echo "Creating archive" &&
 (cd "$FAKEROOTDIR" && 7za -x'!var/lib/pacman/*' a $OPTS7 "$TMPPACK" *) &&
 (cat "$SCRIPT_PATH/../7-Zip/7zSD.sfx" &&
  echo ';!@Install@!UTF-8!' &&
- echo 'Title="Git for Windows '$BITNESS'-bit SDK"' &&
- echo 'BeginPrompt="This archive extracts an SDK to build, test and package Git for Windows '$BITNESS'-bit"' &&
+ echo 'Title="Git for Windows '$SDK_TITLE' SDK"' &&
+ echo 'BeginPrompt="This archive extracts an SDK to build, test and package Git for Windows '$SDK_TITLE'"' &&
  echo 'CancelPrompt="Do you want to cancel the Git SDK installation?"' &&
  echo 'ExtractDialogText="Please, wait..."' &&
  echo 'ExtractPathText="Where do you want to install the Git SDK?"' &&
  echo 'ExtractTitle="Extracting..."' &&
  echo 'GUIFlags="8+32+64+256+4096"' &&
  echo 'GUIMode="1"' &&
- echo 'InstallPath="C:\\git-sdk-'$BITNESS'"' &&
+ echo 'InstallPath="C:\\git-sdk-'$SDK_ARCH'"' &&
  echo 'OverwriteMode="2"' &&
  echo 'ExecuteFile="setup-git-sdk.bat"' &&
  echo 'Delete="setup-git-sdk.bat"' &&

--- a/sdk-installer/release.sh
+++ b/sdk-installer/release.sh
@@ -7,10 +7,8 @@ die () {
 	exit 1
 }
 
-test -z "$1" && {
-	echo "Usage: $0 <version>"
-	exit 1
-}
+test "$#" = 1 ||
+die "Usage: $0 <version>"
 
 case "$MSYSTEM" in
 MINGW32)

--- a/sdk-installer/release.sh
+++ b/sdk-installer/release.sh
@@ -2,13 +2,13 @@
 
 # Recreate git-sdk-$VERSION.exe
 
-test -z "$1" && {
-	echo "Usage: $0 <version>"
+die () {
+	echo "$*" >&2
 	exit 1
 }
 
-die () {
-	echo "$*" >&2
+test -z "$1" && {
+	echo "Usage: $0 <version>"
 	exit 1
 }
 

--- a/sdk-installer/setup-git-sdk.bat
+++ b/sdk-installer/setup-git-sdk.bat
@@ -11,7 +11,7 @@
 @IF ERRORLEVEL 1 GOTO DIE
 
 @REM set PATH
-@set PATH=%cwd%\mini\mingw@@BITNESS@@\bin;%PATH%
+@set PATH=%cwd%\mini\@@MSYSTEM_LOWER@@\bin;%PATH%
 
 @ECHO Cloning the Git for Windows SDK...
 @git init
@@ -30,7 +30,7 @@
 @IF ERRORLEVEL 1 GOTO DIE
 
 @REM Avoid overlapping address ranges
-@IF 32 == @@BITNESS@@ @(
+@IF 32 == @@SDK_ARCH@@ @(
 	ECHO Auto-rebasing .dll files
 	CALL autorebase.bat
 )


### PR DESCRIPTION
I'll leave this in draft until the new SDK is available on https://github.com/git-for-windows/git-sdk-arm64, but I just want to confirm that I got this to work with "my" https://github.com/dennisameling/git-sdk-arm64:

Installer:

<img src="https://user-images.githubusercontent.com/17739158/208513420-33891027-2f6d-470c-84cb-bee2eb2c8193.png" width="400">

It's using the native arm64 `git.exe` from the `mini` folder:

<img src="https://user-images.githubusercontent.com/17739158/208513955-574c8a7f-4277-42d9-ad9b-1f1e4a4af777.png" width="400">

<img src="https://user-images.githubusercontent.com/17739158/208513975-e7f5e4c3-c981-4f7e-bdec-c0048de6f278.png" width="400">

And there we are! A native Git for Windows arm64 SDK!

<img src="https://user-images.githubusercontent.com/17739158/208514029-e1a7d9fb-38ed-42f2-88aa-3571d4edcbb0.png" width="400">

Here's the installer artifact that downloads the SDK from https://github.com/dennisameling/git-sdk-arm64: [git-sdk-installer-1.0.9-arm64.7z.zip](https://github.com/git-for-windows/build-extra/files/10262464/git-sdk-installer-1.0.9-arm64.7z.zip)
