### PR TITLE
check-for-missing-dll: libcurl-4.dll is not a link-time dependency anymore

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -114,7 +114,7 @@ echo "$all_files" |
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
-		-e '^mingw../bin/libcurl-openssl-4.dll' \
+		-e '^mingw../bin/libcurl\(\|-openssl\)-4.dll' \
 		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime_x86\)\.' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' |


### PR DESCRIPTION
It should be shipped with Git for Windows, of course. So let's adjust the `check-for-missing-dlls` script accordingly, just like we have already done for `libcurl-openssl-4.dll`.

This is a follow-up to #502 