### PR TITLE
Rename local pacman db if needed

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.655.d4631bf56
+pkgver=1.1.657.d7f05a9c2
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')

--- a/git-extra/git-extra.install
+++ b/git-extra/git-extra.install
@@ -142,6 +142,18 @@ GITATTRIBUTES
 	! grep -q 'https://dl.bintray.com/git-for-windows/pacman/x86_64' etc/pacman.conf ||
 	sed -i -e 's/https:\/\/dl\.bintray\.com\/git-for-windows\/pacman\/x86_64/https:\/\/wingit.blob.core.windows.net\/x86-64/g' etc/pacman.conf
 
+	# The main pacman database was renamed from `git-for-windows` to `git-for-windows-<arch>`
+	for ext in db db.sig files files.sig
+	do
+		if ! test -f var/lib/pacman/sync/git-for-windows-$arch.$ext
+		then
+			mv var/lib/pacman/sync/git-for-windows.$ext var/lib/pacman/sync/git-for-windows-$arch.$ext
+		elif test -f var/lib/pacman/sync/git-for-windows.$ext
+		then
+			rm var/lib/pacman/sync/git-for-windows.$ext
+		fi
+	done
+
 	test i686 != $"uname -m" ||
 	case "$(md5sum.exe < /msys2.ico)" in
 	292ad5cd*) cp /usr/share/git/msys2-32.ico /msys2.ico;;

--- a/git-extra/git-extra.install.in
+++ b/git-extra/git-extra.install.in
@@ -108,6 +108,18 @@ GITATTRIBUTES
 	! grep -q 'https://dl.bintray.com/git-for-windows/pacman/x86_64' etc/pacman.conf ||
 	sed -i -e 's/https:\/\/dl\.bintray\.com\/git-for-windows\/pacman\/x86_64/https:\/\/wingit.blob.core.windows.net\/x86-64/g' etc/pacman.conf
 
+	# The main pacman database was renamed from `git-for-windows` to `git-for-windows-<arch>`
+	for ext in db db.sig files files.sig
+	do
+		if ! test -f var/lib/pacman/sync/git-for-windows-$arch.$ext
+		then
+			mv var/lib/pacman/sync/git-for-windows.$ext var/lib/pacman/sync/git-for-windows-$arch.$ext
+		elif test -f var/lib/pacman/sync/git-for-windows.$ext
+		then
+			rm var/lib/pacman/sync/git-for-windows.$ext
+		fi
+	done
+
 	test i686 != $"uname -m" ||
 	case "$(md5sum.exe < /msys2.ico)" in
 	292ad5cd*) cp /usr/share/git/msys2-32.ico /msys2.ico;;


### PR DESCRIPTION
There was [a problem](https://github.com/git-for-windows/git-sdk-64/actions/runs/15201707468/job/42756925883#step:3:105) with the most recent `sync` runs in `git-sdk-64` (and in `git-sdk-arm64`, but not `git-sdk-32`) because the local copy of the Pacman database was still named `git-for-windows.db` instead of `git-for-windows-x86_64.db`.

This fixes that.

It's like the (old) Pacman version that `git-sdk-32` has that allowed it to pass.