### PR TITLE
Release Notes: fix GCM entry

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -43,7 +43,7 @@ Due to persistent maintenance challenges, `git svn` is no longer included in Git
 ### New Features
 
 * Comes with [Bash v5.3.9](https://cgit.git.savannah.gnu.org/cgit/bash.git/commit/?id=637f5c8696a6adc9b4519f1cd74aa78492266b7f).
-* Comes with [Git Credential Manager v2.7.2](https://github.com/git-ecosystem/git-credential-manager/releases/tag/v2.7.2).
+* Comes with [Git Credential Manager v2.7.3](https://github.com/git-ecosystem/git-credential-manager/releases/tag/v2.7.3).
 * Comes with [MinTTY v3.8.2](https://github.com/mintty/mintty/releases/tag/3.8.2).
 * The shell aliases in Git Bash that ensured that interpreters such as Python and Node.JS are executed via `winpty` are no longer necessary, and have therefore [been dropped](https://github.com/git-for-windows/build-extra/pull/664).
 * Comes with the MSYS2 runtime (Git for Windows flavor) based on [Cygwin v3.6.7](https://sourceware.org/pipermail/cygwin-announce/2026-March/012878.html).


### PR DESCRIPTION
Git for Windows already includes v2.7.3, not v2.7.2.

Thanks for [noticing](https://github.com/git-for-windows/git/discussions/6180#discussioncomment-16575194), @becm!