### PR TITLE
pacman-helper: add a command to break a lease

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -38,7 +38,7 @@ export CURL_CA_BUNDLE
 
 mode=
 case "$1" in
-fetch|add|remove|push|files|dirs|orphans|push_missing_signatures|file_exists|lock|unlock|quick_add|sanitize_db)
+fetch|add|remove|push|files|dirs|orphans|push_missing_signatures|file_exists|lock|unlock|break_lock|quick_add|sanitize_db)
 	mode="$1"
 	shift
 	;;
@@ -52,7 +52,7 @@ upload)
 *)
 	die "Usage:\n%s\n%s\n%s\n" \
 		" $0 ( fetch | push | ( add | remove ) <package>... )" \
-		" $0 ( lock | unlock <id> )" \
+		" $0 ( lock | unlock <id> | break_lock )" \
 		" $0 ( files | dirs | orphans )"
 	;;
 esac
@@ -773,6 +773,22 @@ unlock () { # <lease-ID>
 
 	"$this_script_dir"/wingit-snapshot-helper.sh wingit x86-64 \
 		"$azure_blobs_token" unlock "$1" git-for-windows.db
+}
+
+break_lock () { #
+	test -z "$PACMANDRYRUN" || {
+		echo "upload: wingit-snapshot-helper.sh wingit x86-64 <token> break-lock git-for-windows.db" >&2
+		return
+	}
+
+	test -n "$azure_blobs_token" || {
+		azure_blobs_token="$(cat "$HOME"/.azure-blobs-token)" &&
+		test -n "$azure_blobs_token" ||
+		die "Could not read token from ~/.azure-blobs-token"
+	}
+
+	"$this_script_dir"/wingit-snapshot-helper.sh wingit x86-64 \
+		"$azure_blobs_token" break-lock git-for-windows.db
 }
 
 file_exists () { # arch filename


### PR DESCRIPTION
When uploading Pacman packages, we have to take care to stop concurrent uploads from interfering with each other. We do that by [acquiring a "lease" to the `git-for-windows.db` file](https://github.com/git-for-windows/build-extra/blob/a5129d3495731b44f8c3023efbbadcd327586fd3/pacman-helper.sh#L621-L623): Once that lease is acquired by one of the uploading workflow runs, it cannot be acquired by another one until the first one is done and [releases that lease](https://github.com/git-for-windows/build-extra/blob/a5129d3495731b44f8c3023efbbadcd327586fd3/pacman-helper.sh#L725-L728).

I noticed today that [the shiny new `pacman-packages` workflow](https://github.com/git-for-windows/git-for-windows-automation/pull/38) had failed to upload the packages. When I edited the definition and then tried to re-run it, the run failed due to some mistake of mine, leaving the lease acquired. So when I edited the definition again and tried to re-re-run it, it could not continue because the lease was already acquired. Similar things happened in the past, and whenever that happens, I go to the Azure Portal and break the lease.

However, today I realized that this is some institutionalized knowledge that is locked in my brain, and prevents the Git for Windows project to become more of a team sport than a project that relies solely on @dscho.

So here is the first step to make the "break the lease" task much more transparent (and implicitly documented), with the eventual goal to wire it through as a new [slash command](https://github.com/git-for-windows/gfw-helper-github-app#slash-commands) in Git for Windows' PRs handled by the GitForWindowsHelper GitHub App, say, `/break pacman-upload-lease` (which would trigger a to-be-implemented GitHub workflow in https://github.com/git-for-windows/git-for-windows-automation/ that mirrors a Check Run back to the PR where it was triggered).