### PR TITLE
README.md: report Issues via our main Git-for-Windows git fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Build environment for Git for Windows
 
-This is Git for Windows SDK, the build environment for [Git for Windows](https://gitforwindows.org/).
+This build-extra repository is a core part of the Git for Windows SDK, the build environment for [Git for Windows](https://gitforwindows.org/). Any issues should be reported using the project's main [Git fork](https://github.com/git-for-windows/git).
 
 The easiest way to install Git for Windows SDK is via the [Git SDK installer](https://github.com/git-for-windows/build-extra/releases/latest). This installer will clone our [repositories](http://github.com/git-for-windows/), including all the necessary components to build Git for Windows, and perform an initial build. It will also install a shortcut to the Git SDK Bash on the desktop.
 


### PR DESCRIPTION
Issue reporting is switched off for the build-extra repository. The Git-for-Windows organisation has many potentially relevant repos for reporting issues. Let's direct queries to the primary repo, rather than say the "SDK" repositories.

While here, clarify that the build-extra repo is a core part of the SDK experience, rather than being the SDK in it's totality.

Fixes: https://github.com/git-for-windows/git/discussions/4355 step 1.

Signed-off-by: Philip Oakley <philipoakley@iee.email>