### PR TITLE
Accommodate for the libcurl split

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -114,6 +114,7 @@ echo "$all_files" |
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
+		-e '^mingw../bin/libcurl-openssl-4.dll' \
 		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime_x86\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' |

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2212,7 +2212,7 @@ begin
         'OpenSSL': RdbCurlVariant[GC_OpenSSL].Checked:=True;
         'WinSSL': RdbCurlVariant[GC_WinSSL].Checked:=True;
     else
-        RdbCurlVariant[GC_OpenSSL].Checked:=True;
+        RdbCurlVariant[GC_WinSSL].Checked:=True;
     end;
 
     (*
@@ -3536,9 +3536,9 @@ begin
     RecordChoice(PreviousDataKey,'Tortoise Option',Data2);
 
     // HTTPS implementation (cURL) options.
-    Data:='OpenSSL';
-    if RdbCurlVariant[GC_WinSSL].Checked then begin
-        Data:='WinSSL';
+    Data:='WinSSL';
+    if RdbCurlVariant[GC_OpenSSL].Checked then begin
+        Data:='OpenSSL';
     end;
     RecordChoice(PreviousDataKey,'CURL Option',Data);
 

--- a/installer/run-checklist.sh
+++ b/installer/run-checklist.sh
@@ -4,10 +4,16 @@ set -ex
 
 curl --version | grep IPv6
 
-! x="$(git -c http.sslbackend=schannel2 ls-remote https://github.com/dscho/images 2>&1)" &&
-case "$x" in *openssl*schannel*|*schannel*openssl*) ;; *) exit 1;; esac
+! x="$(git -c http.sslbackend=123 ls-remote https://github.com/dscho/images 2>&1)" &&
+case "$x" in
+*openssl*schannel*|*schannel*openssl*) ;;
+*) type libcurl-openssl-4.dll || exit 1;;
+esac
 
 git -c http.sslbackend=schannel ls-remote https://github.com/dscho/images
-git -c http.sslbackend=openssl ls-remote https://github.com/dscho/images
+git -c http.sslbackend=openssl ls-remote https://github.com/dscho/images ||
+test "git version 2.40.1.windows.1" = "$(git version)"
 
 git ls-remote git@ssh.dev.azure.com:v3/git-for-windows/git/git main
+
+echo "All checks passed!" >&2

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -150,9 +150,13 @@ has_pacman_package () {
 	return 1
 }
 
+has_pacman_package mingw-w64-$PACMAN_ARCH-curl-winssl &&
+LIBCURL_EXTRA=mingw-w64-$PACMAN_ARCH-curl-openssl-alternate ||
+LIBCURL_EXTRA=
+
 # Packages that have been added after Git SDK 1.0.0 was released...
 required=
-for req in mingw-w64-$PACMAN_ARCH-git-credential-manager $SH_FOR_REBASE \
+for req in mingw-w64-$PACMAN_ARCH-git-credential-manager $SH_FOR_REBASE $LIBCURL_EXTRA \
 	$(test -n "$MINIMAL_GIT" || echo \
 		mingw-w64-$PACMAN_ARCH-connect git-flow unzip docx2txt \
 		mingw-w64-$PACMAN_ARCH-antiword mingw-w64-$PACMAN_ARCH-odt2txt \
@@ -172,7 +176,7 @@ test -z "$required" || {
 }
 
 packages="mingw-w64-$PACMAN_ARCH-git mingw-w64-$PACMAN_ARCH-git-credential-manager
-mingw-w64-$PACMAN_ARCH-git-extra openssh $UTIL_PACKAGES"
+mingw-w64-$PACMAN_ARCH-git-extra openssh $UTIL_PACKAGES $LIBCURL_EXTRA"
 if test -z "$MINIMAL_GIT"
 then
 	packages="$packages mingw-w64-$PACMAN_ARCH-git-doc-html ncurses mintty vim nano

--- a/please.sh
+++ b/please.sh
@@ -2833,6 +2833,18 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 		do
 			name=${package%-*}
 			version=$(echo "$versions" | sed -n "s/^$name //p")
+			if test -z "$version"
+			then
+				# Fall back to mingw-w64-curl-winssl if mingw-w64-curl is not installed
+				if test mingw-w64-curl = "$name"
+				then
+					name=mingw-w64-curl-winssl
+					package=$name-pdb
+					version=$(echo "$versions" | sed -n "s/^$name //p")
+				fi
+				test -n "$version" ||
+				die "Package $name not installed?!?"
+			fi
 			case "$package" in
 			mingw-w64-*)
 				tar=mingw-w64-$pacman_arch-${package#mingw-w64-}-$version-any.pkg.tar.xz


### PR DESCRIPTION
The ongoing work to address https://github.com/git-for-windows/git/issues/4350 requires a couple of minor downstream adjustments in `build-extra`. This PR implements those adjustments.