### PR TITLE
pacman-helper: maintain per-package .versions.json index files

### DIFF
--- a/get-sources.sh
+++ b/get-sources.sh
@@ -29,6 +29,13 @@ sf_repos_url=http://sourceforge.net/projects/msys2/files/REPOS
 msys_sf_source_url=$sf_repos_url/MSYS2/Sources
 mingw_sf_source_url=$sf_repos_url/MINGW/Sources
 azure_blobs_source_url=https://wingit.blob.core.windows.net/sources
+pacman_repo_url=https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads
+
+# When $GITHUB_TOKEN is non-empty, pass it via Basic Auth so the otherwise
+# strictly rate-limited raw.githubusercontent.com (and api.github.com release
+# download) endpoints accept more requests.
+github_curl_auth=
+test -z "$GITHUB_TOKEN" || github_curl_auth="-u x-access-token:$GITHUB_TOKEN"
 
 cd "$(dirname "$0")" ||
 die "Could not change directory to build-extra/"
@@ -210,6 +217,20 @@ do
 	if test ! -f "$dir/$filename"
 	then
 
+		# Try to find the source package via the x86_64 versions index
+		release_url=
+		if test "$name" != "$w64"
+		then
+			x64_pkgname=mingw-w64-x86_64-$w64
+		else
+			x64_pkgname=$name
+		fi
+		release_tag="$(curl $github_curl_auth -Lsf \
+			"$pacman_repo_url/x86_64/$x64_pkgname.versions.json" |
+			sed -n 's/^ *"'"$version"'": *"\([^"]*\)".*/\1/p')"
+		test -z "$release_tag" ||
+		release_url=https://github.com/git-for-windows/pacman-repo/releases/download/$release_tag/$filename
+
 		case "$name" in
 		git-extra|mingw-w64-x86_64-git-extra|mingw-w64-i686-git-extra|mingw-w64-x86_64-git|mingw-w64-i686-git|msys2-runtime|mingw-w64-x86_64-git-credential-manager|mingw-w64-i686-git-credential-manager|mingw-w64-x86_64-git-credential-manager-core|mingw-w64-i686-git-credential-manager-core|mingw-w64-i686-git-lfs|mingw-w64-x86_64-git-lfs|curl|mingw-w64-i686-curl|mingw-w64-x86_64-curl|mingw-w64-i686-wintoast|mingw-w64-x86_64-wintoast|bash|heimdal|perl|openssh)
 			url="$azure_blobs_source_url/$filename"
@@ -269,13 +290,14 @@ do
 			;;
 		esac
 
-		echo "Downloading $url"
+		echo "Downloading ${release_url:-$url}"
 		test -s "$dir/$filename" ||
+		{ test -z "$release_url" || curl $github_curl_auth -sfLo "$dir/$filename" "$release_url"; } ||
 		curl -sfLo "$dir/$filename" "$url" ||
 		curl -sfLo "$dir/$filename" "$sf1_url" ||
 		curl -sfLo "$dir/$filename" "$sf2_url" ||
 		curl -sfLo "$dir/$filename" "$sf3_url" ||
-		die "Could not download $filename from $url ($sf1_url $sf2_url $sf3_url)" >&2
+		die "Could not download $filename from ${release_url:+$release_url }$url ($sf1_url $sf2_url $sf3_url)" >&2
 
 		test -s "$dir/$filename" ||
 		die "Empty file: $dir/$filename"

--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -125,6 +125,15 @@ repo_remove () {
 	done)
 }
 
