### PR TITLE
installer(windows terminal): quote path

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2857,7 +2857,7 @@ begin
         '      {'+
         '        "guid": "{2ece5bfe-50ed-5f3a-ab87-5cd4baafed2b}",'+
         '        "name": "Git Bash",'+
-        '        "commandline": "'+AppPath+'/bin/bash.exe -i -l",'+
+        '        "commandline": "\"'+AppPath+'/bin/bash.exe\" -i -l",'+
         '        "icon": "'+AppPath+'/{#MINGW_BITNESS}/share/git/git-for-windows.ico",'+
         '        "startingDirectory": "%USERPROFILE%"'+
         '      }'+


### PR DESCRIPTION
Without quoting the path, the door is open for executing unintended executables.

This fixes https://github.com/git-for-windows/git/issues/5100.