### PR TITLE
Update git-prompt.sh for Zsh Error

### DIFF
--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -1,3 +1,7 @@
+#!/bin/sh
+newline='
+'
+
 if test -f /etc/profile.d/git-sdk.sh
 then
 	TITLEPREFIX=SDK-${MSYSTEM#MINGW}
@@ -25,8 +29,18 @@ else
 		COMPLETION_PATH="$COMPLETION_PATH/share/git/completion"
 		if test -f "$COMPLETION_PATH/git-prompt.sh"
 		then
+   			. "$COMPLETION_PATH/git-prompt.sh"
+  			if [ ! "${ZSH_VERSION}" = "" ];
+			then
+   				precmd() # Assembles git prompt that closely resembles the bash prompt.
+       				{
+	   				pre="${newline}%F{green}%n@%m%f %F{magenta}${MSYSTEM:-"ZSH"}%f %F{yellow}%~%f %F{cyan}"
+					post="%f${newline}$ "
+     					__git_ps1 "${pre}" "${post}" "(%s)"
+	   			}
+				return 	# Avoids zsh git-completion.bash Error.
+			fi
 			. "$COMPLETION_PATH/git-completion.bash"
-			. "$COMPLETION_PATH/git-prompt.sh"
 			PS1="$PS1"'\[\033[36m\]'  # change color to cyan
 			PS1="$PS1"'`__git_ps1`'   # bash function
 		fi


### PR DESCRIPTION
Howdy!

Problem
If Zsh ever runs /etc/profile.d/git-prompts.sh, then zsh will also run git-completions.bash. git-completions.bash throws an Error when Zsh is detected. This Error echoes this message: "ERROR: this script is obsolete, please see git-completion.zsh" This Error breaks certain git completions and functionality.

Solution
Add condition to git-prompt.sh to avoid git-completion.bash if Zsh is detected. Add prompt that enables git prompts to work.

Note:
Git completions will still work for Bash and Zsh.
Prompts with "__git_ps1" will still work for Bash and Zsh.

A friendly reminder for new contributors:

# What is DCO sign-off?  Why is it required?

DCO stands for [Developer's Certificate of Origin](https://github.com/git/git/blob/v2.18.0/Documentation/SubmittingPatches#L304-L349).

We require all commits to be DCO signed-off in case we need to track down and handle legal and/or technical issues.

To DCO sign-off your commits, you could run the `git-commit` command with [the `-s` option](https://git-scm.com/docs/git-commit#git-commit--s) or just add a line in your commit message in this format:

```
        Signed-off-by: yourFirstName yourLastName <yourEmail@example.org>
```

For more information, check out how PRs are checked for DCO sign-off: https://github.com/probot/dco#how-it-works .

Thank you very much.
