### PR TITLE
make-file-list: do not expect /etc/bash.bash_logout to exist

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -395,15 +395,19 @@ EOF
 test -z "$MINIMAL_GIT_WITH_BUSYBOX" ||
 echo $MSYSTEM_LOWER/bin/busybox.exe
 
-test -n "$MINIMAL_GIT_WITH_BUSYBOX" || cat <<EOF
-etc/profile
-etc/profile.d/lang.sh
-etc/bash.bash_logout
-etc/bash.bashrc
-etc/msystem
-usr/bin/dash.exe
-usr/bin/getopt.exe
-EOF
+if test -z "$MINIMAL_GIT_WITH_BUSYBOX"
+then
+	cat <<-EOF
+	etc/profile
+	etc/profile.d/lang.sh
+	etc/bash.bashrc
+	etc/msystem
+	usr/bin/dash.exe
+	usr/bin/getopt.exe
+	EOF
+	test ! -f /etc/bash.bash_logout ||
+	echo etc/bash.bash_logout
+fi
 
 EXTRA_DLL_FILES=
 case $MSYSTEM_LOWER in

--- a/please.sh
+++ b/please.sh
@@ -3260,6 +3260,9 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		/usr/bin/msys-unistring*.dll
 		/usr/bin/msys-gnutls*.dll
 
+		# For the /etc/bash.bash_logout check
+		/etc/bash.bash_logout
+
 		# markdown, to render the release notes
 		/usr/bin/markdown
 


### PR DESCRIPTION
As of `filesystem` 2025.02.23-1, that file does not exist anymore. So let's not insist on its presence when building Git for Windows' artifacts.

This fixes [the currently failing `git-artifacts` workflow](https://github.com/git-for-windows/git-sdk-64/actions/runs/13535776680/job/37827746211#step:6:54320).