### PR TITLE
installer: fix the broken "Enable Pseudo Console Support" option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path installer-${{ matrix.bitness }}/*.exe | %{$_.FullName}
-          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /LOG=installer.log"
+          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
           "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
           "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
       - name: validate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,7 @@ jobs:
           echo '::endgroup'
 
           set -x &&
+          grep 'Installation process succeeded' installer.log &&
           cygpath -aw / &&
           git.exe version --build-options >version &&
           cat version &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,6 +193,10 @@ jobs:
         if: matrix.artifact == 'build-installers'
         shell: bash
         run: |
+          echo '::group::installer.log'
+          cat installer.log
+          echo '::endgroup'
+
           set -x &&
           cygpath -aw / &&
           git.exe version --build-options >version &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,12 @@ jobs:
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path installer-${{ matrix.bitness }}/*.exe | %{$_.FullName}
-          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
+          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
+          $exitCode = $installer.ExitCode
+          if ($exitCode -ne 0) {
+            Write-Host "::error::Installer failed with exit code $exitCode!"
+            exit 1
+          }
           "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
           "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
       - name: validate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,6 +204,7 @@ jobs:
 
           set -x &&
           grep 'Installation process succeeded' installer.log &&
+          ! grep -iw failed installer.log &&
           cygpath -aw / &&
           git.exe version --build-options >version &&
           cat version &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
           git clone --bare --depth=1 --single-branch --branch=main $partial \
             https://github.com/git-for-windows/git-sdk-${{ matrix.bitness }} .sdk
       - name: build ${{ matrix.artifact }} artifact
+        id: build-artifact
         shell: bash
         run: |
           case "${{ matrix.artifact }}" in
@@ -166,6 +167,7 @@ jobs:
               ${{ matrix.artifact }}
             ;;
           esac &&
+          echo "git-version=$(sdk-artifact/cmd/git.exe version)" >>$GITHUB_OUTPUT &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH &&
@@ -195,7 +197,7 @@ jobs:
           cygpath -aw / &&
           git.exe version --build-options >version &&
           cat version &&
-          grep "$(sed -e 's|^v||' -e 's|-|.|g' <bundle-artifacts/next_version)" version &&
+          grep "${{ steps.build-artifact.outputs.git-version }}" version &&
           checklist=installer/run-checklist.sh &&
           # cannot test SSH keys in read-only mode, skip test for now
           sed -i 's|git@ssh.dev.azure.com:v3/git-for-windows/git/git|https://github.com/git/git|' $checklist &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,8 +192,13 @@ jobs:
             Write-Host "::error::Installer failed with exit code $exitCode!"
             exit 1
           }
-          "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
-          "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          if ("${{ matrix.bitness }}" -eq 32) {
+            "${env:ProgramFiles(x86)}\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+            "${env:ProgramFiles(x86)}\Git\mingw32\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          } else {
+            "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+            "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          }
       - name: validate
         if: matrix.artifact == 'build-installers'
         shell: bash

--- a/installer/checklist.txt
+++ b/installer/checklist.txt
@@ -8,11 +8,8 @@ After building new installers, check that
 	- `gitk` runs and shows the history
 	- `git gui` runs and does not complain about a missing repository
 	- `git help git` opens the page and it has no verbatim `linkgit:`
-	- `curl --version` lists `IPv6` in the last line
-	- verify that `git -c http.sslbackend=schannel2 ls-remote
-	  https://github.com/dscho/images` errors out, and that it works with
-	  schannel and openssl
-	- verify that `git ls-remote` works with a VSTS SSH URL
+	- `run-checklist.sh` passes (performs a couple automated tests related
+	  to cURL, the Git version, etc)
 - Git CMD
 	- starts
 	- `git log` in a repository is colorful and stops after the first page

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -3184,7 +3184,7 @@ begin
         if not SaveStringToFile(ExpandConstant('{app}\etc\git-bash.config'),'MSYS=enable_pcon',False) then begin
             LogError('Could not write to '+ExpandConstant('{app}\etc\git-bash.config'))
         end
-    else
+    end else begin
         if not SaveStringToFile(ExpandConstant('{app}\etc\git-bash.config'),'MSYS=disable_pcon',False) then begin
             LogError('Could not write to '+ExpandConstant('{app}\etc\git-bash.config'))
         end

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1272,7 +1272,7 @@ begin
 
     if IsOriginalUserAdmin then begin
         // detection only works when we're not running as admin
-        Log('Symbolic link permission detection failed: running as admin');
+        Log('Skipping symbolic link permission detection: running as admin');
         Result:=False;
     end else begin
         // maybe rights assigned through group policy without enabling developer mode?

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1098,7 +1098,7 @@ begin
     Result:=True;
     if not IsX64 then
         SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support.'+#13+'More information at https://gitforwindows.org/32-bit.html',mbError,MB_OK or MB_DEFBUTTON1,IDOK)
-    else if SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO then
+    else if not ParamIsSet('ALLOWINSTALLING32ON64') and (SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO) then
         Result:=False;
 #else
     if not IsWin64 then begin

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2639,7 +2639,7 @@ begin
     end;
 
     if not LinkCreated then begin
-        if not FileCopy(AppDir+'\tmp\git-wrapper.exe',FileName,False) then begin
+        if not FileCopy(AppDir+'\{#MINGW_BITNESS}\share\git\git-wrapper.exe',FileName,False) then begin
             Log('Line {#__LINE__}: Creating copy "'+FileName+'" failed.');
             // This is not a critical error, Git could basically be used without the
             // aliases for built-ins, so we continue.
@@ -3024,11 +3024,6 @@ begin
             end;
         end;
 
-        // Copy git-wrapper to the temp directory.
-        if not FileCopy(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-log.exe',AppDir+'\tmp\git-wrapper.exe',False) then begin
-            Log('Line {#__LINE__}: Creating copy "'+AppDir+'\tmp\git-wrapper.exe" failed.');
-        end;
-
         // Create built-ins as aliases for git.exe.
         for i:=0 to Count do begin
             FileName:=AppDir+'\{#MINGW_BITNESS}\bin\'+BuiltIns[i];
@@ -3048,10 +3043,6 @@ begin
             HardlinkOrCopyGit(AppDir+'\cmd\git-lfs.exe',False);
         end;
 
-        // Delete git-wrapper from the temp directory.
-        if not DeleteFile(AppDir+'\tmp\git-wrapper.exe') then begin
-            Log('Line {#__LINE__}: Deleting temporary "'+AppDir+'\tmp\git-wrapper.exe" failed.');
-        end;
     end else
         LogError('Line {#__LINE__}: Unable to read file "{#MINGW_BITNESS}\{#APP_BUILTINS}".');
 

--- a/installer/run-checklist.sh
+++ b/installer/run-checklist.sh
@@ -20,4 +20,32 @@ case "$(git version)" in *2.40.*|*2.[123][0-9].*) true;; *) exit 123;; esac
 
 git ls-remote git@ssh.dev.azure.com:v3/git-for-windows/git/git main
 
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+pcon_choice="$(sed -n 's/^Enable Pseudo Console Support: //p' /etc/install-options.txt)" ||
+die 'Could not read /etc/install-options.txt'
+
+if test -n "$pcon_choice"
+then
+	pcon_config="$(cat /etc/git-bash.config)" ||
+	die 'Could not read /etc/git-bash.config'
+
+	case "$pcon_choice" in
+	Enabled)
+		test "MSYS=enable_pcon" = "$pcon_config" ||
+		die "Expected enable_pcon in git-bash.config, but got '$pcon_config'"
+		;;
+	Disabled)
+		test "MSYS=disable_pcon" = "$pcon_config" ||
+		die "Expected disable_pcon in git-bash.config, but got '$pcon_config'"
+		;;
+	*)
+		die "Unexpected Pseudo Console choice: $pcon_choice"
+		;;
+	esac
+fi
+
 echo "All checks passed!" >&2


### PR DESCRIPTION
As reported in https://github.com/git-for-windows/git/issues/4571, the Pseudo Console support checkbox does the exact opposite of what it is intended to do.

Turns out that this bug has been with us since Git for Windows v2.41.0, i.e. since June 1st 2023 (or, if you count the pre-releases, since since May 17th, 2023).

This PR fixes the logic and adds a check to prevent regressions in the future.