### PR TITLE
installer: do not try to terminate/restart apps under /CLOSEAPPLICATIONS

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -678,7 +678,7 @@ var
     Caption:String;
     ManualClosingRequired:Boolean;
 begin
-    if (AppDir='') then begin
+    if (AppDir='') or (Pos('/CLOSEAPPLICATIONS',UpperCase(GetCmdTail))>0) or (Pos('/FORCECLOSEAPPLICATIONS',UpperCase(GetCmdTail))>0) then begin
         SetArrayLength(Processes,0);
         Exit;
     end;


### PR DESCRIPTION
When `/CLOSEAPPLICATIONS` or `/FORCECLOSEAPPLICATIONS` is passed to InnoSetup, it will handle the closing/terminating of in-use apps, and we do not have to do anything manually.

This fixes https://github.com/git-for-windows/git/issues/5250
