### PR TITLE
please.sh build-mingw-w64-git: optionally reset `pkgrel`

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3441,6 +3441,9 @@ build_mingw_w64_git () { # [--only-i686] [--only-x86_64] [--only-aarch64] [--ski
 	--skip-doc-html)
 		sed_makepkg_e="$sed_makepkg_e"' -e s/"\${MINGW_PACKAGE_PREFIX}-\${_realname}-doc-html"//'
 		;;
+        --reset-pkgrel)
+                sed_makepkg_e="$sed_makepkg_e"' -e s/^pkgrel=[0-9][0-9]*$/pkgrel=1/'
+                ;;
 	--build-src-pkg)
 		src_pkg=t
 		;;


### PR DESCRIPTION
As @rimrul noticed, between v2.43.0-rc1 and v2.43.0-rc2 we [did not reset `pkgrel=1`](https://github.com/git-for-windows/git/pull/4692#issuecomment-1817775282).

This is part 1 of the two-parter to address this (and I plan on merging this today, [in time for v2.43.0 final](https://gh.io/gitCal)).