### PR TITLE
Skip distributing `git instaweb`

### DIFF
--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -243,6 +243,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/\(mingw\|clang\)[^/]*/.*/git-\(remote-testsvn\|shell\)\.exe$' \
 	-e '^/\(mingw\|clang\)[^/]*/.*/git-cvsserver.*$' \
 	-e '^/\(mingw\|clang\)[^/]*/.*/gitweb/' \
+	-e '^/\(mingw\|clang\)[^/]*/.*/git-instaweb' \
 	-e '^/\(mingw\|clang\)[^/]*/lib/\(dde\|itcl\|sqlite\|tdbc\)' \
 	-e '^/\(mingw\|clang\)[^/]*/libexec/git-core/git-archimport$' \
 	-e '^/\(mingw\|clang\)[^/]*/share/doc/git-doc/git-archimport' \
@@ -312,7 +313,7 @@ else
 		-e '^/\(mingw\|clang\)[^/]*/bin/\(WhoUses\|xmlwf\)\.exe$' \
 		-e '^/\(mingw\|clang\)[^/]*/etc/pki' -e '^/\(mingw\|clang\)[^/]*/lib/p11-kit/' \
 		-e '/git-\(add--interactive\|archimport\|citool\|cvs.*\)$' \
-		-e '/git-\(gui.*\|instaweb\|p4\|relink\)$' \
+		-e '/git-\(gui.*\|p4\|relink\)$' \
 		-e '/git-\(send-email\|svn\)$' \
 		-e '/\(mingw\|clang\)[^/]*/libexec/git-core/git-\(imap-send\|daemon\)\.exe$' \
 		-e '/\(mingw\|clang\)[^/]*/libexec/git-core/git-remote-ftp.*\.exe$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -325,7 +325,7 @@ else
 		-e '^/\(mingw\|clang\)[^/]*/share/gettext-' \
 		-e '^/\(mingw\|clang\)[^/]*/share/git/\(builtins\|compat\|completion\)' \
 		-e '^/\(mingw\|clang\)[^/]*/share/git/.*\.ico$' \
-		-e '^/\(mingw\|clang\)[^/]*/share/\(git-gui\|gitweb\)/' \
+		-e '^/\(mingw\|clang\)[^/]*/share/git-gui/' \
 		-e '^/\(mingw\|clang\)[^/]*/share/perl' \
 		-e '^/\(mingw\|clang\)[^/]*/share/pki/' \
 		-e '/zsh/' \


### PR DESCRIPTION
While [analyzing Perl users](https://github.com/git-for-windows/git/issues/5393#issuecomment-4242978450), I noticed that `git instaweb` is included in Git for Windows, even if GitWeb (on which it relies) is not.

Let's fix that.