### PR TITLE
check-for-missing-dlls: fixes for ARM64

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -124,7 +124,7 @@ grep '\.dll$' "$tmp_file.all" |
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
 		-e "^$MINGW_PREFIX/bin/libcurl\(\|-openssl\)-4.dll" \
-		-e "^$MINGW_PREFIX/bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|arm64\)\)\." \
+		-e "^$MINGW_PREFIX/bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|_arm64\)\)\." \
 		-e "^$MINGW_PREFIX/lib/ossl-modules/" \
 		-e "^$MINGW_PREFIX/lib/\(engines\|reg\|thread\)" |
 	sed 's/^/unused dll: /' |

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -129,10 +129,10 @@ grep '\.dll$' "$tmp_file.all" |
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
-		-e '^mingw../bin/libcurl\(\|-openssl\)-4.dll' \
-		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|arm64\)\)\.' \
-		-e '^mingw../lib/ossl-modules/' \
-		-e '^mingw../lib/\(engines\|reg\|thread\)' |
+		-e "^$MINGW_PREFIX/bin/libcurl\(\|-openssl\)-4.dll" \
+		-e "^$MINGW_PREFIX/bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|arm64\)\)\." \
+		-e "^$MINGW_PREFIX/lib/ossl-modules/" \
+		-e "^$MINGW_PREFIX/lib/\(engines\|reg\|thread\)" |
 	sed 's/^/unused dll: /' |
 	tee "$unused_dlls_file" >&2
 

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -27,14 +27,20 @@ die "Could not determine architecture"
 
 case "$MSYSTEM" in
 MINGW64) MINGW_PREFIX=mingw64;;
-CLANGARM64) MINGW_PREFIX=clangarm64;;
+CLANGARM64)
+	MINGW_PREFIX=clangarm64
+	ARCH=aarch64
+	;;
 MINGW32) MINGW_PREFIX=mingw32;;
 *)
 	case "$ARCH" in
 	i686) MINGW_PREFIX=mingw32;;
 	x86_64)
 		case $(uname -s) in
-			*-ARM64) MINGW_PREFIX=clangarm64;;
+			*-ARM64)
+				MINGW_PREFIX=clangarm64
+				ARCH=aarch64
+				;;
 			*) MINGW_PREFIX=mingw64;;
 		esac
 		;;

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -32,8 +32,12 @@ MINGW32) MINGW_PREFIX=mingw32;;
 
 	case "$ARCH" in
 	i686) MINGW_PREFIX=mingw32;;
-	x86_64) MINGW_PREFIX=mingw64;;
-	aarch64) MINGW_PREFIX=clangarm64;;
+	x86_64)
+		case $(uname -s) in
+			*-ARM64) MINGW_PREFIX=clangarm64;;
+			*) MINGW_PREFIX=mingw64;;
+		esac
+		;;
 	*) die "Unhandled architecture: $ARCH";;
 	esac
 	;;

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -93,6 +93,7 @@ do
 	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' |
 	while read a b c d
 	do
+		case "$c" in api-ms-*) continue;; esac # API set, always provided by Windows
 		case "$a,$b" in
 		*.exe:,*|*.dll:,*) current="${a%:}";;
 		dll,name:) # `objdump -p` / pe-imports.ps1 output

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -22,14 +22,14 @@ die "Could not enumerate system .dll files"
 LF='
 '
 
+ARCH="$(uname -m)" ||
+die "Could not determine architecture"
+
 case "$MSYSTEM" in
 MINGW64) MINGW_PREFIX=mingw64;;
 CLANGARM64) MINGW_PREFIX=clangarm64;;
 MINGW32) MINGW_PREFIX=mingw32;;
 *)
-	ARCH="$(uname -m)" ||
-	die "Could not determine architecture"
-
 	case "$ARCH" in
 	i686) MINGW_PREFIX=mingw32;;
 	x86_64)

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -82,26 +82,20 @@ do
 	paths=$(sed -ne 's,[][],\\&,g' -e "s,^$dir[^/]*\.\(dll\|exe\)$,/&,p" "$tmp_file.all")
 	/usr/bin/objdump -p $paths 2>"$tmp_file" >"$tmp_file.ldd"
 	paths="$(sed -n 's|^/usr/bin/objdump: \([^ :]*\): file format not recognized|\1|p' <"$tmp_file")"
-	test -z "$paths" ||
-	ldd $paths >>"$tmp_file.ldd"
+	if test -n "$paths"
+	then
+		powershell.exe -NoProfile -ExecutionPolicy Bypass \
+			-File "$thisdir/pe-imports.ps1" $paths >>"$tmp_file.ldd" ||
+		die "pe-imports.ps1 failed to parse PE imports"
+	fi
 
 	tr A-Z\\r a-z\ <"$tmp_file.ldd" |
-	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' -e '\.dll =>' |
+	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' |
 	while read a b c d
 	do
 		case "$a,$b" in
 		*.exe:,*|*.dll:,*) current="${a%:}";;
