### PR TITLE
create-sdk-artifact(build installers): include `update-via-pacman.ps1`

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3239,6 +3239,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		/usr/ssl/certs/ca-bundle.crt
 		/usr/share/pacman/
 		/var/lib/pacman/local/
+		/update-via-pacman.ps1
 
 		# Some other utilities required by `make-file-list.sh`
 		/usr/bin/cat.exe


### PR DESCRIPTION
 This script is already used by the `sync` jobs that keep the Git for Windows SDKs up to date.

We're about to use the same script in the automation that builds Git for Windows' packages, so let's make sure that this script is available in those scenarios.