### PR TITLE
makepkg-git: support Windows/ARM64 better

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3392,7 +3392,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 	if test makepkg-git = $mode && test ! -x "$output_path/usr/bin/git"
 	then
 		printf '#!/bin/sh\n\nexec %s/bin/git.exe "$@"\n' \
-			"/mingw$bitness" >"$output_path/usr/bin/git"
+			"$PREFIX" >"$output_path/usr/bin/git"
 	fi &&
 	if test makepkg-git = $mode && ! grep -q http://docbook.sourceforge.net/release/xsl-ns/current "$output_path/etc/xml/catalog"
 	then


### PR DESCRIPTION
As of e292201a (please.sh: change from bitness to architecture in create_sdk_artifact, 2022-12-28), we want to use the CPU architecture (or equivalent) instead of the "bitness", but there was one forgotten instance that still needs to be fixed.