### PR TITLE
Drop superseded msys2 runtime entries from the release notes

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -42,9 +42,7 @@ Git for Windows is distributed with other components yet, such as Bash, zlib, cu
 ### New Features
 
 * Comes with [MinTTY v3.7.8](https://github.com/mintty/mintty/releases/tag/3.7.8).
-* Comes with the MSYS2 runtime (Git for Windows flavor) based on [Cygwin v3.6.0](https://cygwin.com/pipermail/cygwin-announce/2025-March/012224.html).
 * Comes with [OpenSSH v10.0.P1](https://github.com/openssh/openssh-portable/releases/tag/V_10_0_P1).
-* Comes with the MSYS2 runtime (Git for Windows flavor) based on [Cygwin v3.6.1](https://cygwin.com/pipermail/cygwin-announce/2025-April/012266.html).
 * Comes with the MSYS2 runtime (Git for Windows flavor) based on [Cygwin v3.6.2](https://cygwin.com/pipermail/cygwin-announce/2025-May/012350.html).
 * Comes with [cURL v8.14.0](https://curl.se/changes.html#8_14_0).
 

--- a/add-release-note.js
+++ b/add-release-note.js
@@ -46,7 +46,7 @@ const addReleaseNote = (type, message) => {
 
   // Remove any superseded entries
   if (type === 'feature') {
-    const match = message.match(/^(Comes with \[[^\]]+ )(v|patch level)/)
+    const match = message.match(/^(Comes with (?:\[[^\]]+|the MSYS2 runtime .*Cygwin) )(v|patch level)/)
     if (match) sections.feature = sections.feature.filter(e => !e.startsWith(`* ${match[1]}${match[2]}`))
   }
 


### PR DESCRIPTION
I just noticed that the release notes for Git for Windows v2.50.0-rc0 contain multiple entries for the MSYS2 runtime; Fix that.