### PR TITLE
Fix missing i686 dlls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -306,27 +306,35 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bitness: ['32', '64']
+        arch:
+          - name: i686
+            mingw-prefix: mingw32
+            msystem: MINGW32
+            sdk-repo: git-sdk-32
+          - name: x86_64
+            mingw-prefix: mingw64
+            msystem: MINGW64
+            sdk-repo: git-sdk-64
     steps:
       - uses: actions/checkout@v4
       - name: initialize bare SDK clone
         shell: bash
         run: |
           git clone --bare --depth=1 --single-branch --branch=main --filter=blob:none \
-            https://github.com/git-for-windows/git-sdk-${{ matrix.bitness }} .sdk
-      - name: build build-installers-${{ matrix.bitness }} artifact
+            https://github.com/git-for-windows/${{ matrix.arch.sdk-repo }} .sdk
+      - name: build build-installers-${{ matrix.arch.name }} artifact
         shell: bash
         run: |
           INCLUDE_OBJDUMP=t \
           ./please.sh create-sdk-artifact \
-            --bitness=${{ matrix.bitness }} \
+            --architecture=${{ matrix.arch.name }} \
             --sdk=.sdk \
             --out=sdk-artifact \
             build-installers &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
-          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH &&
-          echo "MSYSTEM=MINGW${{ matrix.bitness }}" >>$GITHUB_ENV
+          cygpath -aw "$PWD/sdk-artifact/${{ matrix.arch.mingw-prefix }}/bin" >>$GITHUB_PATH &&
+          echo "MSYSTEM=${{ matrix.arch.msystem }}" >>$GITHUB_ENV
       - name: check for missing DLLs
         shell: bash
         run: ./check-for-missing-dlls.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,6 +250,7 @@ jobs:
         id: build-artifact
         shell: bash
         run: |
+          set -x &&
           case "${{ matrix.artifact }}" in
           full)
             git --git-dir=.sdk worktree add --detach sdk-artifact
@@ -262,7 +263,9 @@ jobs:
               ${{ matrix.artifact }}
             ;;
           esac &&
-          echo "git-version=$(sdk-artifact/cmd/git.exe version)" >>$GITHUB_OUTPUT &&
+          ls -la sdk-artifact/ &&
+          version="$(sdk-artifact/${{ matrix.arch.mingw-prefix }}/bin/git.exe version)" &&
+          echo "git-version=$version" >>$GITHUB_OUTPUT &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/${{ matrix.arch.mingw-prefix }}/bin" >>$GITHUB_PATH &&

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -345,6 +345,7 @@ jobs:
       - name: build build-installers-${{ matrix.arch.name }} artifact
         shell: bash
         run: |
+          set -x &&
           INCLUDE_OBJDUMP=t \
           ./please.sh create-sdk-artifact \
             --architecture=${{ matrix.arch.name }} \
@@ -354,10 +355,11 @@ jobs:
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/${{ matrix.arch.mingw-prefix }}/bin" >>$GITHUB_PATH &&
-          echo "MSYSTEM=${{ matrix.arch.msystem }}" >>$GITHUB_ENV
+          echo "MSYSTEM=${{ matrix.arch.msystem }}" >>$GITHUB_ENV &&
+          cat $GITHUB_PATH
       - name: check for missing DLLs
         shell: bash
-        run: ./check-for-missing-dlls.sh
+        run: sh -x ./check-for-missing-dlls.sh
       - name: check for missing DLLs (MinGit)
         shell: bash
         run: MINIMAL_GIT=1 ./check-for-missing-dlls.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,7 +129,7 @@ jobs:
         shell: bash
         run: |
           ./please.sh create-sdk-artifact \
-            --bitness=64 \
+            --architecture=x86_64 \
             --sdk=.sdk \
             --out=sdk-artifact \
             build-installers &&
@@ -213,12 +213,28 @@ jobs:
       fail-fast: false
       matrix:
         artifact: ['minimal', 'makepkg-git', 'build-installers', 'full']
-        bitness: ['32', '64']
+        arch:
+          - name: i686
+            mingw-prefix: mingw32
+            msystem: MINGW32
+            sdk-repo: git-sdk-32
+          - name: x86_64
+            mingw-prefix: mingw64
+            msystem: MINGW64
+            sdk-repo: git-sdk-64
         exclude:
           - artifact: minimal