+update_versions_json () { # <file> <version> <tagname>
+	{
+		test ! -f "$1" ||
+		sed -n 's/^ *\("[^"]*": *"[^"]*"\).*/ \1/p' "$1"
+		printf ' "%s": "%s"\n' "$2" "$3"
+	} | sort -u | sed '$!s/$/,/' |
+	{ printf '{\n'; cat; printf '}\n'; } >"$1.tmp" && mv "$1.tmp" "$1"
+}
+
 sanitize_db () { # <file>...
 	perl -e '
 		foreach my $path (@ARGV) {
@@ -225,7 +234,7 @@ quick_action () { # <action> <file>...
 	git -C "$dir" config set core.sparseCheckout true &&
 	git -C "$dir" config set core.sparseCheckoutCone false &&
 	mkdir -p "$dir"/.git/info &&
-	printf '%s\n' '/git-*.db*' '/git-*.files*' >"$dir"/.git/info/sparse-checkout &&
+	printf '%s\n' '/git-*.db*' '/git-*.files*' '/*.versions.json' >"$dir"/.git/info/sparse-checkout &&
 	printf '%s\n' '/git-for-windows.db*' '/git-for-windows.files*' >"$dir"/.git/info/exclude &&
 	mkdir "$dir/sources" ||
 	die "Could not create temporary directory"
@@ -351,6 +360,7 @@ quick_action () { # <action> <file>...
 	dbs=
 	to_push=
 	>"$dir/release_notes.txt"
+	tagname="$(TZ=UTC date +%Y-%m-%dT%H-%M-%S.%NZ)"
 	for arch in $architectures
 	do
 		eval "msys=\$${arch}_msys"
@@ -452,6 +462,16 @@ quick_action () { # <action> <file>...
 		 case "$label" in
 		 add)
 			git add --sparse $msys $mingw \*.sig ':(exclude)*.old.sig' &&
+			for file in $msys $mingw
+			do
+				pkgname="${file%-*-*-*.pkg.tar.*}" &&
+				remainder="${file#"$pkgname"-}" &&
+				verrel="${remainder%-*.pkg.tar.*}" &&
+				update_versions_json "$pkgname.versions.json" \
+					"$verrel" "$tagname" ||
+				die "Could not update %s\n" "$pkgname.versions.json"
+			done &&
+			git add --sparse '*.versions.json' &&
 			msg="$(printf 'Update %s package(s)\n\n%s\n' \
 				$(printf '%s\n' $msys $mingw | wc -l) \
 				"$(printf '%s\n' $msys $mingw |
@@ -501,6 +521,17 @@ quick_action () { # <action> <file>...
 					echo "Rebasing $arch" >&2
 					(cd "$dir/$arch" &&
 					 git -C "$dir/$arch" checkout HEAD^ -- 'git-for-windows*.db*' 'git-for-windows*.files*' &&
+					 # Revert .versions.json to parent state; re-inserted after rebase
+					 git diff-tree --no-commit-id -r --name-only HEAD -- '*.versions.json' |
+					 while IFS= read -r vjson
+					 do
+						if git cat-file -e "HEAD^:$vjson" 2>/dev/null
+						then
+							git checkout HEAD^ -- "$vjson"
+						else
+							git rm --cached -- "$vjson"
+						fi || exit 1
+					 done &&
 					 git -C "$dir/$arch" commit --amend --no-edit &&
 					 git -C "$dir/$arch" rebase origin/$arch &&
 
@@ -532,7 +563,22 @@ quick_action () { # <action> <file>...
 							}
 						}
 					 fi &&
-					 git -C "$dir/$arch" commit --amend --no-edit -- 'git-for-windows*.db*' 'git-for-windows*.files*') ||
+					 # Re-insert .versions.json entries after rebase
+					 case "$label" in
+					 add)
+						for file in $msys $mingw
+						do
+							pkgname="${file%-*-*-*.pkg.tar.*}" &&
+							remainder="${file#"$pkgname"-}" &&
+							verrel="${remainder%-*.pkg.tar.*}" &&
+							update_versions_json "$pkgname.versions.json" \
+								"$verrel" "$tagname" ||
+							die "Could not update %s\n" "$pkgname.versions.json"
+						done &&
+						git add --sparse '*.versions.json'
+						;;
+					 esac &&
+					 git -C "$dir/$arch" commit --amend --no-edit -- 'git-for-windows*.db*' 'git-for-windows*.files*' '*.versions.json') ||
 					die "Could not update $dir/$arch"
 				done
 				git -C "$dir" -c "$extra_header" push origin $to_push && break
@@ -547,7 +593,6 @@ quick_action () { # <action> <file>...
 
 	# Mirror the deployment to a new GitHub Release
 	# at `git-for-windows/pacman-repo`
-	tagname="$(TZ=UTC date +%Y-%m-%dT%H-%M-%S.%NZ)"
 	if test -n "$PACMANDRYRUN"
 	then
 		echo "Would create a GitHub Release '$tagname' at git-for-windows/pacman-repo" >&2

--- a/please.sh
+++ b/please.sh
@@ -265,6 +265,12 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 	unpack=$dir/.unpack
 	url=https://raw.githubusercontent.com/git-for-windows/pacman-repo/refs/heads
 
+	# When $GITHUB_TOKEN is non-empty, pass it via Basic Auth so the otherwise
+	# strictly rate-limited raw.githubusercontent.com (and api.github.com
+	# release download) endpoints accept more requests.
+	github_curl_auth=
+	test -z "$GITHUB_TOKEN" || github_curl_auth="-u x-access-token:$GITHUB_TOKEN"
+
 	mkdir -p "$dir" ||
 	die "Could not create '%s'\n" "$dir"
 
@@ -336,20 +342,25 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 				die 'Could not copy %s (%d)\n' "$tar" $?
 			else
 				echo "Retrieving $tar..." >&2
-				case $tar in
-				mingw-w64-x86_64-curl-*-8.18.0-1*|mingw-w64-i686-curl-*-8.18.0-1*)
-					tar_url=https://github.com/git-for-windows/pacman-repo/releases/download/2026-01-07T21-55-10.690988000Z/$tar;;
-				mingw-w64-clang-aarch64-curl-*-8.18.0-1*)
-					tar_url=https://github.com/git-for-windows/pacman-repo/releases/download/2026-01-07T21-45-13.731088400Z/$tar;;
-				*) tar_url=$url/$oarch/$tar;;
-				esac
-				curl -Lsfo "$dir/$tar" $tar_url
+				pkgname="${tar%-*-*-*.pkg.tar.*}"
+				remainder="${tar#"$pkgname"-}"
+				verrel="${remainder%-*.pkg.tar.*}"
+				release_tag="$(curl $github_curl_auth -Lsf \
+					"$url/$oarch/$pkgname.versions.json" |
+					sed -n 's/^ *"'"$verrel"'": *"\([^"]*\)".*/\1/p')"
+				if test -n "$release_tag"
+				then
+					tar_url=https://github.com/git-for-windows/pacman-repo/releases/download/$release_tag/$tar
+				else
+					tar_url=$url/$oarch/$tar
+				fi
+				curl $github_curl_auth -Lsfo "$dir/$tar" $tar_url
 				case $? in
 				0) ;; # okay
 				56)
 					while test 56 = $?
 					do
