### PR TITLE
Fix `check-for-missing-dlls` failures

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -22,25 +22,22 @@ die "Could not enumerate system .dll files"
 LF='
 '
 
-if test -z "$MINGW_PREFIX"
-then
-	case "$MSYSTEM" in
-	MINGW64) MINGW_PREFIX=mingw64;;
-	CLANGARM64) MINGW_PREFIX=clangarm64;;
-	MINGW32) MINGW_PREFIX=mingw32;;
-	*)
-		ARCH="$(uname -m)" ||
-		die "Could not determine architecture"
+case "$MSYSTEM" in
+MINGW64) MINGW_PREFIX=mingw64;;
+CLANGARM64) MINGW_PREFIX=clangarm64;;
+MINGW32) MINGW_PREFIX=mingw32;;
+*)
+	ARCH="$(uname -m)" ||
+	die "Could not determine architecture"
 
-		case "$ARCH" in
-		i686) MINGW_PREFIX=mingw32;;
-		x86_64) MINGW_PREFIX=mingw64;;
-		aarch64) MINGW_PREFIX=clangarm64;;
-		*) die "Unhandled architecture: $ARCH";;
-		esac
-		;;
+	case "$ARCH" in
+	i686) MINGW_PREFIX=mingw32;;
+	x86_64) MINGW_PREFIX=mingw64;;
+	aarch64) MINGW_PREFIX=clangarm64;;
+	*) die "Unhandled architecture: $ARCH";;
 	esac
-fi
+	;;
+esac
 
 if test -t 2
 then

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -465,4 +465,9 @@ usr/bin/tmux.exe
 $(ldd /usr/bin/tmux.exe | sed -n 's/.*> \/\(.*msys-event[^ ]*\).*/\1/p')
 EOF
 
-test -z "$INCLUDE_OBJDUMP" || echo usr/bin/objdump.exe
+test -z "$INCLUDE_OBJDUMP" || {
+	echo usr/bin/objdump.exe
+	test -n "$MINIMAL_GIT" &&
+	grep -q msys-zstd-1 /usr/bin/objdump.exe 2>/dev/null &&
+	echo usr/bin/msys-zstd-1.dll
+}


### PR DESCRIPTION
The `check-for-missing-dlls` workflow in git-sdk-64 [started failing](https://github.com/git-for-windows/git-sdk-64/actions/runs/25359699430) in the MinGit step after a recent binutils update added a zstd dependency to `objdump.exe`:

```
/usr/bin/objdump.exe is missing msys-zstd-1.dll
```

The first commit fixes this by conditionally including `msys-zstd-1.dll` in the MinGit file list when `objdump.exe` links to it.

The second commit fixes an independent bug where running the check script locally in the full Git SDK environment silently skipped the entire DLL-tracking loop because `MINGW_PREFIX` was set to an absolute Windows-style path by the SDK environment, which did not match the relative paths in the file list.