### PR TITLE
please.sh: add asciidoctor to build-installers

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3327,6 +3327,14 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 
 		# BusyBox
 		$PREFIX/bin/busybox.exe
+
+		# Asciidoctor (requires Ruby to run)
+		$PREFIX/bin/asciidoctor
+		$PREFIX/bin/asciidoctor.bat
+		$PREFIX/lib/ruby/
+		$PREFIX/bin/ruby.exe
+		$PREFIX/bin/ruby*.dll
+
 		EOF
 		mkdir -p "$output_path/.sparse" &&
 		cp "$sparse_checkout_file" "$output_path/.sparse/build-installers"


### PR DESCRIPTION
[This pipeline](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/10159591709/job/28094144095) failed because `asciidoctor` wasn't available. However, it _is_ [available](https://github.com/git-for-windows/git-sdk-arm64/tree/e31bf6358ef639c35716ced851bc98e3bb4e10d4/var/lib/pacman/local/mingw-w64-clang-aarch64-asciidoctor-2.0.23-1) in the `git-sdk-arm64` repo. Looks like it just doesn't end up in the `build-installers` SDK flavor which is used by that pipeline.

In an earlier commit, Git for Windows switched from its own *-asciidoctor-extensions package to the MSYS2-provided *-asciidoctor package.

However, ARM64 pipelines that use the build-artifacts SDK flavor now complain that the asciidoctor binary isn't available.

This commit should ensure that Asciidoctor becomes available.

Ref: https://github.com/git-for-windows/build-extra/commit/eb16e991b8f0bfebc367a4d900585883547032ba