### PR TITLE
Avoid several warnings while building `mingw-w64-git*`

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3263,6 +3263,9 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		/usr/bin/xgettext.exe
 		/usr/bin/msys-gettext*.dll
 
+		# The `error_highlight` Ruby gem, needed by `asciidoctor`
+		*error_highlight*
+
 		# Files to include into the installer/Portable Git/MinGit
 		EOF
 		git -C "$output_path" checkout -- &&

--- a/please.sh
+++ b/please.sh
@@ -3258,6 +3258,11 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		# markdown, to render the release notes
 		/usr/bin/markdown
 
+		# gettext (for makepkg)
+		/usr/bin/gettext.exe
+		/usr/bin/xgettext.exe
+		/usr/bin/msys-gettext*.dll
+
 		# Files to include into the installer/Portable Git/MinGit
 		EOF
 		git -C "$output_path" checkout -- &&


### PR DESCRIPTION
We used to include `gettext` in the `build-installers` SDK artifact, but more by mistake than on purpose. We need to include it again, this time on purpose, to fix https://github.com/git-for-windows/git/issues/4952.