### PR TITLE
ReleaseNotes: stop mentioning certificates that aren't bundled

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -35,8 +35,6 @@ Should you encounter other problems, please first search [the bug tracker](https
 ## Licenses
 Git is licensed under the GNU General Public License version 2.
 
-Git for Windows also contains Embedded CAcert Root Certificates. For more information please go to [https://www.cacert.org/policy/RootDistributionLicense.php](https://www.cacert.org/policy/RootDistributionLicense.php).
-
 Git for Windows is distributed with other components yet, such as Bash, zlib, curl, tcl/tk, perl, MSYS2. Each of these components is governed by their respective license.
 
 ## Changes since Git for Windows v2.48.1 (February 13th 2025)


### PR DESCRIPTION
Ever since the switch from MSys/MinGW to MSYS2/MINGW in 2015, i.e. almost 10 years ago, Git for Windows hasn't bundled the certificates that were specifically mentioned in the release notes.

They were introduced via https://github.com/msysgit/msysgit/issues/37, which is _such_ a blast from a more pleasant past. But since the certificates aren't included any more, we should not claim that we do in the release notes, either.