### PR TITLE
Fix `check-for-missing-dlls`

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -266,6 +266,8 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/usr/lib/\(itcl\|tdbc\|pkcs11/p11-kit-client\|thread\)' \
 	-e '^/usr/lib/ssh/sshd\($\|-\)' \
 	-e '^/usr/share.*/magic$' \
+	-e '^/usr/lib/perl5/core_perl/auto/DB_File/' \
+	-e '^/usr/lib/perl5/core_perl/DB_File\.pm$' \
 	-e '^/usr/share/perl5/core_perl/Unicode/' \
 	-e '^/usr/share/perl5/core_perl/pods/' \
 	-e '^/usr/share/perl5/core_perl/Locale/' \


### PR DESCRIPTION
Unlike Git for Windows' version of the `perl` package, which we just dropped in favor of MSYS2's Perl, the latter ships `DB_File` as a core module, and its DLL links against `msys-db-6.2.dll` which we intentionally exclude from the installer. This causes the `check-for-missing-dlls` workflow to fail in [git-sdk-64](https://github.com/git-for-windows/git-sdk-64/actions/runs/23550859691), [git-sdk-32](https://github.com/git-for-windows/git-sdk-32/actions/runs/23550844347), and [git-sdk-arm64](https://github.com/git-for-windows/git-sdk-arm64/actions/runs/23550864957).

Exclude both the extension DLL and the Perl module from the installer file list, since `DB_File` is useless without the Berkeley DB library anyway.

Together with the `update-via-pacman.ps1: allow downgrades` commits ([git-sdk-64](https://github.com/git-for-windows/git-sdk-64/commit/444011e1cc019d49575704af3b3af7ac35651176), [git-sdk-32](https://github.com/git-for-windows/git-sdk-32/commit/70728b891ed50e486cd1d89aedf6b4d7f36af28c), [git-sdk-arm64](https://github.com/git-for-windows/git-sdk-arm64/commit/069bb0206bed507b6b369db9471db3f128f841c7)) that address the `readkey.dll is missing msys-perl5_38.dll` failure by allowing `pacman -Syuu` to downgrade perl-TermReadKey from the stale Git for Windows build (2.38-9, linked against Perl 5.38) to MSYS2's upstream rebuild (2.38-7, linked against Perl 5.40), this should fix the check-for-missing-dlls workflow in all three SDK repositories.