### PR TITLE
delete outdated release note

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -48,7 +48,6 @@ Please also note that the 32-bit variant of Git for Windows is deprecated; Its l
 
 ### New Features
 
-* Comes with [gnupg v2.2.42](https://github.com/gpg/gnupg/releases/tag/gnupg-2.2.42).
 * Comes with [libfido2 v1.14.0](https://github.com/Yubico/libfido2/releases/tag/1.14.0).
 * Comes with the MSYS2 runtime (Git for Windows flavor) based on [Cygwin v3.4.10](https://inbox.sourceware.org/cygwin-announce/20231129150845.713029-1-corinna-cygwin@cygwin.com/).
 * Comes with [Perl v5.38.2](http://search.cpan.org/dist/perl-5.38.2/pod/perldelta.pod).


### PR DESCRIPTION
We've updated to GPG 2.4.4 int the meantime, but our automation didn't replace the old release note, because we spell out GNU Privacy Guard now.