### PR TITLE
ReleaseNotes/prerelease: use the new Git for Windows snapshots URL

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -30,7 +30,7 @@ See [http://git-scm.com/](http://git-scm.com/) for further details about Git inc
 
   Alternatively, you can disable Mandatory ASLR completely in Windows Exploit protection.
 
-Should you encounter other problems, please first search [the bug tracker](https://github.com/git-for-windows/git/issues) (also look at the closed issues) and [the mailing list](http://groups.google.com/group/git-for-windows), chances are that the problem was reported already. Also make sure that you use an up to date Git for Windows version (or a [current snapshot build](https://wingit.blob.core.windows.net/files/index.html)). If it has not been reported yet, please follow [our bug reporting guidelines](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) and [report the bug](https://github.com/git-for-windows/git/issues/new).
+Should you encounter other problems, please first search [the bug tracker](https://github.com/git-for-windows/git/issues) (also look at the closed issues) and [the mailing list](http://groups.google.com/group/git-for-windows), chances are that the problem was reported already. Also make sure that you use an up to date Git for Windows version (or a [current snapshot build](https://gitforwindows.org/git-snapshots/)). If it has not been reported yet, please follow [our bug reporting guidelines](https://github.com/git-for-windows/git/wiki/Issue-reporting-guidelines) and [report the bug](https://github.com/git-for-windows/git/issues/new).
 
 ## Licenses
 Git is licensed under the GNU General Public License version 2.

--- a/please.sh
+++ b/please.sh
@@ -2953,7 +2953,7 @@ render_release_notes_and_mail () { # <output-directory> <next-version> [<sha-256
 	url=https://gitforwindows.org/
 	case "$display_version" in
 	prerelease-*)
-		url=https://wingit.blob.core.windows.net/files/index.html
+		url=https://gitforwindows.org/git-snapshots/
 		;;
 	*-rc*)
 		url=https://github.com/git-for-windows/git/releases/tag/$2


### PR DESCRIPTION
For almost eight years, Git for Windows' snapshots were hosted at https://wingit.blob.core.windows.net/files/index.html, i.e. on Azure Blobs.

As of a combination of PRs (https://github.com/git-for-windows/git-for-windows-automation/pull/109, https://github.com/git-for-windows/gfw-helper-github-app/pull/117), snapshots are not only now built and deployed via GitHub Actions instead of Azure Pipelines (and ARM64 artifacts are now included, too), they are also hosted [on GitHub](https://github.com/git-for-windows/git-snapshots/releases/), with the main page being hosted [on GitHub Pages](https://github.com/git-for-windows/git-snapshots/commits/gh-pages).

Therefore, the original link now redirects to a new location (which is also a lot easier to remember): http://gitforwindows.org/git-snapshots. Let's adjust the link to link there directly.

Note that technically, we could alternatively delete the `render_release_notes_and_mail` function from `please.sh`, as it was only used in the Azure Pipeline that is no longer triggered to build the snapshots. Let's leave the code there for a bit longer, though.

This is a companion PR of https://github.com/git-for-windows/git-for-windows-automation/pull/111.