-            bitness: 32
+            arch:
+              name: i686
+              mingw-prefix: mingw32
+              msystem: MINGW32
+              sdk-repo: git-sdk-32
           - artifact: makepkg-git
-            bitness: 32
+            arch:
+              name: i686
+              mingw-prefix: mingw32
+              msystem: MINGW32
+              sdk-repo: git-sdk-32
     steps:
       - uses: actions/checkout@v4
       - name: initialize bare SDK clone
@@ -229,7 +245,7 @@ jobs:
           *) partial=--filter=blob:none;;
           esac &&
           git clone --bare --depth=1 --single-branch --branch=main $partial \
-            https://github.com/git-for-windows/git-sdk-${{ matrix.bitness }} .sdk
+            https://github.com/git-for-windows/${{ matrix.arch.sdk-repo }} .sdk
       - name: build ${{ matrix.artifact }} artifact
         id: build-artifact
         shell: bash
@@ -240,7 +256,7 @@ jobs:
             ;;
           *)
             ./please.sh create-sdk-artifact \
-              --bitness=${{ matrix.bitness }} \
+              --architecture=${{ matrix.arch.name }} \
               --sdk=.sdk \
               --out=sdk-artifact \
               ${{ matrix.artifact }}
@@ -249,34 +265,35 @@ jobs:
           echo "git-version=$(sdk-artifact/cmd/git.exe version)" >>$GITHUB_OUTPUT &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin/core_perl" >>$GITHUB_PATH &&
           cygpath -aw "$PWD/sdk-artifact/usr/bin" >>$GITHUB_PATH &&
-          cygpath -aw "$PWD/sdk-artifact/mingw${{ matrix.bitness }}/bin" >>$GITHUB_PATH &&
-          echo "MSYSTEM=MINGW${{ matrix.bitness }}" >>$GITHUB_ENV
+          cygpath -aw "$PWD/sdk-artifact/${{ matrix.arch.mingw-prefix }}/bin" >>$GITHUB_PATH &&
+          echo "MSYSTEM=${{ matrix.arch.msystem }}" >>$GITHUB_ENV &&
+          cat $GITHUB_PATH
       - name: build installer
         if: matrix.artifact == 'build-installers'
         shell: bash
-        run: ./installer/release.sh --include-self-check --output=$PWD/installer-${{ matrix.bitness }} 0-test
+        run: ./installer/release.sh --include-self-check --output=$PWD/installer-${{ matrix.arch.name }} 0-test
       - uses: actions/upload-artifact@v4
         if: matrix.artifact == 'build-installers'
         with:
-          name: installer-${{ matrix.bitness }}
-          path: installer-${{ matrix.bitness }}
+          name: installer-${{ matrix.arch.name }}
+          path: installer-${{ matrix.arch.name }}
       - name: run the installer
         if: matrix.artifact == 'build-installers'
         shell: pwsh
         run: |