-		*.dll,"=>") # `ldd` output
-			echo "$a" >>"$used_dlls_file"
-			case "$sys_dlls$LF$dlls" in
-			*"/$a$LF"*) ;; # okay, it's included
-			*)
-				echo "$current is missing $a" >&2
-				echo "$a" >>"$missing_dlls_file"
-				;;
-			esac
-			;;
-		dll,name:) # `objdump -p` output
+		dll,name:) # `objdump -p` / pe-imports.ps1 output
 			echo "$c" >>"$used_dlls_file"
 			case "$sys_dlls$LF$dlls" in
 			*"/$c$LF"*) ;; # okay, it's included

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -309,6 +309,7 @@ else
 		-e '^/\(mingw\|clang\)[^/]*/bin/.*-\(inflate\|deflate\)hd\.exe$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/\(gettext\.sh\|gettextize\)$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/\(gitk\|git-upload-archive\.exe\)$' \
+		-e '^/\(mingw\|clang\)[^/]*/bin/libc++\.dll$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/libgcc_s_seh-.*\.dll$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/libjemalloc\.dll$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/lib\(ffi\|gmp\|gomp\|jansson\|metalink\|minizip\|tasn1\)-.*\.dll$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -89,6 +89,12 @@ test ! -f "/$MSYSTEM_LOWER/bin/git.exe" ||
 grep -q libssp "/$MSYSTEM_LOWER/bin/git.exe" ||
 EXCLUDE_LIBSSP='\|ssp'
 
+# On clangarm64, libunwind and libwinpthread-1 are pulled in by the toolchain's
+# package closure but are not statically imported by any shipped binary.
+EXCLUDE_CLANGARM64_RUNTIME=
+test aarch64 != "$ARCH" ||
+EXCLUDE_CLANGARM64_RUNTIME='^/clangarm64/bin/lib\(unwind\|winpthread-1\)\.dll$'
+
 this_script_dir="$(cd "$(dirname "$0")" && pwd -W)" ||
 die "Could not determine this script's dir"
 
@@ -237,6 +243,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/\(autopoint\|[a-z]*-config\)$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/lib\(asprintf\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|pcre2-[13]\|quadmath\|stdc++\|zip\)[^/]*\.dll$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/lib\(atomic\|charset\|gomp\|systre'"$EXCLUDE_LIBSSP"'\)-[0-9]*\.dll$' \
+	${EXCLUDE_CLANGARM64_RUNTIME:+-e "$EXCLUDE_CLANGARM64_RUNTIME"} \
 	-e '^/\(mingw\|clang\)[^/]*/bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\|zip\)[^/]*\.exe$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/recode-sr-latin.exe$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/\(cert\|p11\|psk\|srp\)tool.exe$' \

