### PR TITLE
Include git-difftool--helper in minimal git

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -291,7 +291,7 @@ else
 		-e '^/\(mingw\|clang\)[^/]*/bin/\(WhoUses\|xmlwf\)\.exe$' \
 		-e '^/\(mingw\|clang\)[^/]*/etc/pki' -e '^/\(mingw\|clang\)[^/]*/lib/p11-kit/' \
 		-e '/git-\(add--interactive\|archimport\|citool\|cvs.*\)$' \
-		-e '/git-\(difftool.*\|gui.*\|instaweb\|p4\|relink\)$' \
+		-e '/git-\(gui.*\|instaweb\|p4\|relink\)$' \
 		-e '/git-\(send-email\|svn\)$' \
 		-e '/\(mingw\|clang\)[^/]*/libexec/git-core/git-\(imap-send\|daemon\)\.exe$' \
 		-e '/\(mingw\|clang\)[^/]*/libexec/git-core/git-remote-ftp.*\.exe$' \


### PR DESCRIPTION
Resolves git-for-windows/git#4806

Verified as working by running the following in sdk

```
/usr/src/build-extra$ ./mingit/release.sh 0-test
```

Only `mingw64/lib/exec/git-core/mergetools/git-difftool--helper` is added to `MinGit-0-test-64-bit.zip`