-          $exePath = Get-ChildItem -Path installer-${{ matrix.bitness }}/*.exe | %{$_.FullName}
+          $exePath = Get-ChildItem -Path installer-${{ matrix.arch.name }}/*.exe | %{$_.FullName}
           $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
           $exitCode = $installer.ExitCode
           if ($exitCode -ne 0) {
             Write-Host "::error::Installer failed with exit code $exitCode!"
             exit 1
           }
-          if ("${{ matrix.bitness }}" -eq 32) {
+          if ("${{ matrix.arch.name }}" -eq "i686") {
             "${env:ProgramFiles(x86)}\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
-            "${env:ProgramFiles(x86)}\Git\mingw32\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+            "${env:ProgramFiles(x86)}\Git\${{ matrix.arch.mingw-prefix }}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
           } else {
             "$env:ProgramFiles\Git\usr\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
-            "$env:ProgramFiles\Git\mingw${{ matrix.bitness }}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
+            "$env:ProgramFiles\Git\${{ matrix.arch.mingw-prefix }}\bin" | Out-File -Encoding ascii -Append $env:GITHUB_PATH
           }
       - name: show installer log
         # run this even if the installation failed (actually, _in particular_ when the installation failed)

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -26,8 +26,9 @@ ARCH="$(uname -m)" ||
 die "Could not determine architecture"
 
 case "$ARCH" in
-i686) BITNESS=32;;
-x86_64) BITNESS=64;;
+i686) MINGW_PREFIX=mingw32;;
+x86_64) MINGW_PREFIX=mingw64;;
+aarch64) MINGW_PREFIX=clangarm64;;
 *) die "Unhandled architecture: $ARCH";;
 esac
 
@@ -46,9 +47,9 @@ unused_dlls_file=/tmp/unused-dlls.$$.txt
 tmp_file=/tmp/tmp.$$.txt
 trap "rm \"$used_dlls_file\" \"$missing_dlls_file\" \"$unused_dlls_file\" \"$tmp_file\"" EXIT
 
-all_files="$(export ARCH BITNESS && "$thisdir"/make-file-list.sh | tr A-Z a-z | grep -v '/getprocaddr64.exe$')" &&
+all_files="$(export ARCH && "$thisdir"/make-file-list.sh | tr A-Z a-z | grep -v '/getprocaddr64.exe$')" &&
 usr_bin_dlls="$(echo "$all_files" | grep '^usr/bin/[^/]*\.dll$')" &&
-mingw_bin_dlls="$(echo "$all_files" | grep '^mingw'$BITNESS'/bin/[^/]*\.dll$')" &&
+mingw_bin_dlls="$(echo "$all_files" | grep '^'$MINGW_PREFIX'/bin/[^/]*\.dll$')" &&
 dirs="$(echo "$all_files" | sed -n 's/[^/]*\.\(dll\|exe\)$//p' | sort | uniq)" &&
 for dir in $dirs
 do
@@ -57,7 +58,7 @@ do
 
 	case "$dir" in
 	usr/*) dlls="$sys_dlls$LF$usr_bin_dlls$LF";;
-	mingw$BITNESS/*) dlls="$sys_dlls$LF$mingw_bin_dlls$LF";;
+	$MINGW_PREFIX/*) dlls="$sys_dlls$LF$mingw_bin_dlls$LF";;
 	*) dlls="$sys_dlls$LF";;
 	esac
 

--- a/git-extra/Makefile
+++ b/git-extra/Makefile
@@ -21,7 +21,7 @@ $(BUILDDIR)/%.res: $(SRCDIR)/%.rc
 	$(WINDRES) --input $< --output $@ --output-format coff
 
 $(BUILDDIR)/WhoUses.exe: $(BUILDDIR)/WhoUses.o $(BUILDDIR)/SystemInfo.o
-	$(CXX) $(CXXFLAGS) -o $@ $(LDFLAGS) $^
+	$(CXX) $(CXXFLAGS) -o $@ $(LDFLAGS) $^ -lmsvcrt-os
 
 $(BUILDDIR)/WhoUses.o: $(SRCDIR)/WhoUses.cpp $(SRCDIR)/SystemInfo.h
 $(BUILDDIR)/SystemInfo.o: $(SRCDIR)/SystemInfo.cpp $(SRCDIR)/SystemInfo.h

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.641.031e03baf
+pkgver=1.1.643.38774dcc1
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -21,7 +21,7 @@ pkgver() {
   test ! -f "$(git rev-parse --git-path shallow)" || git -c http.sslbackend fetch --unshallow
   rev="$(git rev-list -1 HEAD -- .)"
   test -n "$(git show . |
-    sed -n -e '1,/^@@/d' -e '/^[-+]pkgver=/d' -e '/^[-+]/p')" ||
+    sed -n -e '1,/^@@/d' -e '/^[-+]pkgver=/d' -e '/^[-+]pkgver=/d' -e "/^[-+] *'[0-9a-f]\{64\}'$/d" -e '/^[-+]/p')" ||
   rev="$(git rev-list -1 $rev^ -- .)"
   printf "%s.%s.%s" "${_ver_base}" "$(git rev-list --count $rev -- .)" \
     "$(git rev-parse --short=9 $rev)"

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.643.38774dcc1
+pkgver=1.1.646.1654659da
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')
@@ -68,7 +68,7 @@ sha256sums=('8ed76d1cb069ac8568f21c431f5e23caebea502d932ab4cdff71396f4f0d5b72'
             '3cd83627f1d20e1108533419fcf33c657cbcf777c3dc39fa7f13748b7d63858a'
             'd51229e5ec3653782a2c09aa5ad9af8f159aba94bc28498d7f358c33399b313d'
             '4716d520e7e6e0a1281bad1ae4c21e3e6442127c3030d27681162b9c40aa6b9d'
-            '937e25c096e0fa91f86f689a00a5bf5442c2333fbedab30239a935e682ae2e80'
+            '6d2e4285f5671247598446fb1876a137741b7ec87bfe1d7edbd2dc522918df60'
             'd212e1bbe75a9f81443126701324c9c44c3ed5750dd9822eba754a1799ed13b3'
             '402c51eba82453a76f5110f4754bb1005df507a6e4532574c2b9627ff4e1dc81'
             '8433a9e72b3bc9c3bc7903b54b868399bdb17a6c8de4af4dd5450dd42859c898'

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -297,6 +297,13 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	# Work around /etc/xml/catalog being updated using the MINGW version of xmlcatalog
 	! grep -q '"[CD]:/' /etc/xml/catalog ||
 	sed -i -e 's|"[CD]:/[^"]*/usr/|"/usr/|g' /etc/xml/catalog
