### PR TITLE
Add check over Windows Integration to already exists during upgrade

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -1904,6 +1904,40 @@ begin
 #endif
 end;
 
+procedure PreselectShellIntegrationIfMatchingInstall();
+var
+  RootKey: Integer;
+  Cmd: String;
+  AppPath: String;
+begin
+  AppPath := UninstallAppPath;  // Set earlier in QueryUninstallValues()
+
+  if AppPath = '' then
+    Exit;
+
+  if IsAdminLoggedOn then
+    RootKey := HKEY_LOCAL_MACHINE
+  else
+    RootKey := HKEY_CURRENT_USER;
+
+  // Git Bash Here
+  if RegQueryStringValue(RootKey,
+    'SOFTWARE\Classes\Directory\shell\git_shell\command', '', Cmd) then
+  begin
+    if Pos(AppPath, Cmd) > 0 then
+      WizardSelectComponents('ext\shellhere');
+  end;
+
+  // Git GUI Here
+  if RegQueryStringValue(RootKey,
+    'SOFTWARE\Classes\Directory\shell\git_gui\command', '', Cmd) then
+  begin
+    if Pos(AppPath, Cmd) > 0 then
+      WizardSelectComponents('ext\guihere');
+  end;
+end;
+
+
 procedure InitializeWizard;
 var
     PrevPageID,TabOrder,TopOfLabels,Top,Left:Integer;
@@ -1922,6 +1956,9 @@ begin
     AppDir:=UninstallAppPath;
     GetDefaultsFromGitConfig('ProgramData');
     GetDefaultsFromGitConfig('system');
+
+    // Check if Windows Integration already exists to reapply it during update
+    PreselectShellIntegrationIfMatchingInstall();
 
     ChosenOptions:='';
 


### PR DESCRIPTION
It is my suggestion for fixing Bug#5683 I opened months ago. https://github.com/git-for-windows/git/issues/5683

It will enable preserving Windows Integration in any context of update - manually (it will check the option automatically if detected) or via silent update (winget or other path) by detecting if the Registry entries already exists and match the current installation at that time.
