### PR TITLE
installer: really default to Secure Channel

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2324,7 +2324,7 @@ begin
     RdbCurlVariant[GC_WinSSL]:=CreateRadioButton(CurlVariantPage,'Use the native Windows Secure Channel library','Server certificates will be validated using Windows Certificate Stores.'+#13+'This option also allows you to use your company''s internal Root CA certificates'+#13+'distributed e.g. via Active Directory Domain Services.',TabOrder,Top,Left);
 
     // Restore the setting chosen during a previous install.
-    case ReplayChoice('CURL Option','OpenSSL') of
+    case ReplayChoice('CURL Option','WinSSL') of
         'OpenSSL': RdbCurlVariant[GC_OpenSSL].Checked:=True;
         'WinSSL': RdbCurlVariant[GC_WinSSL].Checked:=True;
     else


### PR DESCRIPTION
Commit 8a7ab99 (installer: switch the libcurl default to Secure Channel, 2023-05-15) attempted to change the default libcurl backend for clean new installs to Secure channel, but only adjusted one of two fallbacks in the installer. There is one default value that gets passed to ReplayChoice() to return if it finds no previous choice and one value that gets used if ReplayChoice() returns an unexpected value. 8a7ab99 changed the latter to use Secure Channel, but left the former to default to OpenSSL. Adjust the default value to match the intention of that patch.

This fixes https://github.com/git-for-windows/git/issues/5295