### PR TITLE
installer: improve error reporting when `ExecAsOriginalUser` fails

### DIFF
--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -208,10 +208,12 @@ var
 begin
     OutPath:=ExpandConstant('{tmp}\')+LogKey+'.out';
     ErrPath:=ExpandConstant('{tmp}\')+LogKey+'.err';
-    if ExecAsOriginalUser(ExpandConstant('{sys}\cmd.exe'),'/D /C "'+Cmd+' >"'+OutPath+'" 2>"'+ErrPath+'""','',SW_HIDE,ewWaitUntilTerminated,Res) and (Res=0) then
-        Result:=True
-    else begin
-        LogError(ErrorMessage+' (output: '+ReadFileAsString(OutPath)+', errors: '+ReadFileAsString(ErrPath)+').');
+    if not ExecAsOriginalUser(ExpandConstant('{sys}\cmd.exe'),'/D /C "'+Cmd+' >"'+OutPath+'" 2>"'+ErrPath+'""','',SW_HIDE,ewWaitUntilTerminated,Res) then begin
+        LogError(ErrorMessage+' (sys error: '+SysErrorMessage(Res)+').');
         Result:=False;
-    end;
+    end else if (Res<>0) then begin
+        LogError(ErrorMessage+' (output: '+ReadFileAsString(OutPath)+', errors: '+ReadFileAsString(ErrPath)+', exit code: '+IntToStr(Res)+').');
+        Result:=False;
+    end else
+        Result:=True;
 end;


### PR DESCRIPTION
When the call to `ExecAsOriginalUser` fails already, there is no `stdout` nor `stderr` to work with, but there is an error message that we can show to the user, but we haven't. Let's change that.

This should help diagnosing those vexing problems where the installer fails while reconfiguring existing Scalar enlistments.

Sadly, it is too late for v2.41.0 now, but it may help in the future nevertheless.