### PR TITLE
Really only add the aarch64 Pacman repository for git-sdk-arm64

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.628.f599c8ce7
+pkgver=1.1.630.257a670d3
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -120,8 +120,8 @@ GITATTRIBUTES
 	grep -q "$otherpacman" etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
 
-	test ! -d /clangarm64 ||
-	grep -q "git-for-windows-aarch64" etc/pacman.conf ||
+	test -z "$(find /clangarm64 -type f -print -quit) || # if /clangarm64 exists and contains at least one file
+	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
 	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
 
 	! grep -q 'https://dl.bintray.com/\$repo/pacman/\$arch' etc/pacman.conf ||

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -86,8 +86,8 @@ GITATTRIBUTES
 	grep -q "$otherpacman" etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
 
-	test ! -d /clangarm64 ||
-	grep -q "git-for-windows-aarch64" etc/pacman.conf ||
+	test -z "$(find /clangarm64 -type f -print -quit) || # if /clangarm64 exists and contains at least one file
+	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
 	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
 
 	! grep -q 'https://dl.bintray.com/\$repo/pacman/\$arch' etc/pacman.conf ||


### PR DESCRIPTION
In https://github.com/git-for-windows/git-sdk-64/commit/40af5e29d1efdfb384e25b21891edc64a254099f, the `filesystem` package got updated, which contains the `/clangarm64` directory (which contains quite a few subdirectories, but no files).

This fooled the post-install script of `git-extra` into believing that git-sdk-64 actually targets Windows/ARM64 and hence it added Git for Windows' aarch64 Pacman repository.

I [manually reverted](https://github.com/git-for-windows/git-sdk-64/commit/cce08432ac15f6d68b9b5a2b4a5a7ee4e3823084) that to _not_ register the aarch64 Pacman repository.

However, the next update of the `filesystem` would trigger the same issue.

Let's make the post-install script of `git-extra` smarter so that it does not get fooled anymore.