### PR TITLE
git-prompt.sh: remove annoying space when MSYSTEM not set

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -15,6 +15,10 @@ else
 	PS1="$PS1"'\u@\h '             # user@host<space>
 	PS1="$PS1"'\[\033[35m\]'       # change to purple
 	PS1="$PS1"'$MSYSTEM '          # show MSYSTEM
+	if [ ! -z "$MSYSTEM" ]
+	then
+		PS1="$PS1"'$MSYSTEM '  # show MSYSTEM
+	fi
 	PS1="$PS1"'\[\033[33m\]'       # change to brownish yellow
 	PS1="$PS1"'\w'                 # current working directory
 	if test -z "$WINELOADERNOEXEC"

--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -13,11 +13,10 @@ else
 	PS1="$PS1"'\n'                 # new line
 	PS1="$PS1"'\[\033[32m\]'       # change to green
 	PS1="$PS1"'\u@\h '             # user@host<space>
-	PS1="$PS1"'\[\033[35m\]'       # change to purple
-	PS1="$PS1"'$MSYSTEM '          # show MSYSTEM
 	if [ ! -z "$MSYSTEM" ]
 	then
-		PS1="$PS1"'$MSYSTEM '  # show MSYSTEM
+		PS1="$PS1"'\[\033[35m\]'        # change to purple
+		PS1="$PS1"'$MSYSTEM '           # show MSYSTEM
 	fi
 	PS1="$PS1"'\[\033[33m\]'       # change to brownish yellow
 	PS1="$PS1"'\w'                 # current working directory


### PR DESCRIPTION
Signed-off-by: David Refoua <David@Refoua.me>

This commit removes the annoying double space in the first line of PS1 when `MSYSTEM` is not set.