### PR TITLE
Ensure Bash-specific completion commands run only in Bash

### DIFF
--- a/git-extra/PKGBUILD
+++ b/git-extra/PKGBUILD
@@ -5,7 +5,7 @@ pkgbase="mingw-w64-${_realname}"
 pkgname=($_realname
         "${MINGW_PACKAGE_PREFIX}-${_realname}")
 _ver_base=1.1
-pkgver=1.1.689.fe8c5259c
+pkgver=1.1.691.e78bebdf5
 pkgrel=1
 pkgdesc="Git for Windows extra files"
 arch=('any')
@@ -74,7 +74,7 @@ sha256sums=('8ed76d1cb069ac8568f21c431f5e23caebea502d932ab4cdff71396f4f0d5b72'
             'd212e1bbe75a9f81443126701324c9c44c3ed5750dd9822eba754a1799ed13b3'
             '402c51eba82453a76f5110f4754bb1005df507a6e4532574c2b9627ff4e1dc81'
             '8433a9e72b3bc9c3bc7903b54b868399bdb17a6c8de4af4dd5450dd42859c898'
-            'e2d0e4c58dca8ad7dba59df5db37a6ffb917f984edf67ae51d3f4c2db06e459b'
+            'e14a655b778db71b89f6b6b65af39c61994b53654325e84a10753957452f17bb'
             'a7540390bf956f33f6497a87c8986e124a8ecdacad26d0f75695c83dc2410d96'
             '32c9a549ecb1c9e06622221dae98a000ac2ce9c2be97d5d0c4f80610af3dc55c'
             '02d38e480a1ec4227e94a5aa073945901680aa3387e3386f8b77f10426ebbc75'

--- a/git-extra/git-prompt.sh
+++ b/git-extra/git-prompt.sh
@@ -17,7 +17,7 @@ else
 	PS1="$PS1"'$MSYSTEM '          # show MSYSTEM
 	PS1="$PS1"'\[\033[33m\]'       # change to brownish yellow
 	PS1="$PS1"'\w'                 # current working directory
-	if test -z "$WINELOADERNOEXEC"
+	if test -n "$BASH_VERSION" && test -z "$WINELOADERNOEXEC"
 	then
 		GIT_EXEC_PATH="$(git --exec-path 2>/dev/null)"
 		COMPLETION_PATH="${GIT_EXEC_PATH%/libexec/git-core}"
@@ -39,7 +39,7 @@ fi
 MSYS2_PS1="$PS1"               # for detection by MSYS2 SDK's bash.basrc
 
 # Evaluate all user-specific Bash completion scripts (if any)
-if test -z "$WINELOADERNOEXEC"
+if test -n "$BASH_VERSION" && test -z "$WINELOADERNOEXEC"
 then
 	for c in "$HOME"/bash_completion.d/*.bash
 	do
@@ -52,4 +52,7 @@ fi
 # Prevents command completion if line is empty or only has whitespace
 # Can be overriden by adding the following to your .bashrc file.
 # shopt -u no_empty_cmd_completion
-shopt -s no_empty_cmd_completion
+if test -n "$BASH_VERSION"
+then
+	shopt -s no_empty_cmd_completion
+fi


### PR DESCRIPTION
Modified git-prompt.sh to wrap Bash-only constructs with checks for $BASH_VERSION. This prevents errors when the script is sourced in non-Bash shells and maintains compatibility with MSYS2 environments and Wine.

- Wrap shopt and completion script evaluation with Bash check
- Add Bash check to WINELOADERNOEXEC conditionals

I'm a Windows user, and I'm using Zsh on top of git for windows, this fix the error when you run Zsh -i -l directly.
