### PR TITLE
installer: delete context menu entries created for library folder on uninstall

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -566,11 +566,13 @@ begin
         RootKey:=HKEY_CURRENT_USER;
     end;
 
-    SetArrayLength(Keys,4);
+    SetArrayLength(Keys,6);
     Keys[0]:='SOFTWARE\Classes\Directory\shell\git_shell';
     Keys[1]:='SOFTWARE\Classes\Directory\Background\shell\git_shell';
     Keys[2]:='SOFTWARE\Classes\Directory\shell\git_gui';
     Keys[3]:='SOFTWARE\Classes\Directory\Background\shell\git_gui';
+    Keys[4]:='SOFTWARE\Classes\LibraryFolder\background\shell\git_shell';
+    Keys[5]:='SOFTWARE\Classes\LibraryFolder\background\shell\git_gui';
 
     for i:=0 to Length(Keys)-1 do begin
         Command:='';


### PR DESCRIPTION
A PR(#150) from a long time ago added some context menu entries for the Windows library folder but did not include scripts for their removal, leading to residual registry data after the software was uninstalled.

This PR is intended to address that issue.