### PR TITLE
Uninstall Git for Windows more thoroughly

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -235,6 +235,7 @@ Type: files; Name: {app}\{#MINGW_BITNESS}\libexec\git-core\git.exe
 
 ; Delete git-lfs wrapper
 Type: files; Name: {app}\cmd\git-lfs.exe
+Type: dirifempty; Name: {app}\cmd
 
 ; Delete copied *.dll files
 Type: files; Name: {app}\{#MINGW_BITNESS}\libexec\git-core\*.dll

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -240,7 +240,7 @@ Type: dirifempty; Name: {app}\cmd
 ; Delete copied *.dll files
 Type: files; Name: {app}\{#MINGW_BITNESS}\libexec\git-core\*.dll
 
-; Delete the dynamical generated MSYS2 files
+; Delete the dynamically-generated MSYS2 files
 Type: files; Name: {app}\etc\hosts
 Type: files; Name: {app}\etc\mtab
 Type: files; Name: {app}\etc\networks

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -269,12 +269,10 @@ Type: files; Name: {app}\bin\msys-2.0.dll
 Type: files; Name: {app}\bin\rebase.exe
 Type: dirifempty; Name: {app}\bin
 Type: files; Name: {app}\etc\rebase.db.i386
-Type: dirifempty; Name: {app}\etc
 #endif
 
 ; Delete recorded install options
 Type: files; Name: {app}\etc\install-options.txt
-Type: dirifempty; Name: {app}\etc
 Type: dirifempty; Name: {app}\{#MINGW_BITNESS}\libexec\git-core
 Type: dirifempty; Name: {app}\{#MINGW_BITNESS}\libexec
 Type: dirifempty; Name: {app}\{#MINGW_BITNESS}
@@ -282,6 +280,7 @@ Type: dirifempty; Name: {app}
 
 ; Delete Git Bash options
 Type: files; Name: {app}\etc\git-bash.config
+Type: dirifempty; Name: {app}\etc
 
 ; Delete Windows Terminal profile fragments
 Type: files; Name: {commonappdata}\Microsoft\Windows Terminal\Fragments\Git\git-bash.json

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -3136,6 +3136,8 @@ begin
     }
 
     WizardForm.StatusLabel.Caption:='Creating some Cygwin symlinks';
+    if (not ForceDirectories(AppDir+'\dev')) then
+        LogError('Failed to create /dev; continuing anyway');
     CreateCygwinSymlink(AppDir+'\dev\fd','/proc/self/fd');
     CreateCygwinSymlink(AppDir+'\dev\stdin','/proc/self/fd/0');
     CreateCygwinSymlink(AppDir+'\dev\stdout','/proc/self/fd/1');

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -278,8 +278,9 @@ Type: dirifempty; Name: {app}\{#MINGW_BITNESS}\libexec
 Type: dirifempty; Name: {app}\{#MINGW_BITNESS}
 Type: dirifempty; Name: {app}
 
-; Delete Git Bash options
+; Delete Git Bash options and the system config
 Type: files; Name: {app}\etc\git-bash.config
+Type: files; Name: {app}\etc\gitconfig
 Type: dirifempty; Name: {app}\etc
 
 ; Delete Windows Terminal profile fragments


### PR DESCRIPTION
In https://github.com/git-for-windows/git/issues/5492 I was made aware that `cmd` and `etc` (and in particular, `etc\gitconfig`) are not removed by the uninstaller.

This PR fixes it, and then also adds some defensive programming that _might_ have prevented the (rare?) problem that was the actual reason for said report.