### PR TITLE
Release Notes: announce that `git svn` will be phased out

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -43,6 +43,8 @@ Git for Windows is distributed with other components yet, such as Bash, zlib, cu
 
 Git for Windows v2.48.1 is the last version to ship with the i686 ("32-bit") variant of the installer, portable Git and archive. Only 32-bit MinGit will be built for future versions, [until April 2029](https://gitforwindows.org/32-bit).
 
+Due to persistent maintenance challenges and the community's limited engagement and usage, `git svn` support in Git for Windows will be phased out over the next few releases.
+
 ### New Features
 
 * Comes with [MinTTY v3.7.7](https://github.com/mintty/mintty/releases/tag/3.7.7).


### PR DESCRIPTION
It poses a substantial maintenance burden, what with the need not only to keep maintaining Perl, but also subversion (and apr, apr-util, and swig, and the Perl bindings of subversion).

At the same time, less and less `git svn` tickets (and no PRs worth talking about) have trickled in.

Therefore it is a good time to say good-bye to `git svn` and send it off to a cozy, relaxing retirement on the beach. It has served us well and can now go on to enjoy life instead of work.

I'd like this to be part of v2.48.1's release announcement.