### PR TITLE
make-file-list.sh: future-proof the `pactree` output parsing

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -107,7 +107,7 @@ pacman_list () {
 		do
 			pactree -u "$arg"
 		done |
-		sed 's/>.*//' |
+		sed 's/[<>=].*//' |
 		grep -v "^\\($(echo $PACKAGE_EXCLUDES | sed \
 			-e 's/ /\\|/g' \
 			-e 's/mingw-w64-/&\\(i686\\|x86_64\\|clang-aarch64\\)-/g')\\)\$" |


### PR DESCRIPTION
@jeremyd2019 I basically took your suggestion from https://github.com/git-for-windows/build-extra/pull/591#discussion_r1955266697, ghost-wrote a commit message, and opened this PR. What do you think? Okay?