### PR TITLE
Release Notes: list the many bug fixes in Git for Windows v2.51.0(2)

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -42,7 +42,7 @@ Git for Windows is distributed with other components yet, such as Bash, zlib, cu
 ### New Features
 
 * Comes with [PCRE2 v10.46](https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.46).
-* Comes with [cURL v8.16.0](https://curl.se/changes.html#8_16_0).
+* Comes with [cURL v8.16.0](https://curl.se/changes.html#8_16_0). This addresses [a bug where fetches/pushes could fail with `failed to read data from server: SEC_E_CONTEXT_EXPIRED (0x80090317)` under certain circumstances](https://github.com/git-for-windows/git/issues/5838).
 * Comes with [Tig v2.6.0](https://github.com/jonas/tig/releases/tag/tig-2.6.0).
 * Comes with [MinTTY v3.8.1](https://github.com/mintty/mintty/releases/tag/3.8.1).
 * Comes with [OpenSSL v3.5.3](https://www.openssl.org/news/openssl-3.5-notes.html).
@@ -50,6 +50,23 @@ Git for Windows is distributed with other components yet, such as Bash, zlib, cu
 ### Bug Fixes
 
 * The auto-updater now shows Git for Windows icon in the notification [also on Windows/ARM64](https://github.com/git-for-windows/build-extra/pull/644).
+* `git clone`/`git fetch` now deals more gracefully with directory / file conflicts when the files backend is used for ref storage, by failing only the ones that are involved in the conflict while allowing others. This is a regression in Git v2.51.0 that was [reported in Git for Windows](https://github.com/git-for-windows/git/issues/5804) and independently also [to the Git mailing list](https://lore.kernel.org/git/YQXPR01MB3046197EF39296549EE6DD669A33A@YQXPR01MB3046.CANPRD01.PROD.OUTLOOK.COM/). This was fixed by merging Git's topic branch [`kn/refs-files-case-insensitive`](https://github.com/gitgitgadget/git/commits/kn/refs-files-case-insensitive).
+* Support for pathspecs in `diff --no-index` [was somewhat buggy](https://github.com/git-for-windows/issues/5836), which has been fixed.
+* `git sparse-checkout` subcommand learned a new `clean` action to prune otherwise unused working-tree files that are outside the areas of interest. An earlier version of this had been [integrated into Microsoft Git already](https://github.com/microsoft/git/pull/796). This was fixed by merging Git's topic branch [`ds/sparse-checkout-clean`](https://github.com/gitgitgadget/git/commits/ds/sparse-checkout-clean).
+* `git rebase -i` failed to clean-up the commit log message when the command commits the final one in a chain of "fixup" commands, which has been corrected. Backported from Git's topic branch [`pw/rebase-i-cleanup-fix`](https://github.com/gitgitgadget/git/commits/pw/rebase-i-cleanup-fix).
+* `git subtree` did not work correctly when splitting squashed subtrees, which has been improved. Backported from Git's topic branch [`cs/subtree-squash-split-fix`](https://github.com/gitgitgadget/git/commits/cs/subtree-squash-split-fix).
+* Some among `git add -p` and friends ignored `color.diff` and/or `color.ui` configuration variables, which is an old regression, which has been corrected. This was fixed by merging Git's topic branch [`jk/add-i-color`](https://github.com/gitgitgadget/git/commits/jk/add-i-color).
+* A corner-case bug in `git log -L...` has been corrected. This was fixed by merging Git's topic branch [`sg/line-log-boundary-fixes`](https://github.com/gitgitgadget/git/commits/sg/line-log-boundary-fixes).
+* A broken or malicious `git fetch` can say that it has the same object for many many times, and the upload-pack serving it can exhaust memory storing them redundantly, which has been corrected. This was fixed by merging Git's topic branch [`ps/upload-pack-oom-protection`](https://github.com/gitgitgadget/git/commits/ps/upload-pack-oom-protection).
+* Fixes multiple crashes around midx write-out codepaths. This was fixed by merging Git's topic branch [`ds/midx-write-fixes`](https://github.com/gitgitgadget/git/commits/ds/midx-write-fixes).
+* `git repack --path-walk` lost objects in some corner cases, which has been corrected. This was fixed by merging Git's topic branch [`ds/path-walk-repack-fix`](https://github.com/gitgitgadget/git/commits/ds/path-walk-repack-fix).
+* Under a race against another process that is repacking the repository, especially a partially cloned one, `git fetch` may mistakenly think some objects we do have are missing, which has been corrected. This was fixed by merging Git's topic branch [`jk/fetch-check-graph-objects-fix`](https://github.com/gitgitgadget/git/commits/jk/fetch-check-graph-objects-fix).
+* Various options to `git diff` that makes comparison ignore certain aspects of the differences (like "space changes are ignored", "differences in lines that match these regular expressions are ignored") did not work well with `--name-only` and friends. This was fixed by merging Git's topic branch [`ly/diff-name-only-with-diff-from-content`](https://github.com/gitgitgadget/git/commits/ly/diff-name-only-with-diff-from-content).
+* `git diff --no-index` run inside a subdirectory under control of a Git repository operated at the top of the working tree and stripped the prefix from the output, and oddballs like "-" (stdin) did not work correctly because of it.  Correct the set-up by undoing what the set-up sequence did to the current working directory and prefix. This was fixed by merging Git's topic branch [`jc/diff-no-index-in-subdir`](https://github.com/gitgitgadget/git/commits/jc/diff-no-index-in-subdir).
+* Various bugs about rename handling in "ort" merge strategy have been fixed. This was fixed by merging Git's topic branch [`en/ort-rename-fixes`](https://github.com/gitgitgadget/git/commits/en/ort-rename-fixes).
+* `git push` had a code path that led to `BUG()` but it should have reported a regular failure, as it is a response to a usual but invalid end-user action to attempt pushing an object that does not exist. This was fixed by merging Git's topic branch [`dl/push-missing-object-error`](https://github.com/gitgitgadget/git/commits/dl/push-missing-object-error).
+* `git refs migrate` to migrate the reflog entries from a refs  backend to another had a handful of bugs squashed. This was fixed by merging Git's topic branch [`ps/reflog-migrate-fixes`](https://github.com/gitgitgadget/git/commits/ps/reflog-migrate-fixes).
+* During interactive rebase, using `drop` on a merge commit lead to an error, which was incorrect. This was fixed by merging Git's topic branch [`js/rebase-i-allow-drop-on-a-merge`](https://github.com/gitgitgadget/git/commits/js/rebase-i-allow-drop-on-a-merge).
 
 ## Changes since Git for Windows v2.50.1 (July 8th 2025)
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -42,7 +42,7 @@ Git for Windows is distributed with other components yet, such as Bash, zlib, cu
 ### New Features
 
 * Comes with [PCRE2 v10.46](https://github.com/PCRE2Project/pcre2/releases/tag/pcre2-10.46).
-* Comes with [cURL v8.16.0](https://curl.se/changes.html#8_16_0). This addresses [a bug where fetches/pushes could fail with `failed to read data from server: SEC_E_CONTEXT_EXPIRED (0x80090317)` under certain circumstances](https://github.com/git-for-windows/git/issues/5838).
+* Comes with [cURL v8.16.0](https://curl.se/changes.html#8_16_0). This addresses [a bug where fetches/pushes could fail with `failed to read data from server: SEC_E_CONTEXT_EXPIRED (0x80090317)` under certain circumstances](https://github.com/git-for-windows/git/issues/5838). Also included: a [back-port of a fix](https://github.com/git-for-windows/MINGW-packages/pull/163) for a bug where connection failures were mistakenly reported as time-outs.
 * Comes with [Tig v2.6.0](https://github.com/jonas/tig/releases/tag/tig-2.6.0).
 * Comes with [MinTTY v3.8.1](https://github.com/mintty/mintty/releases/tag/3.8.1).
 * Comes with [OpenSSL v3.5.3](https://www.openssl.org/news/openssl-3.5-notes.html).


### PR DESCRIPTION
With this amount of bug fixes, it is high time to release a new version so that Git users can benefit from them. The current plan is to release Git for Windows v2.51.0(2) on this coming Monday, September 29th, 2025.