### PR TITLE
cv2pdb: upgrade to v0.53

### DIFF
--- a/mingw-w64-cv2pdb/PKGBUILD
+++ b/mingw-w64-cv2pdb/PKGBUILD
@@ -3,7 +3,7 @@
 _realname=cv2pdb
 pkgbase="mingw-w64-${_realname}"
 pkgname=("${MINGW_PACKAGE_PREFIX}-${_realname}")
-pkgver=0.50
+pkgver=0.53
 pkgrel=1
 pkgdesc="Converter of DWARF debug information to PDB files (mingw-w64)"
 arch=('any')
@@ -12,7 +12,7 @@ license=('Artistic2')
 
 options=('!strip')
 
-source=("${_realname}"::"git+https://github.com/rainers/cv2pdb#branch=HEAD")
+source=("${_realname}"::"git+https://github.com/rainers/cv2pdb#tag=v${pkgver}")
 
 sha256sums=('SKIP')
 
@@ -26,24 +26,6 @@ i686) WARCH=Win32; OUTDIR=bin/Release;;
 x86_64) WARCH=x64; OUTDIR=bin/Release_x64;;
 *) die "Unsupported architecture: $CARCH"
 esac
-
-pkgver() {
-  cd "$srcdir/cv2pdb"
-  for p in \
-	0.39:3e0d57ca2607de1313060df084f55173100b3596 \
-	0.40:c1c515d00cedc8cb7453616bf0da80141b62454f \
-	0.41:31189818cbfc6d0bebf82025f3df632a287b61d6 \
-	0.42:14eef861769f85b6f32c68ff1898c41d8ac65ef5 \
-	0.43:edc8ac2e4ac38f973ebb259a6a75c1ea9db32072 \
-	0.44:ab4b0b1946295f9762ec3ed83a7c84cc8b7aa975 \
-	0.45:14641495119635e26aabad1dbccc79a6dd1fc94c \
-	0.46:3239e14109ac416358e1962932fdd360e724beea
-  do
-	  git rev-parse --verify --quiet refs/tags/${p%%:*} >/dev/null >&2 ||
-		  git tag -m "Missing tag" ${p%%:*} ${p#*:}
-  done
-  git describe --tags HEAD | tr - . | sed 's/^v//'
-}
 
 prepare () {
   cd "$srcdir/cv2pdb"


### PR DESCRIPTION
[This cv2pdb version](https://github.com/rainers/cv2pdb/releases/tag/v0.53) is supposed to have a much-improved DWARF -> PDB support, which is exactly what we use in Git for Windows.