### PR TITLE
signtool.sh: add support for arm64 osslsigncode

### DIFF
--- a/signtool.sh
+++ b/signtool.sh
@@ -7,7 +7,10 @@
 # the corresponding password in ~/.sig/codesign.pass.
 
 type osslsigncode >/dev/null 2>&1 || {
-	if test -x /mingw64/bin/osslsigncode.exe
+	if test -x /clangarm64/bin/osslsigncode.exe
+	then
+		PATH=/clangarm64/bin:$PATH
+	elif test -x /mingw64/bin/osslsigncode.exe
 	then
 		PATH=/mingw64/bin:$PATH
 	elif test -x /mingw32/bin/osslsigncode.exe


### PR DESCRIPTION
I ran into an issue with my pipeline where [it was hanging](https://github.com/dennisameling/git/actions/runs/3758239394/jobs/6387153640) on the `git signtool` command. After some checks I found that the `signtool.sh` file didn't have logic yet for `clangarm64`, which is most likely the culprit here.

Now that [upstream MSYS2 has support for osslsigncode.exe](https://github.com/msys2/MINGW-packages/pull/14671) on `clangarm64` , let's leverage it here as the git-sdk-arm64 doesn't have any `mingw64` or `mingw32` packages anymore.