### PR TITLE
installer: fix the `scalar reconfigure --all` invocation

### DIFF
--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -206,14 +206,21 @@ var
     OutPath,ErrPath:String;
     Res:Longint;
 begin
-    OutPath:=ExpandConstant('{tmp}\')+LogKey+'.out';
-    ErrPath:=ExpandConstant('{tmp}\')+LogKey+'.err';
+    OutPath:=ExpandConstant('{tmp}.')+LogKey+'.out';
+    ErrPath:=ExpandConstant('{tmp}.')+LogKey+'.err';
     if not ExecAsOriginalUser(ExpandConstant('{sys}\cmd.exe'),'/D /C "'+Cmd+' >"'+OutPath+'" 2>"'+ErrPath+'""','',SW_HIDE,ewWaitUntilTerminated,Res) then begin
         LogError(ErrorMessage+' (sys error: '+SysErrorMessage(Res)+').');
         Result:=False;
     end else if (Res<>0) then begin
-        LogError(ErrorMessage+' (output: '+ReadFileAsString(OutPath)+', errors: '+ReadFileAsString(ErrPath)+', exit code: '+IntToStr(Res)+').');
+        if not FileExists(OutPath) then
+            LogError(ErrorMessage+' (output could not be redirected to '+OutPath+')')
+        else if not FileExists(ErrPath) then
+            LogError(ErrorMessage+' (stderr could not be redirected to '+ErrPath+')')
+        else
+            LogError(ErrorMessage+' (output: '+ReadFileAsString(OutPath)+', errors: '+ReadFileAsString(ErrPath)+', exit code: '+IntToStr(Res)+').');
         Result:=False;
     end else
         Result:=True;
+    DeleteFile(OutPath);
+    DeleteFile(ErrPath);
 end;


### PR DESCRIPTION
When running the installer of `microsoft/git` v2.45.2.vfs.0.2, it is possible to run into this error:

	Line 3401: Could not reconfigure Scalar enlistment.

The most likely reason is a recent change in InnoSetup (and therefore affects both `microsoft/git` and regular Git for Windows), concretely: [this one](https://github.com/jrsoftware/issrc/commit/ba9bdedad772c429dee700957b78aae0d1c8dab3#diff-ba50e25972bfa9da0e0159b1fae6c5921f46440eebc624cb9401093c1bc32804R181).

Essentially, when creating a safe directory, InnoSetup now protects it via reduced permissions (e.g. allowing the original user who started the installer only to read, but not write into the directory) if it is in a temporary directory on a local drive.

This is affects e.g. the `ExecSilentlyAsOriginalUser()` function which wants to write `stdout` and `stderr` into two files in the temporary directory that is created by InnoSetup.

Earlier, this was possible because the safe directory still allowed the original user to write into it, but now that is no longer the case.

As a work-around, let's write those two files directly into the `%TEMP%` directory of the original user (where the account has write permissions). To do that, we use the fact that `{tmp}` refers to a subdirectory, and by appending some unique suffix we can construct a path to such a file.

This fixes https://github.com/git-for-windows/git/issues/5038.