### PR TITLE
Parse Windows' version correctly in post-install script

### DIFF
--- a/post-install.bat
+++ b/post-install.bat
@@ -11,7 +11,11 @@
 @REM <percent>~fI Expands <percent>I to a fully qualified path name.
 @FOR /F "delims=" %%D IN ("%~dp0") DO @CD %%~fD
 
-@FOR /F "tokens=4 delims=.[XP " %%i IN ('ver') DO @SET ver=%%i
+@SET /A "version=0" & FOR /F "tokens=2 delims=[]" %%i IN ('"VER"') DO @(
+	@FOR /F "tokens=2 delims=. " %%v IN ("%%~i") DO @(
+		@SET /A "version=%%~v + 0"
+	)
+)
 
 @REM If this is a 32-bit Git for Windows, adjust the DLL address ranges.
 @REM We cannot use %PROCESSOR_ARCHITECTURE% for this test because it is
@@ -19,7 +23,7 @@
 @IF EXIST mingw32\bin\git.exe @(
 	@REM We need to rebase just to make sure that it still works even with
 	@REM 32-bit Windows 10
-	@IF 10 LEQ %ver% @(
+	@IF %version% GEQ 10 @(
 		@REM We copy `rebase.exe` because it links to `msys-2.0.dll`
 		@REM (and @REM thus prevents modifying it). It is okay to
 		@REM execute `rebase.exe`, though, because the DLL base address
@@ -41,6 +45,9 @@
 @echo "running post-install"
 @REM Run the post-install scripts
 @usr\bin\bash.exe --norc -c "export PATH=/usr/bin:$PATH; export SYSCONFDIR=/etc; for p in $(export LC_COLLATE=C; echo /etc/post-install/*.post); do test -e \"$p\" && . \"$p\"; done"
+
+@REM Unset environment variables set by this script
+@SET "version="
 
 @REM Remove this script
 @DEL post-install.bat


### PR DESCRIPTION
The following snippet in `post-install.bat` attempts to parse Windows' major version number from `ver` builtin command output:

```batchfile
@FOR /F "tokens=4 delims=.[XP " %%i IN ('ver') DO @SET ver=%%i
@IF 10 LEQ %ver% @...
```

However, that code has numerous problems:

  - `ver` listing varies between major Windows releases (though Git for Windows' support for these has most likely phased out already) and may not necessarily yield the same amount of tokens, thus it's better to perform a two-step tokenization - string, *then* version
  - while the output of `ver` hasn't been found to contain 'poisonous' Batch characters (e.g. <>|&), it's preferred to wrap it in double quotes to prevent the contents 'escaping' into another command and use `~` during assignment should it contain double quotes itself
  - the code won't run if `ver` encounters an error, yielding an empty variable **or** inheriting a value from the environment the script happened to be running in, introducing potential security issues (PR note: especially when a buggy AutoRun command is executed in that subshell before)
  - numeric comparison will fail should `ver` contain an empty string, thus the variable needs to be pre-initialized with a numeric value
  - a number as the left operand obscures error messages from `if`

This can result in the following, rather cryptic error:

```batchfile
Line 3444: Unable to run post-install scripts:

C:\Program Files\Git>   @IF 10 LEQ  @(
```

Echoed due to `%ver%` being empty because of the problems listed above.

Fixes git-for-windows/git#1585 and git-for-windows/git#4019; maybe more.

Ran into this while looking for clues related to git-for-windows/git#4466...