### PR TITLE
Add UsePreviousSetupType to Setup section to preserve settings during upgrade

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -85,6 +85,7 @@ PrivilegesRequired=none
 #endif
 UninstallDisplayName={#APP_NAME}
 UninstallDisplayIcon={app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
+UsePreviousSetupType=yes
 #ifndef COMPILE_FROM_IDE
 VersionInfoVersion={#FILE_VERSION}
 #endif


### PR DESCRIPTION
The intend here is to resolve the issue when settings are not carried over when upgrading in silent mode - the most visible were the Windows Integration to me but it can impact other settings as well. 

After reviewing documentation, I found out that UsePreviousSetupType directive should handle it, but was missing from the installer script.

As per documentation: 
When this directive is yes, the default, at startup Setup will look in the registry to see if the same application is already installed, and if so, it will use the setup type and component settings of the previous installation as the default settings presented to the user in the wizard. Note that Setup cannot re-use settings from a previous installation that had Uninstallable set to no, since the registry entries it looks for are not created when Uninstallable is no. -- end of documentation.

As discussed on my previous attempt, here is the new one trying to account for the proper way to carry over any and all settings, even future one.

Signed-off-by: Nicolas DENIS <the.clickman@gmail.com>
