### PR TITLE
installer: allow silent install of 32-bit installer on ARM64

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1091,7 +1091,7 @@ begin
     UpdateInfFilenames;
 #if BITNESS=='32'
     Result:=True;
-    if not IsWin64 then
+    if not IsX64 then
         SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support.'+#13+'More information at https://gitforwindows.org/32-bit.html',mbError,MB_OK or MB_DEFBUTTON1,IDOK)
     else if SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO then
         Result:=False;


### PR DESCRIPTION
When Installing 32-bit Git for Windows we show a Warning that we're deprecating 32-bit support, but there are two Versions of the 32-bit warning. The Version shown on 32-Bit Windows allows a silent install, while the Version on 64-Bit Windows does not. This is fine on AMD64, but for Windows 10 on ARM64 we don't have a good alternative offer. So show them the same message as we show on i686.