### PR TITLE
installer: warn about 32-bit deprecation

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -44,6 +44,8 @@ This package contains software from a number of other projects including Bash, z
 
 As announced previously, Git for Windows will drop support for Windows 7 and for Windows 8 in one of the next versions, following [Cygwin's and MSYS2's lead](https://www.msys2.org/docs/windows_support/) (Git for Windows relies on MSYS2 for components such as Bash and Perl).
 
+Also following the footsteps of the MSYS2 and Cygwin projects on which Git for Windows depends, the 32-bit variant of Git for Windows [is nearing its end of support](https://gitforwindows.org/32-bit.html).
+
 ### New Features
 
 * In the olden Git days, there were "dashed" Git commands (e.g. `git-commit` instead of `git commit`). These haven't been supported for interactive use in a really, really long time. But they still worked in Git aliases and hooks ("scripts"). Since Git v1.5.4 (released on February 2nd, 2008), it was discouraged/deprecated to use dashed Git commands even in scripts. As of this version, Git for Windows [no longer supports these dashed commands](https://github.com/git-for-windows/git/pull/4252).

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1091,6 +1091,10 @@ begin
     UpdateInfFilenames;
 #if BITNESS=='32'
     Result:=True;
+    if not IsWin64 then
+        SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support.'+#13+'More information at https://gitforwindows.org/32-bit.html',mbError,MB_OK or MB_DEFBUTTON1,IDOK)
+    else if SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO then
+        Result:=False;
 #else
     if not IsWin64 then begin
         LogError('The 64-bit version of Git requires a 64-bit Windows. Aborting.');


### PR DESCRIPTION
As per https://github.com/git-for-windows/git/issues/4279, Git for Windows is deprecating the 32-bit variant. Let's teach the installer to detect when a user is installing this variant and show an appropriate warning in that case. On a 32-bit Windows, they will see this type of dialog box:

![image](https://user-images.githubusercontent.com/127790/220462849-78832474-0d9b-497d-bbfc-c5f690924e11.png)

On a 64-bit Windows, they will see this dialog box:

![image](https://user-images.githubusercontent.com/127790/220462937-195ea1f1-6a2d-47b7-a4ad-5127bc5ed49d.png)