### PR TITLE
_Do_ use add-release-note.js

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -2588,9 +2588,6 @@ mention () { # [--may-be-already-there] <what, e.g. bug-fix, new-feature> <relea
 
 	quoted="* $(echo "$*" | sed "s/[\\\/\"'&]/\\\\&/g")"
 
-	if test ! -d "$sdk32$pkgpath"; then
-		(cd "$sdk64$pkgpath" && require_clean_worktree)
-	fi ||
 	up_to_date /usr/src/build-extra ||
 	die "build-extra is not up-to-date\n"
 
@@ -2650,11 +2647,6 @@ mention () { # [--may-be-already-there] <what, e.g. bug-fix, new-feature> <relea
 	 git commit -s -m "Mention $what_singular in release notes" \
 		-m "$(echo "$*" | fmt -72)" ReleaseNotes.md) ||
 	die "Could not commit release note edits\n"
-
-	test ! -d "$sdk32"/usr/src/build-extra ||
-	(cd "$sdk32"/usr/src/build-extra &&
-	 git pull --ff-only "$sdk64"/usr/src/build-extra main) ||
-	die "Could not synchronize release note edits to 32-bit SDK\n"
 }
 
 finalize () { # [--delete-existing-tag] <what, e.g. release-notes>


### PR DESCRIPTION
This PR is designed to fix the unfortunate short release note pointed out in https://github.com/git-for-windows/git/pull/4316#issuecomment-1446624712 (see e.g. https://lore.kernel.org/git/20230227162638.3393-1-johannes.schindelin@gmx.de/T/#u).