### PR TITLE
mingit(BusyBox): do exclude Bash

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -33,7 +33,7 @@ EXTRA_FILE_EXCLUDES=
 UTIL_PACKAGES="sed awk grep findutils coreutils"
 if test -n "$MINIMAL_GIT_WITH_BUSYBOX"
 then
-	PACKAGE_EXCLUDES="$PACKAGE_EXCLUDES bash coreutils mingw-w64-busybox
+	PACKAGE_EXCLUDES="$PACKAGE_EXCLUDES bash sh coreutils mingw-w64-busybox
 		libiconv libintl libreadline ncurses openssl
 		mingw-w64-libmetalink mingw-w64-spdylay diffutils"
 


### PR DESCRIPTION
The entire point of the BusyBox variant of MinGit is to avoid having to use MSYS2 resources unnecessarily.

But `sh.exe` slipped through the net, by virtue of being listed in the `sh` dependency (provided by `bash`) that comes in via openssh -> heimdal -> heimdal-libs -> libedit -> sh.

This was pointed out in
https://github.com/git-for-windows/git/issues/3285#issuecomment-1396543785

Let's exclude it specifically.