### PR TITLE
Add a script to downgrade Pacman packages

### DIFF
--- a/downgrade-pacman-package.sh
+++ b/downgrade-pacman-package.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+die () {
+    echo "$*" >&2
+    exit 1
+}
+
+test $# -gt 1 ||
+die "Usage: $0 <test-scriptlet> <package>..."
+
+test="$1"; shift
+
+git -C / update-index --ignore-submodules --refresh &&
+git -C / diff-files --ignore-submodules &&
+git -C / diff-index --cached --ignore-submodules HEAD ||
+die "Uncommitted changes"
+
+msg=
+for package
+do
+	dir="$(ls -d /var/lib/pacman/local/$package-[0-9]*)" ||
+	die "Package '$package' not installed?"
+
+	current_version=${dir#*/$package-}
+
+	sdk_commit="$(git -C / log --format=%H -1 --diff-filter=A $dir/mtree)" &&
+	test -n "$sdk_commit" ||
+	die "Could not identify commit that upgraded '$package'"
+
+	previous_version="$(git -C / diff --name-only --diff-filter=D $sdk_commit^! |
+		sed -n "s|^var/lib/pacman/local/$package-\\([0-9].*\\)/mtree$|\\1|p")" &&
+	test -n "$previous_version" ||
+	die "Could not determine previous version of '$package'"
+
+	echo "Downgrading '$package' from $current_version to $previous_version"
+	test ! -f "$dir/install" || (
+		. "$dir/install"
+		test function = "$(type -t pre_upgrade)" || exit 0
+		echo "Running pre_upgrade in '$package'" >&2
+		pre_upgrade $current_version $previous_version
+	) ||
+	die "pre_upgrade failed with code $?"
+
+	echo "Removing files of $package-$current_version" >&2
+	sed -n '/^%FILES%$/,/^$/{/^%FILES%$/d;/^$/d;/\/$/d;p}' <"$dir/files" |
+	xargs -rd '\n' git -C / rm &&
+	git -C / rm -r "$dir" ||
+	die "Could not remove files of '$package'"
+
+	echo "Adding files of $package-$previous_version" >&2
+	dir=/var/lib/pacman/local/$package-$previous_version &&
+	git -C / checkout $sdk_commit^ $dir/ &&
+	sed -n '/^%FILES%$/,/^$/{/^%FILES%$/d;/^$/d;/\/$/d;p}' <"$dir/files" |
+	xargs -rd '\n' git -C / checkout $sdk_commit^ -- ||
+	die "Could not add files of '$package'"
+	test ! -f "$dir/install" || (
+		. "$dir/install"
+		test function = "$(type -t pre_upgrade)" || exit 0
+		echo "Running post_upgrade in '$package'" >&2
+		post_upgrade $current_version $previous_version
+	) ||
+	die "post_upgrade failed with code $?"
+
+	sed -i \
+		-e 's/^# *\(IgnorePkg *=\)/\1/' \
+		-e "/^IgnorePkg *=/{/\(=\| \)$package\( \|$\)/b;s/$/ $package/}" \
+		/etc/pacman.conf ||
+	die "Could not edit /etc/pacman.conf"
+
+	msg="${msg+$msg
+}$package $current_version -> $previous_version"
+done
+
+eval "$test" ||
+die "test failed with code $?"
+
+git -C / add etc/pacman.conf &&
+git -C / commit -m "Downgrade $# packages" -m "$msg"


### PR DESCRIPTION
We just downgraded a couple of packages to accommodate for Git for Windows sticking to OpenSSL v1.1.x while MSYS2 moved on to OpenSSL v3.x

Unfortunately, an upgrade of the `pacman` package undid this, so we had to redo it.

Here is a script that was used to redo it. It takes as first parameter a shell scriptlet that tests whether the issue that needed to be fixed was actually fixed, followed by a list of packages to downgrade to the previous version. This script was used to auto-generate https://github.com/git-for-windows/git-sdk-64/commit/4c5ca7dbd83, by calling

	/usr/src/build-extra/downgrade-pacman-package.sh \
		 'bsdtar -h || test $? != 127' \
		 bsdcpio bsdtar libarchive libserf libssh2 rsync

This closes https://github.com/git-for-windows/git/issues/4197.