### PR TITLE
Switch to the new Pacman repository

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.653.48e2403b3
+pkgver=1.1.655.d4631bf56
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -99,30 +99,39 @@ GITATTRIBUTES
 	case "$uname_m" in
 	i686)
 		arch=i686
-		otherarch=x86-64
+		otherarch=x86_64
 		otherpacman=git-for-windows-mingw64
 		;;
 	x86_64)
-		arch=x86-64
+		arch=x86_64
 		otherarch=i686
 		otherpacman=git-for-windows-mingw32
 		;;
 	esac
 
+	! grep -q '^\[git-for-windows\]$' etc/pacman.conf ||
+	sed -i -e 's/^\(\[git-for-windows\)\(\]\)$/\1-'"$arch"'\2/' etc/pacman.conf
+
+	! grep -q wingit.blob.core.windows.net etc/pacman.conf ||
+	sed -i -e '/https:\/\/wingit\.blob\.core\.windows\.net\//{
+		s|x86-64|x86_64|
+		s|https://[^/]*|https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads|
+	}' etc/pacman.conf
+
 	grep -q git-for-windows[^-] etc/pacman.conf ||
-	sed -i -e '/^\[mingw32\]/i[git-for-windows]\nServer = https://wingit.blob.core.windows.net/'$arch'\n' etc/pacman.conf
+	sed -i -e '/^\[mingw32\]/i[git-for-windows-'"$arch"']\nServer = https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/'$arch'\n' etc/pacman.conf
 
 	! grep -A2 git-for-windows[^-] etc/pacman.conf |
 	grep -q '^SigLevel = Optional' ||
-	sed -i -e '/\[git-for-windows\]/{N;N;s/\nSigLevel = Optional//}' \
+	sed -i -e '/\[git-for-windows-'"$arch"'\]/{N;N;s/\nSigLevel = Optional//}' \
 		etc/pacman.conf
 
 	grep -q "$otherpacman" etc/pacman.conf ||
-	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
+	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/'$otherarch'\n' etc/pacman.conf
 
 	test -z "$(find /clangarm64 -type f -print -quit 2>/dev/null)" || # if /clangarm64 exists and contains at least one file
 	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
-	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
+	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/aarch64\n' etc/pacman.conf
 
 	! grep -q 'https://dl.bintray.com/\$repo/pacman/\$arch' etc/pacman.conf ||
 	sed -i -e 's/https:\/\/dl\.bintray\.com\/\$repo\/pacman\/\$arch/https:\/\/wingit.blob.core.windows.net\/'$arch'/g' etc/pacman.conf

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -65,30 +65,39 @@ GITATTRIBUTES
 	case "$uname_m" in
 	i686)
 		arch=i686
-		otherarch=x86-64
+		otherarch=x86_64
 		otherpacman=git-for-windows-mingw64
 		;;
 	x86_64)
-		arch=x86-64
+		arch=x86_64
 		otherarch=i686
 		otherpacman=git-for-windows-mingw32
 		;;
 	esac
 
+	! grep -q '^\[git-for-windows\]$' etc/pacman.conf ||
+	sed -i -e 's/^\(\[git-for-windows\)\(\]\)$/\1-'"$arch"'\2/' etc/pacman.conf
+
+	! grep -q wingit.blob.core.windows.net etc/pacman.conf ||
+	sed -i -e '/https:\/\/wingit\.blob\.core\.windows\.net\//{
+		s|x86-64|x86_64|
+		s|https://[^/]*|https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads|
+	}' etc/pacman.conf
+
 	grep -q git-for-windows[^-] etc/pacman.conf ||
-	sed -i -e '/^\[mingw32\]/i[git-for-windows]\nServer = https://wingit.blob.core.windows.net/'$arch'\n' etc/pacman.conf
+	sed -i -e '/^\[mingw32\]/i[git-for-windows-'"$arch"']\nServer = https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/'$arch'\n' etc/pacman.conf
 
 	! grep -A2 git-for-windows[^-] etc/pacman.conf |
 	grep -q '^SigLevel = Optional' ||
-	sed -i -e '/\[git-for-windows\]/{N;N;s/\nSigLevel = Optional//}' \
+	sed -i -e '/\[git-for-windows-'"$arch"'\]/{N;N;s/\nSigLevel = Optional//}' \
 		etc/pacman.conf
 
 	grep -q "$otherpacman" etc/pacman.conf ||
-	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://wingit.blob.core.windows.net/'$otherarch'\n' etc/pacman.conf
+	sed -i -e '/^\[mingw32\]/i['$otherpacman']\nServer = https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/'$otherarch'\n' etc/pacman.conf
 
 	test -z "$(find /clangarm64 -type f -print -quit 2>/dev/null)" || # if /clangarm64 exists and contains at least one file
 	grep -q "git-for-windows-aarch64" etc/pacman.conf || # then add Git for Windows' aarch64 repository (unless it's already added)
-	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://wingit.blob.core.windows.net/aarch64\n' etc/pacman.conf
+	sed -i -e '/^\[clangarm64]/i[git-for-windows-aarch64]\nServer = https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads/aarch64\n' etc/pacman.conf
 
 	! grep -q 'https://dl.bintray.com/\$repo/pacman/\$arch' etc/pacman.conf ||
 	sed -i -e 's/https:\/\/dl\.bintray\.com\/\$repo\/pacman\/\$arch/https:\/\/wingit.blob.core.windows.net\/'$arch'/g' etc/pacman.conf

--- a/please.sh
+++ b/please.sh
@@ -2792,7 +2792,7 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 		"${this_script_path%/*}")/}"cached-source-packages
 	test -n "$unpack" ||
 	unpack=$dir/.unpack
-	url=https://wingit.blob.core.windows.net
+	url=https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads
 
 	mkdir -p "$dir" ||
 	die "Could not create '%s'\n" "$dir"
@@ -2803,7 +2803,7 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 
 		case $arch in
 			x86_64)
-				oarch=x86-64
+				oarch=x86_64
 				pacman_arch=x86_64
 				artifact_suffix=64-bit
 				;;


### PR DESCRIPTION
I meant to do this a lot earlier: In February, I started migrating off of the Pacman repository that is hosted in my personal Azure account, to a new Pacman repository that is hosted on GitHub Releases.

With this PR, Git for Windows' SDK is moved over to the new Pacman repository.

Note that the `get-sources.sh` script is left alone, for now, as it will require substantial work (because it is no longer as easy to find the source package for a given package _version_; It will require [using the GitHub REST API](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases), probably via `gh` so that the `--jq` option can be used to filter by the desired asset filename).