### PR TITLE
installer: drop support for Windows 7 and 8.0

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -95,6 +95,7 @@ WizardImageBackColor=clWhite
 WizardImageStretch=no
 WizardImageFile={#SourcePath}\git.bmp
 WizardSmallImageFile={#SourcePath}\gitsmall.bmp
+MinVersion=6.3
 
 [Types]
 ; Define a custom type to avoid getting the three default types.


### PR DESCRIPTION
[As announced in July 2022](https://github.com/git-for-windows/build-extra/blob/main/ReleaseNotes.md#changes-since-git-for-windows-v2371-july-12th-2022), Git for Windows is dropping support for these older Windows versions, [following MSYS2's lead](https://github.com/msys2/msys2.github.io/blob/source/web/news.md#2023-01-15---dropping-support-for-windows-7-and-80). Let's make sure that the installer actively blocks the installation process on these versions. The minimal Windows version is now 8.1 (6.3).

Looking ahead: if the minimum version reaches `10.0`, GfW could choose to switch to `CLANG64` instead of the current `MINGW64`, [which is using the more modern `ucrt` C library](https://www.msys2.org/docs/environments/). Our recent work on `CLANGARM64` support paves the way for this potential future switch ✨ 