### PR TITLE
build-installers: include `/etc/msystem.d` when available

### DIFF
--- a/please.sh
+++ b/please.sh
@@ -3327,6 +3327,7 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 				printf '\n' >>"$sparse_checkout_file" &&
 				git -C "$git_sdk_path" show HEAD:.sparse/makepkg-git-i686 >>"$sparse_checkout_file"
 			fi &&
+			printf '\n# For the /etc/msystem.d/ check\n/etc/msystem.d/\n\n' >>"$sparse_checkout_file" &&
 			printf '\n# markdown, to render the release notes\n/usr/bin/markdown\n\n' >>"$sparse_checkout_file" &&
 			ARCH=$architecture "$output_path/git-cmd.exe" --command=usr\\bin\\sh.exe -l \
 			"${this_script_path%/*}/make-file-list.sh" | sed -e 's|[][]|\\&|g' -e 's|^|/|' >>"$sparse_checkout_file"


### PR DESCRIPTION
In #622, I fixed the NuGet package build, but that fix re-broke the aarch64 installer (and my testing on x64 -- as I have no Windows/ARM64 hardware -- was fooled by an unrelated fix that hid the bug).