+
+	# Work around an outdated i686 gnupg/gnutls build that depends on a hence-updated libunistring
+	if test i686 = $arch -a ! -e /usr/bin/msys-unistring-2.dll -a -e /usr/bin/msys-unistring-5.dll &&
+		grep msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null
+	then
+		cp /usr/bin/msys-unistring-5.dll /usr/bin/msys-unistring-2.dll
+	fi
 }
 
 post_upgrade () {

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -263,6 +263,13 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	# Work around /etc/xml/catalog being updated using the MINGW version of xmlcatalog
 	! grep -q '"[CD]:/' /etc/xml/catalog ||
 	sed -i -e 's|"[CD]:/[^"]*/usr/|"/usr/|g' /etc/xml/catalog
+
+	# Work around an outdated i686 gnupg/gnutls build that depends on a hence-updated libunistring
+	if test i686 = $arch -a ! -e /usr/bin/msys-unistring-2.dll -a -e /usr/bin/msys-unistring-5.dll &&
+		grep msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null
+	then
+		cp /usr/bin/msys-unistring-5.dll /usr/bin/msys-unistring-2.dll
+	fi
 }
 
 post_upgrade () {

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -187,6 +187,13 @@ then
 		mingw-w64-$PACMAN_ARCH-antiword mingw-w64-$PACMAN_ARCH-odt2txt ssh-pageant
 		mingw-w64-$PACMAN_ARCH-git-lfs mingw-w64-$PACMAN_ARCH-xz tig $GIT_UPDATE_EXTRA_PACKAGES"
 fi
+
+I686_EXCLUDE=
+if test i686 = "$ARCH" && ! grep msys-uuid-1 /usr/bin/msys-apr-1-0.dll 2>&1 >/dev/null
+then
+	I686_EXCLUDE='uuid\|lzma\|'
+fi
+
 pacman_list $packages "$@" |
 
 grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
@@ -234,10 +241,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/\(mingw\|clang\)[^/]*/share/gtk-doc/' \
 	-e '^/\(mingw\|clang\)[^/]*/share/nghttp2/' \
 	-e '^/usr/bin/msys-\(db\|curl\|icu\|gfortran\|stdc++\|quadmath\)[^/]*\.dll$' \
-	-e '^/usr/bin/msys-\('$(if test i686 = "$ARCH"
-	    then
-		echo 'uuid\|lzma\|'
-	    fi)'fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
+	-e '^/usr/bin/msys-\('"$I686_EXCLUDE"'fdisk\|gettextpo\|gmpxx\|gnutlsxx\|gomp\|xml2\|xslt\|exslt\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(hdb\|history8\|kadm5\|kdc\|otp\|sl\).*\.dll$' \
 	-e '^/usr/bin/msys-\(atomic\|blkid\|charset\|gthread\|metalink\|nghttp2\|ssh2\|kafs\)-.*\.dll$' \
 	-e '^/usr/bin/msys-\(ncurses++w6\|asprintf-[0-9]*\|\)\.dll$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -404,10 +404,22 @@ usr/bin/dash.exe
 usr/bin/getopt.exe
 EOF
 
+EXTRA_DLL_FILES=
 case $MSYSTEM_LOWER in
 mingw*)
 	PDFTOTEXT_FILES="$MSYSTEM_LOWER/bin/pdftotext.exe
 $MSYSTEM_LOWER/bin/libstdc++-6.dll"
