### PR TITLE
please.sh build-mingw-w64-git: assume that all dependencies are installed

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3428,6 +3428,7 @@ build_mingw_w64_git () { # [--only-i686] [--only-x86_64] [--only-aarch64] [--ski
 	sed_makepkg_e=
 	force=
 	src_pkg=
+	maybe_sync=
 	while case "$1" in
 	--only-i686|--only-32-bit)
 		MINGW_ARCH=mingw32
@@ -3468,6 +3469,9 @@ build_mingw_w64_git () { # [--only-i686] [--only-x86_64] [--only-aarch64] [--ski
 		;;
 	-o*)
 		output_path="$(cygpath -am "${1#-?}")" || exit
+		;;
+	--maybe-sync|-s)
+		maybe_sync="-s --noconfirm"
 		;;
 	-*) die "Unknown option: %s\n" "$1";;
 	*) break;;
@@ -3533,7 +3537,7 @@ build_mingw_w64_git () { # [--only-i686] [--only-x86_64] [--only-aarch64] [--ski
 		export SIGNTOOL="git ${d:+--git-dir="$d"} signtool"
 	 fi &&
 	 cd ${git_src_dir%/src/git}/ &&
-	 MAKEFLAGS=${MAKEFLAGS:--j$(nproc)} makepkg-mingw -s --noconfirm $force -p PKGBUILD.$tag &&
+	 MAKEFLAGS=${MAKEFLAGS:--j$(nproc)} makepkg-mingw $maybe_sync $force -p PKGBUILD.$tag &&
 	 if test -n "$src_pkg"
 	 then
 		git --git-dir src/git/.git archive --prefix git/ -o git-$tag.tar.gz $tag &&


### PR DESCRIPTION
The idea of having `git-sdk-*` repositories that track full MSYS2 environments is not only to have a convenient and fast way to bootstrap a build environment in which to build and release Git for Windows, it also enables straight-forward processes for embargoed builds, where we have to "time-travel" back to the state from which the preceding version was built and assembled.

To guarantee that this time traveling continues to work, the build process of a regular Git for Windows release must be prevented from "conveniently" installing missing dependencies; If they are not part of the `git-sdk-*` repository (or not in the `build-installers` sparse checkout), that needs to be changed before releasing, so that the embargoed release process can continue to work as intended.