### PR TITLE
git-extra: Correct maintainer slug

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -1,4 +1,4 @@
-# Maintainer: nalla <nalla@hamal.uberspace.de>
+# Maintainer: Johannes Schindelin <johannes.schindelin@gmx.de>
 
 _realname="git-extra"
 pkgbase="mingw-w64-${_realname}"


### PR DESCRIPTION
The initial maintainer of this pkg is by far the wrong person to be written in the maintainer slug. Let's add @dscho here to correctly state who is maintaining the `git-extra` package.