### PR TITLE
git-extra(vimrc): adjust $PATH to remove Git's libexec

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.653.48e2403b3
+pkgver=1.1.654.aca5df34e
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')
@@ -62,7 +62,7 @@ source=('inputrc'
         'git-askpass.h'
         'git-askpass.rc')
 sha256sums=('8ed76d1cb069ac8568f21c431f5e23caebea502d932ab4cdff71396f4f0d5b72'
-            'e36a3b93b8a33b0a74619f2449ed6d56ed54e4e2938b97070bce4926f1f44054'
+            '7736786309a58112b7ac60627b3df049eb5eac3e0627c364939277477aaa03f1'
             '640d04d2a2da709419188a986d5e5550ad30df23c7ea9be1a389c37a6b917994'
             '17c90698d4dd52dd9f383e72aee54ecea0f62520baf56722de5c83285507c0d9'
             '3cd83627f1d20e1108533419fcf33c657cbcf777c3dc39fa7f13748b7d63858a'

--- a/git-extra/vimrc
+++ b/git-extra/vimrc
@@ -52,4 +52,36 @@ if has("autocmd")
       autocmd Filetype diff
       \ highlight WhiteSpaceEOL ctermbg=red |
       \ match WhiteSpaceEOL /\(^+.*\)\@<=\s\+$/
+
+      " When Git starts up, it prepends its libexec dir to PATH to allow it to
+      " find external commands.
+      "
+      " Thus, if Vim is invoked via a Git process (such as the contrib git-jump,
+      " or any other usage of GIT_EDITOR/VISUAL/EDITOR in Git commands, be they
+      " scripts or internals--with the exception of manually invoking the script
+      " yourself, without using Git: sh .../git-jump), $PATH will contain
+      " something like libexec/git-core.
+      "
+      " We don't generally want it in Vim's $PATH, though, as it is passed down
+      " to *all* subprocesses, including shells started with :terminal or
+      " :shell.
+      function s:fix_git_path() abort
+          let slash = exists('+shellslash') && !&shellslash ? '\\' : '/'
+          let git_core_base = printf('%slib\%%(exec\)\?%sgit-core', slash, slash)
+          " optimization: early return
+          if $PATH !~# git_core_base
+              return
+          endif
+          let path_sep = has('win32') ? ';' : ':'
+          let new_path = split($PATH, path_sep)
+                      \ ->filter({_, d -> d !~# git_core_base..'$' })
+                      \ ->join(path_sep)
+          let $PATH = new_path
+      endfunction
+
+      augroup fix_git_path
+          autocmd!
+          autocmd VimEnter * call s:fix_git_path()
+      augroup end
+
 endif " has("autocmd")


### PR DESCRIPTION
As described on the Git mailing list [1] and elsewhere [2], Git adjusts
PATH before invoking programs, and those adjustments are inherited by
editors if they are invoked as subprocesses. In most cases this is
harmless, but it can create confusion when spawning subprocesses from
the editor (as is common in Vim) and when the user's shell looks at PATH
or the location of a "git" binary.

Include portable code to strip these entries from PATH on startup.

[1]: https://public-inbox.org/git/CALnO6CDtGRRav8zK2GKi1oHTZWrHFTxZNmnOWu64-ab+oY3_Lw@mail.gmail.com/
[2]: https://benknoble.github.io/blog/2020/05/22/libexec-git-core-on-path/

Signed-off-by: D. Ben Knoble <ben.knoble+github@gmail.com>

---

This code comes from my own Dotfiles [3] via 2 authors, myself and
https://github.com/Konfekt, on their recommendation [4].

The only major user-facing change would be that `:!git-commit` and
similar probably no longer work, since libexec-style dir containing
those binaries wouldn't be on PATH anymore. But Git doesn't support that
usage officially, anyway?

I took the liberty of swapping `const` for `let` in this version to make
it a little more portable between versions of Vim; I'm not sure which
version Git for Windows ships, so if I need to convert the lambda
expressions into "v:val" strings, I'll do so.

[3]: https://github.com/benknoble/Dotfiles
[4]: https://github.com/benknoble/Dotfiles/issues/143#issuecomment-2869525481

