### PR TITLE
Start using new git-extra prefix (follow-up)

### DIFF
--- a/get-sources.sh
+++ b/get-sources.sh
@@ -211,7 +211,7 @@ do
 	then
 
 		case "$name" in
-		git-extra|mingw-w64-x86_64-git|mingw-w64-i686-git|msys2-runtime|mingw-w64-x86_64-git-credential-manager|mingw-w64-i686-git-credential-manager|mingw-w64-x86_64-git-credential-manager-core|mingw-w64-i686-git-credential-manager-core|mingw-w64-i686-git-lfs|mingw-w64-x86_64-git-lfs|curl|mingw-w64-i686-curl|mingw-w64-x86_64-curl|mingw-w64-i686-wintoast|mingw-w64-x86_64-wintoast|bash|heimdal|perl|openssh)
+		git-extra|mingw-w64-x86_64-git-extra|mingw-w64-i686-git-extra|mingw-w64-x86_64-git|mingw-w64-i686-git|msys2-runtime|mingw-w64-x86_64-git-credential-manager|mingw-w64-i686-git-credential-manager|mingw-w64-x86_64-git-credential-manager-core|mingw-w64-i686-git-credential-manager-core|mingw-w64-i686-git-lfs|mingw-w64-x86_64-git-lfs|curl|mingw-w64-i686-curl|mingw-w64-x86_64-curl|mingw-w64-i686-wintoast|mingw-w64-x86_64-wintoast|bash|heimdal|perl|openssh)
 			url="$azure_blobs_source_url/$filename"
 			sf1_url=
 			sf2_url=

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -162,7 +162,7 @@ test -z "$required" || {
 }
 
 packages="mingw-w64-$PACMAN_ARCH-git mingw-w64-$PACMAN_ARCH-git-credential-manager
-git-extra openssh $UTIL_PACKAGES"
+mingw-w64-$PACMAN_ARCH-git-extra openssh $UTIL_PACKAGES"
 if test -z "$MINIMAL_GIT"
 then
 	packages="$packages mingw-w64-$PACMAN_ARCH-git-doc-html ncurses mintty vim nano


### PR DESCRIPTION
~⚠️ This needs #457 to be merged first~ ✅ 
~⚠️ This needs #461 to be merged first~ ✅ 

I used the list of files that need updating from [this comment](https://github.com/git-for-windows/git-for-windows-automation/pull/5#issuecomment-1362580886) (thanks @dscho!)

Let's leave the rename of the `git-extra` folder to `mingw-w64-git-extra` for a follow-up PR.

Important note regarding Wiki updates: the updates to the wiki currently live on a branch that are not accessible through GitHub's UI. To see them, do the following:

```
git clone https://github.com/git-for-windows/git.wiki.git
git checkout update-git-extra-docs
```

As we can't create a PR for the changes from that branch, we'll have to commit straight to the `main` branch if all looks good. CC @dscho 