### PR TITLE
please.sh: add missing makepkg deps

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3405,6 +3405,8 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 		# Pacman
 		/usr/bin/pacman.exe
 		/usr/bin/pactree.exe
+		/usr/bin/makepkg
+		/usr/bin/makepkg-mingw
 		/usr/bin/msys-gpg*.dll
 		/usr/bin/gpg.exe
 		/usr/bin/gpgconf.exe
@@ -3416,6 +3418,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--bitnes
 		/etc/pacman*
 		/usr/ssl/certs/ca-bundle.crt
 		/usr/share/pacman/
+		/usr/share/makepkg/
 		/var/lib/pacman/local/
 
 		# Some other utilities required by `make-file-list.sh`


### PR DESCRIPTION
Running `/please.sh build-mingw-w64-git --only-i686` [failed](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/4036208374/jobs/6938659778) with the following error:
```
+ makepkg-mingw -s --noconfirm -p PKGBUILD.v2.39.1.windows.1-529-g10a93f8bfd
/usr/src/build-extra/please.sh: line 3684: makepkg-mingw: command not found
+ die 'Could not build mingw-w64-git\n'
+ printf 'Could not build mingw-w64-git\n'
Could not build mingw-w64-git
```

This is because the `/usr/bin/makepkg-mingw` file somehow is included in the x86_64 build-installers artifact only. This commit explicitly adds those files to `create_sdk_artifact`.

Some questions I still have:
- It feels rather inefficient to me to include those files manually. Why not include the entire `pacman` package with something like `pacman -Ql pacman` (somehow excluding the `/usr/`, `/usr/bin/`, etc. from that output)?
- This doesn't solve the problem completely, as the build still fails with the following error:

```
$ /usr/src/build-extra/please.sh build-mingw-w64-git --only-i686 --build-src-pkg -o artifacts HEAD
Everything up-to-date
sed: can't read /etc/xml/catalog: No such file or directory
=> WARNING: You don't have the required toolchain installed for mingw32.
=> WARNING: To install it run: 'pacman -S mingw-w64-i686-toolchain'
==> ERROR: /etc/makepkg_mingw.conf not found.
    Aborting...
Could not build mingw-w64-git
```

Once we have figured this out, I'll create a separate PR to refactor `create_sdk_artifact()` from `bitness` to architectures instead (`i686`, `x86_64`, `aarch64`).