+	if test i686 = "$ARCH" &&
+		grep msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null &&
+		test ! -d /var/lib/pacman/local/libunistring-0*-1
+	then
+		# Utter hack: i686 gnupg might still link to msys-unistring-2.dll
+		test -f /usr/bin/msys-unistring-2.dll ||
+		cp /usr/bin/msys-unistring-5.dll /usr/bin/msys-unistring-2.dll ||
+		die "Could not fudge msys-unistring-2.dll"
+		EXTRA_DLL_FILES='
+usr/bin/msys-unistring-2.dll'
+	fi
 	;;
 *)
 	# In the clang version, we do not need the libstdc++ DLL
@@ -421,7 +433,7 @@ etc/post-install/01-devices.post
 etc/post-install/03-mtab.post
 etc/post-install/06-windows-files.post
 usr/bin/start
-$PDFTOTEXT_FILES
+$PDFTOTEXT_FILES$EXTRA_DLL_FILES
 usr/bin/column.exe
 EOF
 

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -248,6 +248,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/bin/msys-\(formw6\|menuw6\|panelw6\)\.dll$' \
 	-e '^/usr/bin/msys-svn_swig_\(py\|ruby\)-.*\.dll$' \
 	-e '^/usr/bin/\(dumper\|sasl.*\|sshd\)\.exe$' \
+	-e '^/usr/bin/.*lastlog2' \
 	-e '^/usr/lib/gio/' -e '^/usr/lib/sasl2/msys-sasldb-.*\.dll$' \
 	-e '^/usr/lib/\(itcl\|tdbc\|pkcs11/p11-kit-client\|thread\)' \
 	-e '^/usr/lib/ssh/sshd\($\|-\)' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -27,8 +27,7 @@ aarch64)
 esac
 
 SH_FOR_REBASE=dash
-PACKAGE_EXCLUDES="db info heimdal tcl git util-linux curl git-for-windows-keyring
-	mingw-w64-p11-kit"
+PACKAGE_EXCLUDES="db info heimdal tcl git util-linux curl git-for-windows-keyring"
 EXTRA_FILE_EXCLUDES=
 UTIL_PACKAGES="sed awk grep findutils coreutils"
 if test -n "$MINIMAL_GIT_WITH_BUSYBOX"
@@ -49,7 +48,7 @@ fi
 if test -n "$MINIMAL_GIT"
 then
 	PACKAGE_EXCLUDES="$PACKAGE_EXCLUDES mingw-w64-bzip2 mingw-w64-c-ares
-		mingw-w64-libsystre mingw-w64-libtre-git
+		mingw-w64-libsystre mingw-w64-libtre-git mingw-w64-p11-kit
 		mingw-w64-tcl mingw-w64-tk mingw-w64-wineditline gdbm icu libdb
 		libedit libgdbm perl perl-.*"
 fi
