### PR TITLE
mingit: exclude new sshd executable

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -326,7 +326,7 @@ else
 		-e '^/usr/bin/\(pr\|printenv\|ps\|ptx\|realpath\)\.exe$' \
 		-e '^/usr/bin/\(regtool\|runcon\|scp\|seq\|setfacl\)\.exe$' \
 		-e '^/usr/bin/\(setmetamode\|sftp\|sha.*sum\|shred\)\.exe$' \
-		-e '^/usr/bin/\(shuf\|sleep\|slogin\|split\|sshd\)\.exe$' \
+		-e '^/usr/bin/\(shuf\|sleep\|slogin\|split\|sshd)\.exe$' \
 		-e '^/usr/bin/\(ssh-key.*\|ssp\|stat\|stdbuf\|strace\)\.exe$' \
 		-e '^/usr/bin/\(stty\|sum\|sync\|tac\|tee\|timeout\)\.exe$' \
 		-e '^/usr/bin/\(truncate\|tsort\|tty\|tzset\|umount\)\.exe$' \
@@ -335,7 +335,7 @@ else
 		-e '^/usr/bin/msys-sqlite3[a-z].*\.dll$' \
 		-e '^/usr/bin/msys-\(gomp.*\|vtv.*\)-.*\.dll$' \
 		-e '^/usr/lib/\(awk\|coreutils\|gawk\|openssl\|pkcs11\)/' \
-		-e '^/usr/lib/ssh/sftp' \
+		-e '^/usr/lib/ssh/\(sftp\|sshd\($\|-\)\)' \
 		-e '^/usr/libexec/\(bigram\|code\|frcode\)\.exe$' \
 		-e '^/usr/share/\(cygwin\|git\)/' \
 		-e '^/usr/ssl/misc/' \


### PR DESCRIPTION
The `sshd.exe` file is already excluded from MinGit for quite a while. As of OpenSSH 9.8, there is a new `sshd-session.exe`, which also needs to be excluded.

This new file is part of an ongoing effort to split `sshd` further, see https://github.com/openssh/openssh-portable/commit/03e3de416ed7c34faeb692967737be4a7bbe2eb5 for more details. This was mentioned in some fashion in [the release notes](https://www.openssh.com/releasenotes.html#9.8p1):

> * [sshd(8)](https://man.openbsd.org/sshd.8): the server has been split into a listener binary, [sshd(8)](https://man.openbsd.org/sshd.8),
   and a per-session binary "sshd-session". This allows for a much
   smaller listener binary, as it no longer needs to support the SSH
   protocol. As part of this work, support for disabling privilege
   separation (which previously required code changes to disable) and
   disabling re-execution of [sshd(8)](https://man.openbsd.org/sshd.8) has been removed. Further
   separation of sshd-session into additional, minimal binaries is
   planned for the future.

As a consequence of this ongoing effort, let's not just exclude `sshd-session.exe` piecemeal fashion, but all `sshd-*.exe` files, whatever they be in the future.

This fixes the `check-for-missing-dlls` run that fails currently, see https://github.com/git-for-windows/git-sdk-64/actions/runs/9754263596/job/26920893577#step:6:9 for an example.