### PR TITLE
installer: reflect the fact that FSMonitor is no longer experimental

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2410,10 +2410,12 @@ begin
 #endif
 
 #ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
-    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Enable experimental built-in file system monitor','<RED>(NEW!)</RED> Automatically run a <A HREF=https://github.com/git-for-windows/git/discussions/3251>built-in file system watcher</A>, to speed up common'+#13+'operations such as `git status`, `git add`, `git commit`, etc in worktrees'+#13+'containing many files.',TabOrder,Top,Left);
+    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Built-in file system monitor','<RED>The FSMonitor feature is no longer experimental, and now needs to be'+#13+'configured per repository via the core.fsmonitor config setting.</RED>',TabOrder,Top,Left);
 
     // Restore the settings chosen during a previous install
     RdbExperimentalOptions[GP_EnableFSMonitor].Checked:=ReplayChoice('Enable FSMonitor','Auto')='Enabled';
+    // FSMonitor is no longer experimental, and it is also no longer supported to be enabled by the installer for all repositories.
+    RdbExperimentalOptions[GP_EnableFSMonitor].Enabled:=False;
 #endif
 
 #endif
@@ -3671,9 +3673,6 @@ begin
 
 #ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
     Data:='Disabled';
-    if RdbExperimentalOptions[GP_EnableFSMonitor].Checked then begin
-        Data:='Enabled';
-    end;
     RecordChoice(PreviousDataKey,'Enable FSMonitor',Data);
 #endif
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1807,6 +1807,7 @@ var
     Data:String;
     LblInfo:TLabel;
     AslrSetting: AnsiString;
+    WasFSMonitorEnabled:Boolean;
 begin
     SanitizeGitEnvironmentVariables();
 
@@ -2410,12 +2411,19 @@ begin
 #endif
 
 #ifdef WITH_EXPERIMENTAL_BUILTIN_FSMONITOR
-    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Built-in file system monitor','<RED>The FSMonitor feature is no longer experimental, and now needs to be'+#13+'configured per repository via the core.fsmonitor config setting.</RED>',TabOrder,Top,Left);
+    WasFSMonitorEnabled:=ReplayChoice('Enable FSMonitor','Auto')='Enabled';
+    Data:='<RED>The FSMonitor feature is no longer experimental, and now needs to be'+#13+'configured per repository via the core.fsmonitor config setting.</RED>';
+    if not WasFSMonitorEnabled then
+        Data:=''; // Avoid rendering in red because we want to hide the option, and the way we render red text, it is added as separate `TLabel` that would _still_ be shown.
+    RdbExperimentalOptions[GP_EnableFSMonitor]:=CreateCheckBox(ExperimentalOptionsPage,'Built-in file system monitor',Data,TabOrder,Top,Left);
 
     // Restore the settings chosen during a previous install
-    RdbExperimentalOptions[GP_EnableFSMonitor].Checked:=ReplayChoice('Enable FSMonitor','Auto')='Enabled';
+    RdbExperimentalOptions[GP_EnableFSMonitor].Checked:=WasFSMonitorEnabled;
     // FSMonitor is no longer experimental, and it is also no longer supported to be enabled by the installer for all repositories.
     RdbExperimentalOptions[GP_EnableFSMonitor].Enabled:=False;
+    // If the FSMonitor was not enabled previously, do not even bother to show the option.
+    if not WasFSMonitorEnabled then
+        RdbExperimentalOptions[GP_EnableFSMonitor].Visible:=False;
 #endif
 
 #endif


### PR DESCRIPTION
It is also recommended only for larger repositories/worktrees. So let's not show the option at all anymore unless it had been enabled in the previous installation and the user is upgrading/reinstalling. And even then, disable it.

This addresses https://github.com/git-for-windows/git/issues/4570, at long last.

This is how the Experimental Options page looks now if the user had the FSMonitor feature enabled previously:

![image](https://github.com/user-attachments/assets/351461a3-8895-47a6-afde-a37402355e26)

And this is how it looks like in fresh installs or when upgrading from an installation where FSMonitor was disabled:

![image](https://github.com/user-attachments/assets/17bbf273-6c6c-49a1-b470-70a4c87cee8d)