### PR TITLE
Adjust `check-for-missing-dlls` after the OpenSSL v3.* upgrade

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -116,6 +116,7 @@ echo "$all_files" |
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
 		-e '^mingw../bin/libcurl\(\|-openssl\)-4.dll' \
 		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime_x86\)\.' \
+		-e '^mingw../lib/ossl-modules/' \
 		-e '^mingw../lib/\(engines\|reg\|thread\)' |
 	sed 's/^/unused dll: /' |
 	tee "$unused_dlls_file" >&2


### PR DESCRIPTION
There is a new `.dll` file that the `check-for-missing-dlls` script did not anticipate yet. It is _not_ unused, it's just impossible for that script to know because it only looks at other `.dll` and `.exe` files looking for compile dependencies...

Symptom fixed by this PR:

```
unused dll: mingw32/lib/ossl-modules/legacy.dll
```