### PR TITLE
git-extra: publish both with and without MINGW prefix

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.616.e442fe2d7
+pkgver=1.1.616.3f26b1b0c
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -1,11 +1,15 @@
 # Maintainer: nalla <nalla@hamal.uberspace.de>
 
-pkgname=('git-extra')
+_realname="git-extra"
+pkgbase="mingw-w64-${_realname}"
+pkgname=($_realname
+        "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.614.d551cf0cc
+pkgver=1.1.616.e442fe2d7
 pkgrel=1
 pkgdesc="Git for Windows extra files"
-arch=('i686' 'x86_64')
+arch=('any')
+mingw_arch=('mingw32' 'mingw64' 'clangarm64')
 url="https://github.com/git-for-windows/build-extra"
 license=('GPL')
 groups=('VCS')
@@ -92,14 +96,14 @@ sha256sums=('8ed76d1cb069ac8568f21c431f5e23caebea502d932ab4cdff71396f4f0d5b72'
             '0dd30dc3acd406e70b5ff08fb0bf180ec3782119455989af18c05cf59d09df64')
 
 prepare() {
-  test $startdir/$pkgname.install -nt $startdir/$pkgname.install.in &&
-  test $startdir/$pkgname.install -nt $startdir/gitconfig &&
-  test $startdir/$pkgname.install -nt $startdir/gitattributes ||
+  test $startdir/$_realname.install -nt $startdir/$_realname.install.in &&
+  test $startdir/$_realname.install -nt $startdir/gitconfig &&
+  test $startdir/$_realname.install -nt $startdir/gitattributes ||
   sed -e "/^@@GITCONFIG@@$/r $startdir/gitconfig" \
         -e "/^@@GITCONFIG@@$/d" \
         -e "/^@@GITATTRIBUTES@@$/r $startdir/gitattributes" \
         -e "/^@@GITATTRIBUTES@@$/d" \
-        <$startdir/$pkgname.install.in >$startdir/$pkgname.install
+        <$startdir/$_realname.install.in >$startdir/$_realname.install
 }
 
 build() {
@@ -152,4 +156,34 @@ package() {
   install -m755 git-update $pkgdir${MINGW_PREFIX}/libexec/git-core
   install -m755 update-via-pacman.bat $pkgdir
   install -m755 zzz_rm_stackdumps.sh $pkgdir/usr/share/makepkg/lint_package
+}
+
+# The old package name, git-extra, was causing problems as it's _actually_ a MINGW-package.
+# The old and new package name can't be installed simultaneously, as it installs things like
+# /etc/profile.d/git-sdk.sh which aren't specific to MINGW prefixes like /mingw64 or /mingw32.
+# Therefore, we need to mark it as conflicting.
+package_git-extra() {
+  # As we publish to two separate repositories (git-for-windows and git-for-windows-mingw32), we need
+  # to specifically specify the architecture for both on the legacy package.
+  arch=('i686' 'x86_64')
+  conflicts=('mingw-w64-clang-aarch64-git-extra' 'mingw-w64-x86_64-git-extra' 'mingw-w64-i686-git-extra')
+  package
+}
+
+package_mingw-w64-x86_64-git-extra() {
+  conflicts=('git-extra' 'mingw-w64-clang-aarch64-git-extra' 'mingw-w64-i686-git-extra')
+  provides=('git-extra')
+  package
+}
+
+package_mingw-w64-i686-git-extra() {
+  conflicts=('git-extra' 'mingw-w64-x86_64-git-extra' 'mingw-w64-clang-aarch64-git-extra')
+  provides=('git-extra')
+  package
+}
+
+package_mingw-w64-clang-aarch64-git-extra() {
+  conflicts=('git-extra' 'mingw-w64-x86_64-git-extra' 'mingw-w64-i686-git-extra')
+  provides=('git-extra')
+  package
 }


### PR DESCRIPTION
Following up on [this discussion](https://github.com/git-for-windows/build-extra/pull/452#discussion_r1052009722).

Until now, the `git-extra` package was published under that exact name. However, it's _actually_ a MINGW package which installs things both in e.g. `/mingw64/bin` and `/etc/profile.d`. This is problematic for GfW's upcoming arm64 support, which uses the x64 MSYS shell, so it'll need its own package. At the same time, packages for multiple architectures can't be installed side-by-side like other MINGW-packages, as this one writes to shared folders like `/etc/profile.d` as well. Therefore we mark them as conflicting each other.

With this change, we'll publish the following packages side by side, so the repos will look like this:
- `git-for-windows/git-extra` (old)
- `git-for-windows-mingw32/git-extra` (old)
- `git-for-windows/mingw-w64-x86_64-git-extra` (new)
- `git-for-windows-mingw32/mingw-w64-i686-git-extra` (new)
- `git-for-windows-clangarm64/mingw-w64-aarch64-git-extra` (new)

Publishing side by side allows us to gradually update other parts of GfW to start using the new package names moving forward.

## Test results

After building with `MINGW_ARCH=mingw64 makepkg-mingw`, two files were created:
- `git-extra-1.1.614.d551cf0cc-1-any.pkg.tar.zst` (legacy package: `git-extra`)
- `mingw-w64-x86_64-git-extra-1.1.614.d551cf0cc-1-any.pkg.tar.zst` (new package: `mingw-w64-git-extra`)

Assuming that `git-extra` is already installed (e.g. when working from `git-sdk-64`), let's test these packages.

1. Updating the existing `git-extra` package still works as normal after the changes in this PR:

```
$ pacman -U git-extra-1.1.614.d551cf0cc-1-any.pkg.tar.zst
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) git-extra-1.1.614.d551cf0cc-1

Total Installed Size:  0.47 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] Y
(1/1) checking keys in keyring                                                      [###############################################] 100%
(1/1) checking package integrity                                                    [###############################################] 100%
(1/1) loading package files                                                         [###############################################] 100%
(1/1) checking for file conflicts                                                   [###############################################] 100%
(1/1) checking available disk space                                                 [###############################################] 100%
:: Processing package changes...
(1/1) upgrading git-extra                                                           [###############################################] 100%
```

2. Trying to install `mingw-w64-git-extra` correctly indicates that it conflicts with `git-extra` and Pacman suggests to remove the old package first:

```
$ pacman -U mingw-w64-x86_64-git-extra-1.1.614.d551cf0cc-1-any.pkg.tar.zst
loading packages...
resolving dependencies...
looking for conflicting packages...
:: mingw-w64-x86_64-git-extra and git-extra are in conflict. Remove git-extra? [Y/n] Y

Packages (2) git-extra-1.1.614.d551cf0cc-1 [removal]  mingw-w64-x86_64-git-extra-1.1.614.d551cf0cc-1

Total Installed Size:  0.47 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] Y
(1/1) checking keys in keyring                                                      [###############################################] 100%
(1/1) checking package integrity                                                    [###############################################] 100%
(1/1) loading package files                                                         [###############################################] 100%
(1/1) checking for file conflicts                                                   [###############################################] 100%
(2/2) checking available disk space                                                 [###############################################] 100%
:: Processing package changes...
(1/1) removing git-extra                                                            [###############################################] 100%
(1/1) installing mingw-w64-x86_64-git-extra                                         [###############################################] 100%
Optional dependencies for mingw-w64-x86_64-git-extra
    vim [installed]
    filesystem [installed]
```

3. Let's check whether the old package name, `git-extra`, is indeed provided by the new package:

```
$ pacman -Q git-extra
mingw-w64-x86_64-git-extra 1.1.614.d551cf0cc-1
```

4. Can we actually go back to `git-extra` if we want? Yes, we can:

```
$ pacman -U git-extra-1.1.614.d551cf0cc-1-any.pkg.tar.zst
loading packages...
resolving dependencies...
looking for conflicting packages...
:: git-extra and mingw-w64-x86_64-git-extra are in conflict. Remove mingw-w64-x86_64-git-extra? [Y/n] Y

Packages (2) mingw-w64-x86_64-git-extra-1.1.614.d551cf0cc-1 [removal]  git-extra-1.1.614.d551cf0cc-1

Total Installed Size:  0.47 MiB
Net Upgrade Size:      0.00 MiB

:: Proceed with installation? [Y/n] Y
(1/1) checking keys in keyring                                                      [###############################################] 100%
(1/1) checking package integrity                                                    [###############################################] 100%
(1/1) loading package files                                                         [###############################################] 100%
(1/1) checking for file conflicts                                                   [###############################################] 100%
(2/2) checking available disk space                                                 [###############################################] 100%
:: Processing package changes...
(1/1) removing mingw-w64-x86_64-git-extra                                           [###############################################] 100%
(1/1) installing git-extra                                                          [###############################################] 100%
Optional dependencies for git-extra
    vim [installed]
    filesystem [installed]
```

5. Installing for another architecture also correctly triggers the `conflict` logic:

```
$ pacman -U mingw-w64-clang-aarch64-git-extra-1.1.616.e442fe2d7-1-any.pkg.tar.zst
loading packages...
resolving dependencies...
looking for conflicting packages...
:: mingw-w64-clang-aarch64-git-extra and mingw-w64-x86_64-git-extra are in conflict (git-extra). Remove mingw-w64-x86_64-git-extra? [Y/n] Y

Packages (2) mingw-w64-x86_64-git-extra-1.1.616.e442fe2d7-1 [removal]  mingw-w64-clang-aarch64-git-extra-1.1.616.e442fe2d7-1

Total Installed Size:   0.38 MiB
Net Upgrade Size:      -0.09 MiB

:: Proceed with installation? [Y/n] Y
(1/1) checking keys in keyring                                                                                       [#####################################################################] 100%
(1/1) checking package integrity                                                                                     [#####################################################################] 100%
(1/1) loading package files                                                                                          [#####################################################################] 100%
(1/1) checking for file conflicts                                                                                    [#####################################################################] 100%
(2/2) checking available disk space                                                                                  [#####################################################################] 100%
:: Processing package changes...
(1/1) removing mingw-w64-x86_64-git-extra                                                                            [#####################################################################] 100%
(1/1) installing mingw-w64-clang-aarch64-git-extra                                                                   [#####################################################################] 100%
Optional dependencies for mingw-w64-clang-aarch64-git-extra
    vim [installed]
    filesystem [installed]
```

## Suggested strategy

1. Start publishing the old and new package versions side by side (this PR)
2. Start updating all parts of GfW that install `git-extra` instead of `mingw-w64-git-extra`
7. Stop publishing (and remove?) the old `git-extra` package