### PR TITLE
Fix the PR build installing and validating the 32-bit flavor of Git for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path installer-${{ matrix.bitness }}/*.exe | %{$_.FullName}
-          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /LOG=installer.log"
+          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
           "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
           "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
       - name: validate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,7 @@ jobs:
           echo '::endgroup'
 
           set -x &&
+          grep 'Installation process succeeded' installer.log &&
           cygpath -aw / &&
           git.exe version --build-options >version &&
           cat version &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -193,6 +193,10 @@ jobs:
         if: matrix.artifact == 'build-installers'
         shell: bash
         run: |
+          echo '::group::installer.log'
+          cat installer.log
+          echo '::endgroup'
+
           set -x &&
           cygpath -aw / &&
           git.exe version --build-options >version &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,12 @@ jobs:
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path installer-${{ matrix.bitness }}/*.exe | %{$_.FullName}
-          Start-Process -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
+          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
+          $exitCode = $installer.ExitCode
+          if ($exitCode -ne 0) {
+            Write-Host "::error::Installer failed with exit code $exitCode!"
+            exit 1
+          }
           "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
           "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
       - name: validate

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -204,6 +204,7 @@ jobs:
 
           set -x &&
           grep 'Installation process succeeded' installer.log &&
+          ! grep -iw failed installer.log &&
           cygpath -aw / &&
           git.exe version --build-options >version &&
           cat version &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,6 +152,7 @@ jobs:
           git clone --bare --depth=1 --single-branch --branch=main $partial \
             https://github.com/git-for-windows/git-sdk-${{ matrix.bitness }} .sdk
       - name: build ${{ matrix.artifact }} artifact
+        id: build-artifact
         shell: bash
         run: |
           case "${{ matrix.artifact }}" in
@@ -166,6 +167,7 @@ jobs:
               ${{ matrix.artifact }}
             ;;
           esac &&
+          echo "git-version=$(sdk-artifact/cmd/git.exe version)" >>$GITHUB_OUTPUT &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH &&
@@ -195,7 +197,7 @@ jobs:
           cygpath -aw / &&
           git.exe version --build-options >version &&
           cat version &&
-          grep "$(sed -e 's|^v||' -e 's|-|.|g' <bundle-artifacts/next_version)" version &&
+          grep "${{ steps.build-artifact.outputs.git-version }}" version &&
           checklist=installer/run-checklist.sh &&
           # cannot test SSH keys in read-only mode, skip test for now
           sed -i 's|git@ssh.dev.azure.com:v3/git-for-windows/git/git|https://github.com/git/git|' $checklist &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -192,8 +192,13 @@ jobs:
             Write-Host "::error::Installer failed with exit code $exitCode!"
             exit 1
           }
-          "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
-          "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          if ("${{ matrix.bitness }}" -eq 32) {
+            "${env:ProgramFiles(x86)}\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+            "${env:ProgramFiles(x86)}\Git\mingw32\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          } else {
+            "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+            "$env:ProgramFiles\Git\mingw${{env.ARCH_BITNESS}}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+          }
       - name: validate
         if: matrix.artifact == 'build-installers'
         shell: bash

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1272,7 +1272,7 @@ begin
 
     if IsOriginalUserAdmin then begin
         // detection only works when we're not running as admin
-        Log('Symbolic link permission detection failed: running as admin');
+        Log('Skipping symbolic link permission detection: running as admin');
         Result:=False;
     end else begin
         // maybe rights assigned through group policy without enabling developer mode?

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1098,7 +1098,7 @@ begin
     Result:=True;
     if not IsX64 then
         SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support.'+#13+'More information at https://gitforwindows.org/32-bit.html',mbError,MB_OK or MB_DEFBUTTON1,IDOK)
-    else if SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO then
+    else if not ParamIsSet('ALLOWINSTALLING32ON64') and (SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO) then
         Result:=False;
 #else
     if not IsWin64 then begin

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2639,7 +2639,7 @@ begin
     end;
 
     if not LinkCreated then begin
-        if not FileCopy(AppDir+'\tmp\git-wrapper.exe',FileName,False) then begin
+        if not FileCopy(AppDir+'\{#MINGW_BITNESS}\share\git\git-wrapper.exe',FileName,False) then begin
             Log('Line {#__LINE__}: Creating copy "'+FileName+'" failed.');
             // This is not a critical error, Git could basically be used without the
             // aliases for built-ins, so we continue.
@@ -3024,11 +3024,6 @@ begin
             end;
         end;
 
-        // Copy git-wrapper to the temp directory.
-        if not FileCopy(AppDir+'\{#MINGW_BITNESS}\libexec\git-core\git-log.exe',AppDir+'\tmp\git-wrapper.exe',False) then begin
-            Log('Line {#__LINE__}: Creating copy "'+AppDir+'\tmp\git-wrapper.exe" failed.');
-        end;
-
         // Create built-ins as aliases for git.exe.
         for i:=0 to Count do begin
             FileName:=AppDir+'\{#MINGW_BITNESS}\bin\'+BuiltIns[i];
@@ -3048,10 +3043,6 @@ begin
             HardlinkOrCopyGit(AppDir+'\cmd\git-lfs.exe',False);
         end;
 
-        // Delete git-wrapper from the temp directory.
-        if not DeleteFile(AppDir+'\tmp\git-wrapper.exe') then begin
-            Log('Line {#__LINE__}: Deleting temporary "'+AppDir+'\tmp\git-wrapper.exe" failed.');
-        end;
     end else
         LogError('Line {#__LINE__}: Unable to read file "{#MINGW_BITNESS}\{#APP_BUILTINS}".');
 


### PR DESCRIPTION
Over in https://github.com/git-for-windows/build-extra/pull/522, I was implementing a relatively straight-forward bug fix and added an extra precaution to verify via `run-checklist.sh` that the installer works as intended.

Guess how big my surprise was when not only the [`sdk-artifacts (build-installers, 32)` job failed](https://github.com/git-for-windows/build-extra/actions/runs/5961265753/job/16170153237?pr=522#logs) (and _only_ that one, the 64-bit one was fine!), but when I went down a lengthy rabbit hole once I realized that the silent installation of the 32-bit Git for Windows that is part of the validation _failed_, and must have done so ever since c800a3f6004dc0690ec9bcf0ef79f696f53eeb66, i.e. for over half a year!

Turns out that we did not, in fact, validate what we thought we were validating. In many, entertainingly different ways did we not do that.

This PR reflects some of my journey down that particular rabbit hole and I hope you enjoy the ride.