### PR TITLE
Fix the `check-for-missing-dlls` runs

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -114,7 +114,7 @@ echo "$all_files" |
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
-		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\)\.' \
+		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime_x86\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' |
 	tee "$unused_dlls_file" >&2


### PR DESCRIPTION
Both [x86_64](https://github.com/git-for-windows/git-sdk-64/actions/runs/4878656312/jobs/8704497475) and [i686](https://github.com/git-for-windows/git-sdk-32/actions/runs/4878741237/jobs/8704659507) jobs now complain about the new Avalonia UI stuff in Git Credential Manager. Let's accommodate for that stuff.