@@ -108,6 +107,7 @@ pacman_list () {
 		do
 			pactree -u "$arg"
 		done |
+		sed 's/>.*//' |
 		grep -v "^\\($(echo $PACKAGE_EXCLUDES | sed \
 			-e 's/ /\\|/g' \
 			-e 's/mingw-w64-/&\\(i686\\|x86_64\\|clang-aarch64\\)-/g')\\)\$" |
@@ -210,7 +210,6 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/include/' -e '^/\(mingw\|clang\)[^/]*/include/' \
 	-e '^/usr/share/doc/' \
 	-e '^/usr/share/info/' -e '^/\(mingw\|clang\)[^/]*/share/info/' \
-	-e '^/mingw32/bin/lib\(ffi\|tasn1\)-.*\.dll$' \
 	-e '^/\(mingw\|clang\)[^/]*/share/git-doc/technical/' \
 	-e '^/\(mingw\|clang\)[^/]*/lib/cmake/' \
 	-e '^/\(mingw\|clang\)[^/]*/itcl/' \

--- a/please.sh
+++ b/please.sh
@@ -3255,8 +3255,10 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		/usr/bin/msys-pcre*.dll
 		/usr/bin/msys-gcc_s-*.dll
 
-		# For the libuuid check
+		# For the libuuid/libunistring check
 		/usr/bin/msys-apr*.dll
+		/usr/bin/msys-unistring*.dll
+		/usr/bin/msys-gnutls*.dll
 
 		# markdown, to render the release notes
 		/usr/bin/markdown
@@ -3280,6 +3282,15 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 			# copy git.exe, for the libssp test
 			git -C "$output_path" show HEAD:mingw32/bin/git.exe \
 				>"$output_path/mingw32/bin/git.exe" &&
+			# Work around an outdated i686 gnupg/gnutls build that depends on a hence-updated libunistring
+			if test ! -e "$output_path/usr/bin/msys-unistring-2.dll" -a \
+				-e "$output_path/usr/bin/msys-unistring-5.dll" -a \
+				-e "$output_path/usr/bin/msys-gnutls-30.dll" &&
+				grep msys-unistring-2 "$output_path/usr/bin/msys-gnutls-30.dll"
+			then
+				cp "$output_path/usr/bin/msys-unistring-5.dll" \
+					"$output_path/usr/bin/msys-unistring-2.dll"
+			fi &&
 			ARCH=i686 "$output_path/git-cmd.exe" --command=usr\\bin\\sh.exe -lx \
 			"${this_script_path%/*}/make-file-list.sh" |
 			# escape the `[` in `[.exe`

--- a/please.sh
+++ b/please.sh
@@ -3255,6 +3255,9 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		/usr/bin/msys-pcre*.dll
 		/usr/bin/msys-gcc_s-*.dll
 
+		# For the libuuid check
+		/usr/bin/msys-apr*.dll
+
 		# markdown, to render the release notes
 		/usr/bin/markdown
 


### PR DESCRIPTION
As of yesterday, the [`check-for-missing-dlls` job in `git-sdk-32`](https://github.com/git-for-windows/git-sdk-32/actions/workflows/check-for-missing-dlls.yml) is failing, and only in that `git-sdk-*` repository. The culprit is [this monster of a commit](https://github.com/git-for-windows/git-sdk-32/commit/e9756b51a5ffb7dac5948e7a005c520f3a602be2) that you should not try to load in the browser, as GitHub fails thusly:

![image](https://github.com/user-attachments/assets/b34da540-923c-466d-a768-e0e96468a556)

<details><summary>Here is the commit message in its full glory</summary>

```
Update 169 packages

apr (1.7.0-1 -> 1.7.5-1)
apr-util (1.6.1-1 -> 1.6.3-2)
asciidoc (9.1.0-2 -> 10.2.1-2)
autoconf-wrapper (new: 20240607-1)
autoconf2.13 (2.13-3 -> 2.13-6)
autoconf (2.71-1 -> 2.69-4)
autoconf2.71 (new: 2.71-4)
autoconf2.72 (new: 2.72-3)
autogen (5.18.16-1 -> 5.18.16-5)
automake-wrapper (11-1 -> 20240607-1)
automake1.11 (1.11.6-4 -> 1.11.6-6)
automake1.12 (1.12.6-4 -> 1.12.6-6)
automake1.13 (1.13.4-5 -> 1.13.4-7)
automake1.14 (1.14.1-4 -> 1.14.1-6)
automake1.15 (1.15.1-2 -> 1.15.1-4)
automake1.16 (1.16.3-1 -> 1.16.5-1)
automake1.17 (new: 1.17-1)
bash-completion (2.11-1 -> 2.16.0-1)
binutils (2.36.1-4 -> 2.44-1)
bison (3.7.6-1 -> 3.8.2-5)
bsdcpio (3.5.1-1 -> 3.7.7-1)
bsdtar (3.5.1-1 -> 3.7.7-1)
bzip2 (1.0.8-2 -> 1.0.8-4)
coreutils (8.32-1 -> 8.32-5)
dash (0.5.11.4-1 -> 0.5.12-1)
diffstat (1.64-1 -> 1.67-1)
diffutils (3.7-1 -> 3.10-1)
docbook-xml (4.5-2 -> 4.5-4)
docbook-xsl (1.79.2-1 -> 1.79.2-3)
docx2txt (1.4-1 -> 1.4-2)
dos2unix (7.4.2-1 -> 7.5.2-1)
expat (2.3.0-1 -> 2.6.4-1)
file (5.40-2 -> 5.46-1)
filesystem (2021.06-1 -> 2024.12.18-1)
findutils (4.8.0-1 -> 4.10.0-2)
flex (2.6.4-1 -> 2.6.4-4)
gcc (10.2.0-1 -> 13.3.0-1)
gcc-fortran (removed)
gcc-libs (10.2.0-1 -> 13.3.0-1)
gdb (10.2-3 -> 14.2-7)
gdbm (1.19-1 -> 1.24-1)
gettext (0.19.8.1-1 -> 0.22.4-1)
gettext-devel (0.19.8.1-1 -> 0.22.4-1)
git (2.32.0-1 -> 2.48.1-1)
glib2 (2.68.1-1 -> 2.82.4-1)
gmp (6.2.1-1 -> 6.3.0-1)
grep (3.1-1 -> 1~3.0-7)
groff (1.22.4-1 -> 1.23.0-2)
help2man (1.48.3-1 -> 1.49.3-1)
icu (68.2-1 -> 75.1-2)
info (6.7-3 -> 7.1.1-1)
isl (0.22.1-1 -> 0.27-1)
libarchive (3.5.1-1 -> 3.7.7-1)
libasprintf (0.19.8.1-1 -> 0.22.4-1)
libassuan (2.5.5-1 -> 2.5.7-1)
libatomic_ops (7.6.10-1 -> 7.8.2-1)
libbz2 (1.0.8-2 -> 1.0.8-4)
libedit (20210522_3.1-1 -> 20240808_3.1-1)
libexpat (2.3.0-1 -> 2.6.4-1)
libffi (3.3-1 -> 3.4.6-1)
libgc (8.0.4-1 -> 8.2.8-1)
libgdbm (1.19-1 -> 1.24-1)
libgettextpo (0.19.8.1-1 -> 0.22.4-1)
libgpgme (1.16.0-1 -> 1.24.1-2)
libguile (2.2.7-1 -> 3.0.10-3)
libhogweed (3.7.3-1 -> 3.10.1-1)
libiconv (1.16-2 -> 1.18-1)
libiconv-devel (1.16-2 -> 1.18-1)
libidn2 (2.3.1-2 -> 2.3.7-1)
libintl (0.19.8.1-1 -> 0.22.4-1)
libltdl (2.4.6-11 -> 2.5.4-1)
liblz4 (1.9.3-1 -> 1.10.0-1)
liblzma (5.2.5-1 -> 5.6.4-1)
liblzo2 (2.10-2 -> 2.10-3)
libnettle (3.7.3-1 -> 3.10.1-1)
libnghttp2 (1.43.0-1 -> 1.64.0-1)
libnpth (1.6-1 -> 1.8-1)
libp11-kit (0.23.22-2 -> 0.25.5-2)
libpcre (8.45-1 -> 8.45-5)
libpcre16 (8.45-1 -> 8.45-5)
libpcre32 (8.45-1 -> 8.45-5)
libpcrecpp (8.45-1 -> 8.45-5)
libpcreposix (8.45-1 -> 8.45-5)
libpipeline (1.5.3-2 -> 1.5.8-1)
libpsl (0.21.1-2 -> 0.21.5-2)
libreadline (8.1.0-1 -> 8.2.013-1)
libsqlite (3.36.0-1 -> 3.46.1-1)
libtasn1 (4.17.0-2 -> 4.19.0-1)
libtool (2.4.6-11 -> 2.5.4-1)
libunistring (0.9.10-1 -> 1.3-1)
libunrar (6.0.7-1 -> 7.1.3-1)
libutil-linux (2.35.2-1 -> 2.35.2-5)
libxcrypt (new: 4.4.38-1)
libxml2 (2.9.10-9 -> 2.13.5-1)
libxslt (1.1.34-4 -> 1.1.42-1)
libxxhash (0.8.0-1 -> 0.8.3-1)
libzstd (1.5.0-1 -> 1.5.6-1)
lndir (1.0.3-1 -> 1.0.5-1)
m4 (1.4.19-1 -> 1.4.19-2)
make (4.3-1 -> 4.4.1-2)
man-db (2.9.4-1 -> 2.13.0-1)
markdown (1.0.1-1 -> 1.0.1-2)
mpc (1.2.1-1 -> 1.3.1-1)
mpdecimal (2.5.0-1 -> 4.0.0-1)
mpfr (4.1.0-1 -> 4.2.1-1)
msys2-keyring (1~20210213-2 -> 1~20241007-1)
msys2-launcher (1.3-2 -> 1.5-3)
msys2-w32api-headers (9.0.0.6158.1c773877-1 -> 12.0.0.r0.g819a6ec2e-2)
msys2-w32api-runtime (9.0.0.6158.1c773877-1 -> 12.0.0.r0.g819a6ec2e-2)
ncurses (6.2-1 -> 6.5.20240831-2)
nettle (3.7.3-1 -> 3.10.1-1)
p11-kit (0.23.22-2 -> 0.25.5-2)
pacman (6.0.0-4 -> 6.1.0-10)
pacman-contrib (1.4.0-2 -> 1.10.6-1)
pacman-mirrors (20210703-1 -> 20241217-1)
patch (2.7.6-1 -> 2.7.6-3)
patchutils (0.4.2-1 -> 0.4.2-3)
pcre (8.45-1 -> 8.45-5)
perl-Authen-SASL (2.16-2 -> 2.1700-1)
perl-Convert-BinHex (1.125-1 -> 1.125-2)
perl-Encode-Locale (1.05-1 -> 1.05-2)
perl-Error (0.17029-1 -> 0.17029-2)
perl-File-Listing (6.14-1 -> 6.16-1)
perl-HTML-Tagset (3.20-2 -> 3.24-1)
perl-HTTP-Cookies (6.09-1 -> 6.11-1)
perl-HTTP-Daemon (6.12-1 -> 6.16-1)
perl-HTTP-Date (6.05-1 -> 6.06-1)
perl-HTTP-Message (6.32-1 -> 7.00-1)
perl-HTTP-Negotiate (6.01-2 -> 6.01-3)
perl-IO-HTML (1.004-1 -> 1.004-2)
perl-IO-Socket-SSL (2.071-1 -> 2.089-1)
perl-IO-Stringy (2.113-1 -> 2.113-2)
perl-JSON (4.03-1 -> 4.10-1)
perl-LWP-MediaTypes (6.04-1 -> 6.04-2)
perl-MIME-tools (5.509-1 -> 5.515-1)
perl-MailTools (2.21-1 -> 2.22-1)
perl-Module-Build (0.4231-1 -> 0.4234-2)
perl-Net-HTTP (6.21-1 -> 6.23-1)
perl-Net-SMTP-SSL (1.04-1 -> 1.04-2)
perl-Test-Pod (1.52-1 -> 1.52-2)
perl-TimeDate (2.33-1 -> 2.33-2)
perl-Try-Tiny (0.30-1 -> 0.32-1)
perl-URI (5.09-1 -> 5.31-1)
perl-WWW-RobotRules (6.02-2 -> 6.02-3)
perl-http-cookiejar (new: 0.014-1)
perl-inc-latest (0.500-1 -> 0.500-2)
perl-libwww (6.55-1 -> 6.77-1)
pinentry (1.1.1-1 -> 1.3.1-1)
pkgfile (21-1 -> 21-2)
python (3.9.5-1 -> 3.12.8-3)
rebase (4.5.0-1 -> 4.5.0-4)
rsync (3.2.3-1 -> 3.4.1-1)
sed (4.8-1 -> 4.9-1)
ssh-pageant-git (1.4.12.g6f47092-1 -> 1.4.r15.gc804ba4-1)
swig (4.0.2-1 -> 4.2.1-1)
tar (1.34-1 -> 1.35-2)
tcl (8.6.10-1 -> 8.6.12-3)
time (1.9-1 -> 1.9-3)
tzcode (2021a-1 -> 2025a-1)
unrar (6.0.7-1 -> 7.1.3-1)
unzip (6.0-2 -> 6.0-3)
util-linux (2.35.2-1 -> 2.35.2-5)
which (2.21-2 -> 2.21-4)
windows-default-manifest (6.4-1 -> 6.4-2)
winpty (0.4.3-1 -> 0.4.3-3)
xmlto (0.0.28-2 -> 0.0.29-1)
xxhash (0.8.0-1 -> 0.8.3-1)
xz (5.2.5-1 -> 5.6.4-1)
zstd (1.5.0-1 -> 1.5.6-1)

Signed-off-by: Git for Windows Build Agent <ci@git-for-windows.build>
```

</details>

Essentially, it is the consequence of a big, huge sync of MSYS2's i686 repository of MSYS packages, and unsurprisingly, a couple of things fail now.

Let's only work around them in the quickest manner, as Git for Windows v2.48.1 is intended to be the last release with full i686 support. After this release, there will only be MinGit artifacts for that CPU architecture, and we can save ourselves the effort of fixing things up properly.