### PR TITLE
gnupg-with-gpgkey: allow running on Ubuntu

### DIFF
--- a/gnupg-with-gpgkey.sh
+++ b/gnupg-with-gpgkey.sh
@@ -9,8 +9,19 @@
 # using secret variables, of course).
 
 case "$1" in
+--status-fd=*)
+	status_fd="$1"
+	arg1="$2"
+	;;
+*)
+	status_fd=
+	arg1="$1"
+	;;
+esac
+
+case "$arg1" in
 -bsau)
-	eval gpg --batch --yes --no-tty --pinentry-mode loopback -bsau $GPGKEY
+	eval gpg --batch --yes --no-tty --pinentry-mode loopback $status_fd -bsau $GPGKEY
 	;;
 --detach-sign)
 	case "$*" in


### PR DESCRIPTION
In Git for Windows, we explicitly forbit Git from passing the `--status-fd=2` option to GPG. But on Ubuntu, that option is passed, and it is rather crucial because Git reads the status from `stderr` and is a bit miffed if it does not get any status update there. The symptom is:

```
error: gpg failed to sign the data
error: unable to sign the tag
```

Let's prepare the script to allow for that option to be passed (and also allow for that option _not_ to be passed).

This should fix the problem reported [here](https://github.com/git-for-windows/git-for-windows-automation/pull/22#discussion_r1097837166).