### PR TITLE
build-installers: do include the 7-Zip DLL

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3310,7 +3310,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		cat <<-EOF >>"$sparse_checkout_file" &&
 
 		# 7-Zip
-		$PREFIX/bin/7z.exe
+		$PREFIX/bin/7z.dll
 		$PREFIX/bin/7z.exe
 
 		# WinToast


### PR DESCRIPTION
This is a brown paper bag fix for #527 