### PR TITLE
Installer: detect manually-configured default branch

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -874,6 +874,11 @@ begin
                             'true': RecordInferredDefault('Git Pull Behavior Option','Rebase');
                             'false': RecordInferredDefault('Git Pull Behavior Option','Merge');
                         end;
+                    'init.defaultbranch':
+                        if Value='master' then
+                            RecordInferredDefault('Default Branch Option', ' ')
+                        else
+                            RecordInferredDefault('Default Branch Option', Value)
                 end;
             end;
             i:=j+1;

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -124,10 +124,16 @@ CLANGARM64)
 esac
 MSYSTEM_LOWER=${MSYSTEM,,}
 
-echo "Generating release notes to be included in the installer ..."
-../render-release-notes.sh --css usr/share/git/ ||
+if test -n "$page_id"
+then
+	echo "Space intentionally left empty" >ReleaseNotes.html
+else
+	echo "Generating release notes to be included in the installer ..."
+	../render-release-notes.sh --css usr/share/git/
+fi ||
 die "Could not generate release notes"
 
+test ! -d /var/lib/pacman/local/ ||
 if grep -q edit-git-bash /var/lib/pacman/local/mingw-w64-$ARCH-git-[1-9]*/files
 then
 	INCLUDE_EDIT_GIT_BASH=
@@ -289,12 +295,15 @@ fi
 # 3. Construct DeleteOpenSSHFiles function signature to be used in install.iss
 # 4. Assemble function body and compile flag to be used as guard in install.iss
 echo "$LIST" | sort >sorted-file-list.txt
-pacman -Ql openssh 2>pacman.stderr | sed -n 's|^openssh /\(.*[^/]\)$|\1|p' | sort >sorted-openssh-file-list.txt
-grep -v 'database file for .* does not exist' <pacman.stderr >&2
-openssh_deletes="$(comm -12 sorted-file-list.txt sorted-openssh-file-list.txt |
-	sed -e 'y/\//\\/' -e "s|.*|    if not DeleteFile(AppDir+'\\\\&') then\n        Result:=False;|")"
-inno_defines="$inno_defines$LF[Code]${LF}function DeleteOpenSSHFiles():Boolean;${LF}var$LF    AppDir:String;${LF}begin$LF    AppDir:=ExpandConstant('{app}');$LF    Result:=True;"
-inno_defines="$inno_defines$LF$openssh_deletes${LF}end;$LF#define DELETE_OPENSSH_FILES 1"
+if type -p pacman.exe >/dev/null 2>&1
+then
+	pacman -Ql openssh 2>pacman.stderr | sed -n 's|^openssh /\(.*[^/]\)$|\1|p' | sort >sorted-openssh-file-list.txt
+	grep -v 'database file for .* does not exist' <pacman.stderr >&2
+	openssh_deletes="$(comm -12 sorted-file-list.txt sorted-openssh-file-list.txt |
+		sed -e 'y/\//\\/' -e "s|.*|    if not DeleteFile(AppDir+'\\\\&') then\n        Result:=False;|")"
+	inno_defines="$inno_defines$LF[Code]${LF}function DeleteOpenSSHFiles():Boolean;${LF}var$LF    AppDir:String;${LF}begin$LF    AppDir:=ExpandConstant('{app}');$LF    Result:=True;"
+	inno_defines="$inno_defines$LF$openssh_deletes${LF}end;$LF#define DELETE_OPENSSH_FILES 1"
+fi
 
 test -z "$LIST" ||
 echo "$LIST" |


### PR DESCRIPTION
As reported in https://github.com/git-for-windows/git/issues/4525, during upgrades the Git for Windows installer may overwrite the current default branch name if it has been set manually in the system config (as opposed to configuring it in the previous Git for Windows installer run).

This PR addresses that by letting the system config override the values from the previous installer run.