-						curl -Lsfo "$dir/$tar" $tar_url ||
+						curl $github_curl_auth -Lsfo "$dir/$tar" $tar_url ||
 						die "curl error %s (%d)\n" \
 							"$tar" $?
 					done


### PR DESCRIPTION
The Pacman repository for Git for Windows migrated from Azure Blob Storage to branches in git-for-windows/pacman-repo. Unlike the previous setup where all package versions accumulated in the same container, the Git-based repository only retains the latest version of each package in its branch. Older versions are still available as GitHub Release assets, but there was no way to discover which Release holds a particular version.

This has already caused CI failures when a job needed a package version that had been superseded, e.g. https://github.com/git-for-windows/git-sdk-64/actions/runs/25404775441/job/74515324990#step:7:28

This PR adds per-package `.versions.json` index files to each architecture branch of pacman-repo, mapping every version-pkgrel to the GitHub Release tag where the `.pkg.tar` asset can be downloaded.

### Changes

**pacman-helper.sh**: Maintains `.versions.json` during deployment. The `update_versions_json` helper uses `sed`/`sort` (no perl) to read, insert, sort, and write entries. In the concurrent-deployment rebase path, `.versions.json` changes are stripped before rebase and re-inserted afterwards to avoid conflicts.

**please.sh**: Replaces hard-coded curl 8.18.0-1 workarounds with a `.versions.json` lookup for PDB package downloads. Falls back to the branch URL when the index is unavailable.

**get-sources.sh**: Uses the x86_64 binary package's `.versions.json` to deduce the Release tag for source tarballs, making source packages downloadable from GitHub Releases ahead of turning off Azure Blob Storage.

### pacman-repo seeding

The three architecture branches have been seeded with `.versions.json` files built from all 1172 existing releases (97 packages / 2796 versions for x86_64, 112 / 2696 for i686, 46 / 932 for aarch64): git-for-windows/pacman-repo@c5122e6 git-for-windows/pacman-repo@84eb68d git-for-windows/pacman-repo@cfcc281

