### PR TITLE
mingit: exclude the tzdata

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,12 +54,12 @@ jobs:
           echo "test-sdk-artifacts=true" >>$GITHUB_OUTPUT
 
           git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&
-          show_files releaseable.txt &&
           if grep -q test-sdk-artifacts=true $GITHUB_OUTPUT
           then
             # These are already tested as part of the `sdk-artifacts` matrix
             sed -i '/^\(installer\|mingit\)\/$/d' releaseable.txt
           fi &&
+          show_files releaseable.txt &&
           define_matrix artifacts releaseable.txt touched.txt artifacts.txt &&
           show_files artifacts.txt ||
           exit $?

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,8 +56,8 @@ jobs:
           git ls-files \*/release.sh | sed 's|[^/]*$||' | sort >releaseable.txt &&
           if grep -q test-sdk-artifacts=true $GITHUB_OUTPUT
           then
-            # These are already tested as part of the `sdk-artifacts` matrix
-            sed -i '/^\(installer\|mingit\)\/$/d' releaseable.txt
+            # This is already tested as part of the `sdk-artifacts` matrix
+            sed -i '/^\(installer\)\/$/d' releaseable.txt
           fi &&
           show_files releaseable.txt &&
           define_matrix artifacts releaseable.txt touched.txt artifacts.txt &&

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -50,7 +50,7 @@ then
 	PACKAGE_EXCLUDES="$PACKAGE_EXCLUDES mingw-w64-bzip2 mingw-w64-c-ares
 		mingw-w64-libsystre mingw-w64-libtre-git mingw-w64-p11-kit
 		mingw-w64-tcl mingw-w64-tk mingw-w64-wineditline gdbm icu libdb
-		libedit libgdbm perl perl-.*"
+		libedit libgdbm perl perl-.* mingw-w64-tzdata"
 fi
 if test -z "$INCLUDE_GIT_UPDATE"
 then


### PR DESCRIPTION
Since https://github.com/msys2/MINGW-packages/pull/24750, the `mingw-w64-gcc-libs` package now has a hard dependency on `mingw-w64-tzdata`. That latter package contains, let's say, _many_ files.

As a consequence, the `7z` invocation to build MinGit would now fail like this:

```
Creating .zip archive
+ cd /
+ 7z a -mx9 [...]
release.sh: line 176: /mingw64/bin/7z: Argument list too long
Error: Process completed with exit code 126.
```

This is the underlying reason for the recent [`git-artifacts` CI failures](https://github.com/git-for-windows/git-sdk-64/actions/workflows/git-artifacts.yml):

<img width="463" height="267" alt="image" src="https://github.com/user-attachments/assets/50f2cdff-7202-48cc-b404-a6111fceb6d4" />

Since the new code that makes use of that tzdata explicitly comes with a fall-back to an internal database, let's just skip the tzdata when building MinGit.