### PR TITLE
git-extra: more really only add the aarch64 repository for git-sdk-arm64

### DIFF
--- a/git-extra/git-sdk.sh
+++ b/git-extra/git-sdk.sh
@@ -80,7 +80,7 @@ sdk () {
 			case "$(uname -m)" in
 			i686) shortcut_suffix=" 32-bit";;
 			x86_64)
-				if test -d /clangarm64
+				if test -z "$(find /clangarm64 -type f -print -quit)" || # if /clangarm64 exists and contains at least one file
 				then
 					shortcut_suffix=" arm64"
 				else
@@ -221,7 +221,7 @@ sdk () {
 			MINGW_MOUNT_POINT=/mingw32
 			;;
 		x86_64)
-			if test -d /clangarm64
+			if test -z "$(find /clangarm64 -type f -print -quit)" || # if /clangarm64 exists and contains at least one file
 			then
 				MSYSTEM=CLANGARM64
 				MINGW_MOUNT_POINT=/clangarm64


### PR DESCRIPTION
This follows up on https://github.com/git-for-windows/git/issues/4408#issuecomment-1538451797.

The referenced commit included additional grepping for installing part of the aarch64 repository which I think isn't necessary here, but I could easily be wrong.

I'm about to go off-line for 4 days, and with -rc0 imminent I thought it worthwhile to at least get started, even if I haven't had time to test it.

257a670d (git-extra: really only add the aarch64 repository for git-sdk-arm64, 2023-02-11) missed two additional places that needed the extra checks.

This fixes issue: #4408 `sdk gitk interaction`

Helped-by: Johannes Schindelin <johannes.schindelin@gmx.de>
Signed-off-by: Philip Oakley <philipoakley@iee.email>
