### PR TITLE
astextplain: restore passthrough for plaintext DOC/DOT files

### DIFF
--- a/git-extra/astextplain
+++ b/git-extra/astextplain
@@ -21,7 +21,7 @@ case "$(file --brief --mime-type "$1")" in
 		out=$(pdftotext -q -layout -enc UTF-8 "$1" -) && sed "s/(\^M$)|(^\^L)//" <<<$out || cat "$1"
 		;;
 	# TODO add rtf support
-	application/rtf | text/rtf)
+	application/rtf | text/rtf | text/plain)
 		cat "$1"
 		;;
 	*)


### PR DESCRIPTION
The fix for https://github.com/git-for-windows/git/issues/5641 broke diffs for plaintext DOC and DOT files:

    $ echo Test > test.doc
    $ git add test.doc
    $ git diff --cached
    E: unsupported filetype test.doc

Since `file` correctly identifies the mimetype of such files as `text/plain`, this can be fixed by simply covering this case and printing the file content as it was done previously.