### PR TITLE
installer: accommodate for the new location of `ca-bundle.crt`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,6 +179,27 @@ jobs:
         with:
           name: installer-${{ matrix.bitness }}
           path: installer-${{ matrix.bitness }}
+      - name: run the installer
+        if: matrix.artifact == 'build-installers'
+        shell: pwsh
+        run: |
+          $exePath = Get-ChildItem -Path installer-${{ matrix.bitness }}/*.exe | %{$_.FullName}
+          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /LOG=installer.log"
+          "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+      - name: validate
+        if: matrix.artifact == 'build-installers'
+        shell: bash
+        run: |
+          set -x &&
+          cygpath -aw / &&
+          git.exe version --build-options >version &&
+          cat version &&
+          grep "$(sed -e 's|^v||' -e 's|-|.|g' <bundle-artifacts/next_version)" version &&
+          checklist=installer/run-checklist.sh &&
+          # cannot test SSH keys in read-only mode, skip test for now
+          sed -i 's|git@ssh.dev.azure.com:v3/git-for-windows/git/git|https://github.com/git/git|' $checklist &&
+          sh -x $checklist
   check-for-missing-dlls:
     needs: determine-packages
     if: needs.determine-packages.outputs.test-sdk-artifacts == 'true' || needs.determine-packages.outputs.check-for-missing-dlls == 'true'

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -3075,7 +3075,9 @@ begin
         GitSystemConfigSet('http.sslBackend','openssl');
 
     if not RdbCurlVariant[GC_WinSSL].Checked then begin
-        Cmd:=AppDir+'/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt';
+        Cmd:=AppDir+'/{#MINGW_BITNESS}/etc/ssl/certs/ca-bundle.crt';
+        if not FileExists(Cmd) then
+            Cmd:=AppDir+'/{#MINGW_BITNESS}/ssl/certs/ca-bundle.crt';
         StringChangeEx(Cmd,'\','/',True);
         GitSystemConfigSet('http.sslCAInfo',Cmd);
     end else


### PR DESCRIPTION
This is a follow-up for https://github.com/git-for-windows/git/issues/4230