### PR TITLE
pacman-helper.sh: set release name to be the same as tagname

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -546,7 +546,7 @@ quick_action () { # <action> <file>...
 		echo "Would create a GitHub Release '$tagname' at git-for-windows/pacman-repo" >&2
 	else
 		id="$(curl -H "Authorization: Bearer $GITHUB_TOKEN" -sfL --show-error -XPOST -d \
-			'{"tag_name":"'"$tagname"'","draft":true,"prerelease":true}' \
+			'{"tag_name":"'"$tagname"'","name":"'"$tagname"'","draft":true,"prerelease":true}' \
 			"https://api.github.com/repos/git-for-windows/pacman-repo/releases" |
 		sed -n 's/^  "id": *\([0-9]*\).*/\1/p')"
 	fi ||


### PR DESCRIPTION
I noticed the latest release created picked up its name from the latest commit to the main branch in the pacman-repo repository, namely "2025-02-26T22-44-26.725080300Z: Merge pull request #1 from git-for-windows/populate-the-readme".  Given that it's very unlikely that the commit(s) on the main branch have anything to do with the releases, just specify the name to be the same as the tagname.

When I use `gh release create` to create releases, in order to suppress this behavior, I have to specify `--title` as well as the tag.  It seems the REST API equivalent is `name`

example:
```
gh release create "$timestamp" --title "$timestamp" --notes "" -R ${{ github.repository }} 
```

(I didn't bother trying to specify empty notes, I think you get the same behavior in the REST api by not specifying them)