### PR TITLE
make-file-list: include the new /etc/msystem.d/ folder

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -401,7 +401,7 @@ then
 	etc/profile
 	etc/profile.d/lang.sh
 	etc/bash.bashrc
-	etc/msystem
+	etc/msystem*
 	usr/bin/dash.exe
 	usr/bin/getopt.exe
 	EOF


### PR DESCRIPTION
As of filesystem-2025.05.08-1, the various definitions depending on the environment variable `MSYSTEM` are no longer in a single `/etc/msystem` file, but rather in files in the new `/etc/msystem.d/` directory whose filenames reflect the value of said environment variable.

As [suggested](https://github.com/git-for-windows/git-sdk-64/pull/99#issuecomment-2913315073), let's include this directory in the payload of Git for Windows' installer so that users are not greeted with the message:

	bash: /etc/msystem.d/MSYS: No such file or directory