### PR TITLE
apply-from-lore: allow specifying non-Git URLs

### DIFF
--- a/apply-from-lore.sh
+++ b/apply-from-lore.sh
@@ -89,8 +89,7 @@ do
 					s/^href="\.\.\/\([^"]*\).*/\1/p;q
 				}' <"$OUT2")"
 			test -n "$URL3" || break
-			curl -f https://lore.kernel.org/git/${URL3%/}/raw \
-				>>"$OUT3" ||
+			curl -f "${URL%/*/raw}/${URL3%/}/raw" >>"$OUT3" ||
 			die "Could not retrieve $URL3" >&2
 			NO=$(($NO+1))
 		done


### PR DESCRIPTION
The public-inbox system is used for all kinds of projects that still use that quaint mailing-list centric patch contribution process, not only for Git.

Cygwin, for example, uses it, too.

The `apply-from-lore.sh` script already allowed applying individual patches from other projects' public-inbox URLs.

With this change, it is now also possible to apply patch _series_ from such public-inbox URLs, such as
https://inbox.sourceware.org/cygwin-patches/20230712120804.2992142-1-corinna-cygwin@cygwin.com/

I used this modified version a couple of times when upstreaming MSYS2 runtime patches, and could imagine that it comes in handy for other contributors, too.