--- a/pe-imports.ps1
+++ b/pe-imports.ps1
@@ -1,0 +1,145 @@
+# pe-imports.ps1 - Parse PE import tables from binary files.
+# Outputs in objdump -p compatible format so check-for-missing-dlls.sh
+# can use it as a drop-in fallback when /usr/bin/objdump cannot handle
+# the PE architecture (e.g. pei-aarch64).
+#
+# PE format reference:
+# https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
+#
+# Usage: powershell.exe -NoProfile -ExecutionPolicy Bypass -File pe-imports.ps1 FILE...
+
+foreach ($file in $args) {
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($file)
+    } catch {
+        Write-Error "pe-imports: ${file}: cannot read file"
+        continue
+    }
+
+    try {
+        # `MZ`: DOS stub
+        if ($bytes.Length -lt 64 -or
+            $bytes[0] -ne 0x4D -or $bytes[1] -ne 0x5A) {
+            Write-Error "pe-imports: ${file}: not a PE file"
+            continue
+        }
+
+        # Look for `PE\0\0`
+        $peSignatureOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+        if ($peSignatureOffset + 24 -gt $bytes.Length -or
+            $bytes[$peSignatureOffset] -ne 0x50 -or $bytes[$peSignatureOffset+1] -ne 0x45 -or
+            $bytes[$peSignatureOffset+2] -ne 0 -or $bytes[$peSignatureOffset+3] -ne 0) {
+            Write-Error "pe-imports: ${file}: bad PE signature"
+            continue
+        }
+        $peOffset = $peSignatureOffset + 4
+
+        $numSections = [BitConverter]::ToUInt16($bytes, $peOffset + 2)
+        $optHdrSize  = [BitConverter]::ToUInt16($bytes, $peOffset + 16)
+        # See https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-image-only
+        $optHdrOff   = $peOffset + 20
+
+        $magic = [BitConverter]::ToUInt16($bytes, $optHdrOff)
+        switch ($magic) {
+            0x10B { $dataDirBase = $optHdrOff + 96 }   # PE32
+            0x20B { $dataDirBase = $optHdrOff + 112 }   # PE32+ (x64/ARM64)
+            default {
+                Write-Error "pe-imports: ${file}: unknown optional header magic 0x$($magic.ToString('X4'))"
+                continue
+            }
+        }
+        $optHdrEnd = $optHdrOff + $optHdrSize
+
+        # Data directory index 1: Import Table (8 bytes per entry); for details, see
+        # https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#optional-header-data-directories-image-only
+        $importRVA = [uint32]0
+        $importRVASize = [uint32]0
+        $importDirOff = $dataDirBase + 8
+        if ($importDirOff + 8 -le $optHdrEnd -and
+            $importDirOff + 8 -le $bytes.Length) {
+            $importRVA = [BitConverter]::ToUInt32($bytes, $importDirOff)
+            $importRVASize = [BitConverter]::ToUInt32($bytes, $importDirOff + 4)
+        }
+
+        # Data directory index 13: Delay Import Descriptor
+        $delayImportRVA = [uint32]0
+        $delayImportRVASize = [uint32]0
+        $delayDirOff = $dataDirBase + 104 # = optHdrOff + 200/216 for 32-bit/64-bit
+        if ($delayDirOff + 8 -le $optHdrEnd -and
+            $delayDirOff + 8 -le $bytes.Length) {
+            $delayImportRVA = [BitConverter]::ToUInt32($bytes, $delayDirOff)
+            $delayImportRVASize = [BitConverter]::ToUInt32($bytes, $delayDirOff + 4)
+        }
+
+        if (($importRVA -eq 0 -or $importRVASize -eq 0) -and ($delayImportRVA -eq 0 -or $delayImportRVASize -eq 0)) {
+            # No imports; emit header only so the caller still sees the file.
+            Write-Output "${file}:"
+            continue
+        }
+
+        # Build section table for RVA-to-file-offset translation.
+        # Per the PE spec, an RVA belongs to a section when
+        # VirtualAddress <= RVA < VirtualAddress + VirtualSize.
+        # https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers
+        $secStart = $optHdrOff + $optHdrSize
+        $secVA    = New-Object uint32[] $numSections
+        $secRaw   = New-Object uint32[] $numSections
+        $secVSz   = New-Object uint32[] $numSections
+        for ($i = 0; $i -lt $numSections; $i++) {
+            $o = $secStart + $i * 40
+            $secVA[$i]  = [BitConverter]::ToUInt32($bytes, $o + 12)  # VirtualAddress
+            $secRaw[$i] = [BitConverter]::ToUInt32($bytes, $o + 20)  # PointerToRawData
+            $secVSz[$i] = [BitConverter]::ToUInt32($bytes, $o + 8)   # VirtualSize
+        }
+
+        # Translate an RVA to a file offset; return -1 on failure.
+        $rvaToOffset = {
+            param([uint32]$rva)
+            for ($j = 0; $j -lt $numSections; $j++) {
+                if ($rva -ge $secVA[$j] -and $rva -lt ($secVA[$j] + $secVSz[$j])) {
+                    return $rva - $secVA[$j] + $secRaw[$j]
+                }
+            }
+            return -1
+        }
+
+        # Walk an import descriptor array and emit "DLL Name:" lines.
+        $walkImports = {
+            param([uint32]$descRVA, [uint32]$descRVASize, [int]$descSize, [int]$nameField)
+            $p = & $rvaToOffset $descRVA
+            if ($p -lt 0) { return }
+
+            while ($descRVASize -ge $descSize -and $p + $descSize -le $bytes.Length) {
+                $nRVA = [BitConverter]::ToUInt32($bytes, $p + $nameField)
+                if ($nRVA -eq 0) { break }
+
+                $nOff = & $rvaToOffset $nRVA
+                if ($nOff -lt 0 -or $nOff -ge $bytes.Length) { break }
+
+                $end = $nOff
+                while ($end -lt $bytes.Length -and $bytes[$end] -ne 0) { $end++ }
+
+                $dllName = [System.Text.Encoding]::ASCII.GetString($bytes, $nOff, $end - $nOff)
+                Write-Output "$([char]9)DLL Name: $dllName"
+
+                $p += $descSize
+                $descRVASize -= $descSize
+            }
+        }
+
+        Write-Output "${file}:"
+
+        # Import directory: 20-byte descriptors, Name RVA at offset 12
+        if ($importRVA -ne 0 -and $importRVASize -gt 0) {
+            & $walkImports $importRVA $importRVASize 20 12
+        }
+
+        # Delay-load import directory: 32-byte descriptors, Name RVA at offset 4
+        if ($delayImportRVA -ne 0 -and $delayImportRVASize -gt 0) {
+            & $walkImports $delayImportRVA $delayImportRVASize 32 4
+        }
+    } catch {
+        Write-Error "pe-imports: ${file}: $_"
+        continue
+    }
+}


### PR DESCRIPTION
Our `check-for-missing-dlls` workflow in the git-sdk-arm64 repo currently does nothing. These fixes should make it work as expected.