### PR TITLE
git-extra(i686): remove libunistring workaround

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.646.1654659da
+pkgver=1.1.649.af5925057
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -298,11 +298,12 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	! grep -q '"[CD]:/' /etc/xml/catalog ||
 	sed -i -e 's|"[CD]:/[^"]*/usr/|"/usr/|g' /etc/xml/catalog
 
-	# Work around an outdated i686 gnupg/gnutls build that depends on a hence-updated libunistring
-	if test i686 = $arch -a ! -e /usr/bin/msys-unistring-2.dll -a -e /usr/bin/msys-unistring-5.dll &&
-		grep msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null
+	# Remove work around for an outdated i686 gnupg/gnutls build that depended on a hence-updated libunistring
+	if test i686 = $arch -a -e /usr/bin/msys-unistring-2.dll &&
+		! pacman -Qoq /usr/bin/msys-unistring-2.dll >/dev/null 2>&1 &&
+		! grep -q msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null
 	then
-		cp /usr/bin/msys-unistring-5.dll /usr/bin/msys-unistring-2.dll
+		rm /usr/bin/msys-unistring-2.dll
 	fi
 }
 

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -264,11 +264,12 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	! grep -q '"[CD]:/' /etc/xml/catalog ||
 	sed -i -e 's|"[CD]:/[^"]*/usr/|"/usr/|g' /etc/xml/catalog
 
-	# Work around an outdated i686 gnupg/gnutls build that depends on a hence-updated libunistring
-	if test i686 = $arch -a ! -e /usr/bin/msys-unistring-2.dll -a -e /usr/bin/msys-unistring-5.dll &&
-		grep msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null
+	# Remove work around for an outdated i686 gnupg/gnutls build that depended on a hence-updated libunistring
+	if test i686 = $arch -a -e /usr/bin/msys-unistring-2.dll &&
+		! pacman -Qoq /usr/bin/msys-unistring-2.dll >/dev/null 2>&1 &&
+		! grep -q msys-unistring-2 /usr/bin/msys-gnutls-30.dll 2>&1 >/dev/null
 	then
-		cp /usr/bin/msys-unistring-5.dll /usr/bin/msys-unistring-2.dll
+		rm /usr/bin/msys-unistring-2.dll
 	fi
 }
 


### PR DESCRIPTION
After git-for-windows/MSYS2-packages#219 the extra file is no longer needed.