### PR TITLE
portable: make sure that `package-versions.txt` is included

### DIFF
--- a/portable/release.sh
+++ b/portable/release.sh
@@ -169,6 +169,10 @@ echo $LIST | tr ' ' '\n' >$TMPPACK.list &&
 # root directory like this:
 echo "$(cygpath -aw "$SCRIPT_PATH/root")\\*" >>$TMPPACK.list &&
 (cd / && 7z a $OPTS7 $TMPPACK @${TMPPACK#/}.list) &&
+if test -z "$(7z l $TMPPACK etc/package-versions.txt)"
+then
+	die "/etc/package-versions.txt is missing?!?"
+fi &&
 (cat "$SCRIPT_PATH/../7-Zip/7zS.sfx" &&
  echo ';!@Install@!UTF-8!' &&
  echo 'Title="Portable Git for Windows '$TITLE'"' &&


### PR DESCRIPTION
In https://github.com/git-for-windows/git/issues/4955 it was pointed out that the i686 version ("32-bit") of Portable Git v2.45.1 is missing the `package-versions.txt` file.

While it is unclear why that happened (the logs of the -- embargoed -- build do not reveal any clue about this issue), let's at least ensure that it does not happen again.

/cc @mcgitty