### PR TITLE
Fix `nano`'s syntax coloring

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -19,8 +19,8 @@ install='git-extra.install'
 pkgver() {
   cd "$startdir"
   test ! -f "$(git rev-parse --git-path shallow)" || git -c http.sslbackend fetch --unshallow
-  rev="$(git rev-list -1 HEAD -- .)"
-  test -n "$(git show . |
+  rev="$(git rev-list -1 HEAD -- . ':(exclude)./git-extra.install')"
+  test -n "$(git show . ':(exclude)./git-extra.install' |
     sed -n -e '1,/^@@/d' -e '/^[-+]pkgver=/d' -e '/^[-+]pkgver=/d' -e "/^[-+] *'[0-9a-f]\{64\}'$/d" -e '/^[-+]/p')" ||
   rev="$(git rev-list -1 $rev^ -- .)"
   printf "%s.%s.%s" "${_ver_base}" "$(git rev-list --count $rev -- .)" \

--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.649.af5925057
+pkgver=1.1.653.48e2403b3
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -120,7 +120,7 @@ GITATTRIBUTES
 	grep -q "$otherpacman" etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
 
-	test -z "$(find /clangarm64 -type f -print -quit)" || # if /clangarm64 exists and contains at least one file
+	test -z "$(find /clangarm64 -type f -print -quit 2>/dev/null)" || # if /clangarm64 exists and contains at least one file
 	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
 	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
 
@@ -247,10 +247,12 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	}
 
 	# Enable color and syntax-highlighting in GNU nano
-	test ! -f /etc/nanorc ||
-	grep -q '^set titlecolor' /etc/nanorc ||
-	sed -i -e '/Paint the interface elements/,/root.s .nanorc/s/^# //' \
-		-e 's/^# \(include .*nanorc"\)$/\1/' /etc/nanorc
+	test ! -f /etc/nanorc || {
+		grep -q '^set titlecolor' /etc/nanorc ||
+		sed -i '/Paint the interface elements/,/root.s .nanorc/s/^# //' /etc/nanorc
+		grep -q '^include .*\*\.nanorc' /etc/nanorc ||
+		sed -i 's/^# \(include .*\*\.nanorc"\?\)$/\1/' /etc/nanorc
+	}
 
 	# Do not require /usr/bin/cmd in /usr/bin/start
 	grep -q '^"\$COMSPEC" ' /usr/bin/start ||

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -213,10 +213,12 @@ test -d "$TMPDIR" || test ! -d "$TMP" || {\
 	}
 
 	# Enable color and syntax-highlighting in GNU nano
-	test ! -f /etc/nanorc ||
-	grep -q '^set titlecolor' /etc/nanorc ||
-	sed -i -e '/Paint the interface elements/,/root.s .nanorc/s/^# //' \
-		-e 's/^# \(include .*nanorc"\)$/\1/' /etc/nanorc
+	test ! -f /etc/nanorc || {
+		grep -q '^set titlecolor' /etc/nanorc ||
+		sed -i '/Paint the interface elements/,/root.s .nanorc/s/^# //' /etc/nanorc
+		grep -q '^include .*\*\.nanorc' /etc/nanorc ||
+		sed -i 's/^# \(include .*\*\.nanorc"\?\)$/\1/' /etc/nanorc
+	}
 
 	# Do not require /usr/bin/cmd in /usr/bin/start
 	grep -q '^"\$COMSPEC" ' /usr/bin/start ||

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -86,7 +86,7 @@ GITATTRIBUTES
 	grep -q "$otherpacman" etc/pacman.conf ||
 	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
 
-	test -z "$(find /clangarm64 -type f -print -quit)" || # if /clangarm64 exists and contains at least one file
+	test -z "$(find /clangarm64 -type f -print -quit 2>/dev/null)" || # if /clangarm64 exists and contains at least one file
 	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
 	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
 


### PR DESCRIPTION
A change in nano v8.2 rendered Git for Windows' logic to enable syntax coloring in `nano` non-functional. Let's fix this, along with a couple other minor things I found on the way.

This fixes https://github.com/git-for-windows/git/issues/5462