### PR TITLE
installer: annotate the 'None' credential helper option

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2432,7 +2432,7 @@ begin
     RdbGitCredentialManager[GCM]:=CreateRadioButton(GitCredentialManagerPage,'Git Credential Manager','Use the <A HREF=https://github.com/GitCredentialManager/git-credential-manager>cross-platform Git Credential Manager</A>.'+#13+'See more information about the future of Git Credential Manager <A HREF=https://github.com/GitCredentialManager/git-credential-manager/blob/HEAD/docs/faq.md#about-the-project>here</A>.',TabOrder,Top,Left);
 
     // No credential helper
-    RdbGitCredentialManager[GCM_None]:=CreateRadioButton(GitCredentialManagerPage,'None','Do not use a credential helper.',TabOrder,Top,Left);
+    RdbGitCredentialManager[GCM_None]:=CreateRadioButton(GitCredentialManagerPage,'None','Do not use a credential helper.'+#13+#13+'Note: Select only for headless environments, SSH-only workflows,'+#13+'or custom credential helpers. Otherwise, Git will prompt for'+#13+'credentials on every HTTPS operation.',TabOrder,Top,Left);
 
     // Restore the settings chosen during a previous install, if .NET Framework 4.7.2
     // or later is available.


### PR DESCRIPTION
### Description
The 'None' credential helper option lacked explicit context, which could lead users to unintentionally disable the feature and face authentication anomalies. This PR adds a brief note to the `GCM_None` radio button clarifying that it is intended strictly for headless environments, SSH-only workflows, or custom credential helpers.

### Technical Scope
* **Textual Update Only:** This modification strictly targets the string passed to the `CreateRadioButton` function for the `GCM_None` option.
* **Logic Intact:** No underlying Pascal Script conditional logic, registry parsing, or silent install mechanisms were altered.

### Visual Regression Testing

| Before | After |
|---|---|
| <img width="598" height="466" alt="Credential_Manager_wizard" src="https://github.com/user-attachments/assets/a8df26be-5a1b-428d-9f23-d81f334fd033" /> | <img width="595" height="457" alt="Credential_Manager_wizard_2" src="https://github.com/user-attachments/assets/7fa616a8-0990-4e96-85a1-fff480340ad8" /> |

Signed-off-by: Jason Zbakh <jzbakh@gmail.com>
