### PR TITLE
pacman-helper.sh quick_remove: skip uploading package files

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -551,7 +551,7 @@ quick_action () { # <action> <file>...
 		sed -n 's/^  "id": *\([0-9]*\).*/\1/p')"
 	fi ||
 	die "Could not create a draft release for tag $tagname"
-	for path in $all_files $dbs
+	for path in $(test remove = "$label" || echo $all_files) $dbs
 	do
 		if test -n "$PACMANDRYRUN"
 		then
@@ -583,7 +583,7 @@ quick_action () { # <action> <file>...
 
 	# Upload the file(s) and the appropriate index(es)
 	(cd "$dir" &&
-	 for path in $all_files $dbs
+	 for path in $(test remove = "$label" || echo $all_files) $dbs
 	 do
 		# The Pacman repository on Azure Blobs still uses the old naming scheme
 		remote_path="$(echo "$path" | sed \


### PR DESCRIPTION
The (dual) strategy of the new Pacman repository is to not only publish the latest state in the `x86_64`, `aarch64` and `i686` branches, but also to upload the files in the latest update to a GitHub Release.

Naturally, when adding a new package version, the package archive and its PGP signature need to be included in that Release.

However, when _removing_ a package, the corresponding package archive should of course be omitted ;-)