### PR TITLE
signtool.sh: add verbose logging to osslsigncode

### DIFF
--- a/signtool.sh
+++ b/signtool.sh
@@ -26,6 +26,7 @@ type osslsigncode >/dev/null 2>&1 || {
 
 s () {
 	osslsigncode.exe sign \
+		-verbose \
 		-pkcs12 "$HOME/.sig/codesign.p12" \
 		-readpass "$HOME/.sig/codesign.pass" \
 		-ts http://timestamp.comodoca.com?td=sha256 \


### PR DESCRIPTION
In the issue mentioned below, we've been investigating a problem where code signing _sometimes_ hangs on arm64, but not consistently. It seems to hang somewhere around the osslsigncode.exe process. Let's add some verbose logging there to see if it helps us in the debugging process somehow...

Ref: https://github.com/git-for-windows/git/issues/3107#issuecomment-1634695759
