### PR TITLE
make-file-list: include ms-terminal terminfo

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -330,7 +330,7 @@ else
 		-e "^\\($(echo $EXTRA_FILE_EXCLUDES |
 			sed 's/ /\\|/g')\\)\$"
 fi |
-LC_CTYPE=C.UTF-8 grep --perl-regexp -v -e '^/usr/(lib|share)/terminfo/(?!.*/(cygwin|dumb|screen.*|xterm.*)$)' |
+LC_CTYPE=C.UTF-8 grep --perl-regexp -v -e '^/usr/(lib|share)/terminfo/(?!.*/(cygwin|dumb|ms-terminal|screen.*|xterm.*)$)' |
 sed 's/^\///' | sort | uniq
 
 test -z "$PACKAGE_VERSIONS_FILE" || {


### PR DESCRIPTION
ncurses has provided ms-terminal terminfo since 2019-06-30, according to https://invisible-island.net/ncurses/NEWS.html#t20190630

Signed-off-by: Lauri Tirkkonen <lauri@hacktheplanet.fi>