### PR TITLE
Prepare for uploading Pacman packages targeting Windows/ARM64

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -436,14 +436,6 @@ push () {
 			for arch in $architectures sources
 			do
 				case "$name,$arch" in
-				mingw-w64-i686,x86_64|mingw-w64-x86_64,i686)
-					# wrong architecture
-					continue
-					;;
-				mingw-w64-i686-*,sources)
-					# sources are "included" in x86_64
-					continue
-					;;
 				mingw-w64-x86_64-*,sources)
 					# sources are "included" in x86_64
 					filename=mingw-w64${name#*_64}.src.tar.gz
@@ -451,8 +443,12 @@ push () {
 				*,sources)
 					filename=$name.src.tar.gz
 					;;
-				mingw-w64-*)
+				mingw-w64-$arch,$arch)
 					filename=$name-any.pkg.tar.xz
+					;;
+				mingw-w64-*)
+					# wrong architecture
+					continue
 					;;
 				*)
 					filename=$name-$arch.pkg.tar.xz
@@ -741,14 +737,6 @@ push_missing_signatures () {
 		for arch in $architectures sources
 		do
 			case "$name,$arch" in
-			mingw-w64-i686-*,x86_64|mingw-w64-x86_64-*,i686)
-				# wrong architecture
-				continue
-				;;
-			mingw-w64-i686-*,sources)
-				# sources are "included" in x86_64
-				continue
-				;;
 			libcurl*,sources|mingw-w64-*-git-doc*,sources|msys2-runtime-devel*,sources)
 				# extra package's source included elsewhere
 				continue
@@ -760,8 +748,12 @@ push_missing_signatures () {
 			*,sources)
 				filename=$name.src.tar.gz
 				;;
-			mingw-w64-*)
+			mingw-w64-$arch,$arch)
 				filename=$name-any.pkg.tar.xz
+				;;
+			mingw-w64-*)
+				# wrong architecture
+				continue
 				;;
 			*)
 				filename=$name-$arch.pkg.tar.xz
@@ -810,11 +802,7 @@ push_missing_signatures () {
 
 		for name in $list
 		do
-			case "$name,$arch" in
-			mingw-w64-i686*,x86_64|mingw-w64-x86_64*,i686)
-				# wrong architecture; skip
-				continue
-				;;
+			case "$name" in
 			mingw-w64-$arch-*)
 				filename=$name-any.pkg.tar.xz
 				s=$(arch_to_mingw $arch)
@@ -827,6 +815,10 @@ push_missing_signatures () {
 					repo_add $sign_option $db_name $filename ||
 					die "Could not add $name in $arch/mingw"
 				}
+				;;
+			mingw-w64-*)
+				# wrong architecture; skip
+				continue
 				;;
 			*)
 				filename=$name-$arch.pkg.tar.xz


### PR DESCRIPTION
This should be enough to get that part of the deployment working. The idea is that we will have two new package indices, [a full one](https://wingit.blob.core.windows.net/aarch64/git-for-windows.db) and [a MINGW-only one](https://wingit.blob.core.windows.net/aarch64/git-for-windows-aarch64.db). Until the time when Cygwin starts supporting Windows/ARM64, these will contain the same set of packages.

The idea is that we can then set up `/etc/pacman.conf` in `git-sdk-arm64` to contain these lines:

```ini
[git-for-windows]
# Once Cygwin starts supporting Windows/ARM64, we can switch to aarch64
Server = https://wingit.blob.core.windows.net/x86-64

[git-for-windows-aarch64]
Server = https://wingit.blob.core.windows.net/aarch64
```
