### PR TITLE
Fix git extra.install quoting

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.632.0366f1328
+pkgver=1.1.634.5b4d8fffc
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -120,7 +120,7 @@ GITATTRIBUTES
 	grep -q "$otherpacman" etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
 
-	test -z "$(find /clangarm64 -type f -print -quit) || # if /clangarm64 exists and contains at least one file
+	test -z "$(find /clangarm64 -type f -print -quit)" || # if /clangarm64 exists and contains at least one file
 	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
 	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
 

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -86,7 +86,7 @@ GITATTRIBUTES
 	grep -q "$otherpacman" etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
 
-	test -z "$(find /clangarm64 -type f -print -quit) || # if /clangarm64 exists and contains at least one file
+	test -z "$(find /clangarm64 -type f -print -quit)" || # if /clangarm64 exists and contains at least one file
 	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
 	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
 


### PR DESCRIPTION
This faulty quoting somehow slipped in and for some reason only showed up yesterday in [the automated builds](https://github.com/git-for-windows/git-sdk-64/actions/runs/4268074874/jobs/7430553454#step:6:1034):

> ```
> /var/lib/pacman/local/mingw-w64-x86_64-git-extra-1.1.632.0366f1328-1/install: line 292: unexpected EOF while looking for matching ``'
```