### PR TITLE
pacman-helper.sh: fix usage of release notes file

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -349,7 +349,7 @@ quick_action () { # <action> <file>...
 	test -z "$GPGKEY" || sign_option=--sign
 	dbs=
 	to_push=
-	>release_notes.txt
+	>"$dir/release_notes.txt"
 	for arch in $architectures
 	do
 		eval "msys=\$${arch}_msys"
@@ -456,14 +456,14 @@ quick_action () { # <action> <file>...
 				"$(printf '%s\n' $msys $mingw |
 					sed 's/^\(.*\)-\([^-]*-[^-]*\)-[^-]*\.pkg\.tar\.\(xz\|zst\)$/\1 -> \2/')")"
 			printf '%s\n' $msys $mingw |
-			sed 's/^\(.*\)-\([^-]*-[^-]*\)-[^-]*\.pkg\.tar\.\(xz\|zst\)$/* \1 -> \2/' >>release-notes.txt
+			sed 's/^\(.*\)-\([^-]*-[^-]*\)-[^-]*\.pkg\.tar\.\(xz\|zst\)$/* \1 -> \2/' >>"$dir/release_notes.txt"
 			;;
 		 remove)
 			 msg="$(printf 'Remove %s package(s)\n\n%s\n' \
 				$(printf '%s\n' $msys $mingw | wc -l) \
 				"$(printf '%s\n' $msys $mingw)")"
 			printf '%s\n' $msys $mingw |
-			sed 's/^/* dropped /' >>release-notes.txt
+			sed 's/^/* dropped /' >>"$dir/release_notes.txt"
 			;;
 		 esac &&
 		 git commit -asm "$msg") ||
@@ -551,7 +551,7 @@ quick_action () { # <action> <file>...
 	then
 		echo "Would create a GitHub Release '$tagname' at git-for-windows/pacman-repo" >&2
 	else
-		body="$(sed -z 's/[\"]/\\&/g;s/\n/\\n/g' release-notes.txt)"
+		body="$(sed -z 's/[\"]/\\&/g;s/\n/\\n/g' "$dir/release_notes.txt")"
 		id="$(curl -H "Authorization: Bearer $GITHUB_TOKEN" -sfL --show-error -XPOST -d \
 			'{"tag_name":"'"$tagname"'","name":"'"$tagname"'","body":"'"$body"'","draft":true,"prerelease":true}' \
 			"https://api.github.com/repos/git-for-windows/pacman-repo/releases" |


### PR DESCRIPTION
The empty file was created as release_notes.txt in the CWD, while it was written to as release-notes.txt in $dir/$arch subdirectories, and ultimately read as release-notes.txt I believe in the CWD again.  Get rid of the ambiguity by always referencing it as
"$dir/release_notes.txt"
