### PR TITLE
getgit: Fix user path reg query result potentially getting truncated

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.636.2db97b993
+pkgver=1.1.639.bbde4778d
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.639.bbde4778d
+pkgver=1.1.641.031e03baf
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/getgit
+++ b/git-extra/getgit
@@ -248,7 +248,7 @@ echo "be removed from the context menu is available as $rm_ctxmenu "
 echo ""
 # Setting ENV
 echo -n "Setting env ..."
-userpath=$(reg query "HKEY_CURRENT_USER\Environment" //v Path 2>/dev/null | awk 'NR==3 {print}' | cut -d ' ' -f 13-)
+userpath="$(powershell -command '(Get-ItemProperty -Path 'HKCU:\Environment' -Name Path).Path')"
 if [[ "$userpath" == "" ]]; then
     setx PATH "$(cygpath -m /cmd)" > /dev/null 2>&1
 elif [[ "$userpath" != *"$(cygpath -m /cmd)"* ]]; then

--- a/git-extra/getgit
+++ b/git-extra/getgit
@@ -248,7 +248,7 @@ echo "be removed from the context menu is available as $rm_ctxmenu "
 echo ""
 # Setting ENV
 echo -n "Setting env ..."
-userpath=$(reg query "HKEY_CURRENT_USER\Environment" //v Path 2>/dev/null | awk 'NR==3 {print $NF}')
+userpath=$(reg query "HKEY_CURRENT_USER\Environment" //v Path 2>/dev/null | awk 'NR==3 {print}' | cut -d ' ' -f 13-)
 if [[ "$userpath" == "" ]]; then
     setx PATH "$(cygpath -m /cmd)" > /dev/null 2>&1
 elif [[ "$userpath" != *"$(cygpath -m /cmd)"* ]]; then


### PR DESCRIPTION
This reg query result for the user path environment variable could potentially get truncated if a space was contained anywhere inside the path variable. This is especially problematic because this incorrect value is then written back, effectively destroying part of the users path.

For example with path containing `D:\important\entry;C:\my\very            spacey\path`:
Before: `reg query "HKEY_CURRENT_USER\Environment" //v Path 2>/dev/null | awk 'NR==3 {print $NF}'` -> `spacey\path`

After: `reg query "HKEY_CURRENT_USER\Environment" //v Path 2>/dev/null | awk 'NR==3 {print}' | cut -d ' ' -f 13-` -> `D:\important\entry;C:\my\very            spacey\path`