### PR TITLE
make-file-list: `file.exe` now depends on LZMA

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -220,8 +220,8 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/msys-\(db\|curl\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
 	-e '^/usr/bin/msys-\('$(if test i686 = "$ARCH"
 	    then
-		echo 'uuid\|'
-	    fi)'lzma\|fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
+		echo 'uuid\|lzma\|'
+	    fi)'fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(hdb\|history8\|kadm5\|kdc\|otp\|sl\).*\.dll$' \
 	-e '^/usr/bin/msys-\(atomic\|blkid\|charset\|gthread\|metalink\|nghttp2\|ssh2\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \


### PR DESCRIPTION
This fixes the problem pointed out here: https://github.com/git-for-windows/git-sdk-64/actions/runs/3889278102/jobs/6637401828