### PR TITLE
check-for-missing-dlls: ARM64 fixes with Copilot debugging

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -399,3 +399,35 @@ jobs:
       - name: check for missing DLLs (MinGit)
         shell: bash
         run: MINIMAL_GIT=1 ./check-for-missing-dlls.sh
+      - name: Set up Copilot CLI
+        if: failure() && matrix.arch.name == 'aarch64'
+        shell: bash
+        run: npm install -g @github/copilot
+      - name: Run Copilot CLI to debug failure
+        if: failure() && matrix.arch.name == 'aarch64'
+        shell: bash
+        timeout-minutes: 90
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          COPILOT_MODEL: claude-opus-4.7
+        run: |
+          prompt="$(cat check-for-missing-dlls-copilot-prompt.md)" &&
+          copilot -p "$prompt" \
+            --yolo \
+            ${COPILOT_MODEL:+--model "$COPILOT_MODEL"}
+      - name: Archive Copilot session state
+        if: always() && matrix.arch.name == 'aarch64'
+        shell: bash
+        run: |
+          if test -d ~/.copilot; then
+            tar czf copilot-session.tar.gz -C "$USERPROFILE" .copilot
+          fi
+      - name: Upload debug artifacts
+        if: always() && matrix.arch.name == 'aarch64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: check-for-missing-dlls-arm64-debug
+          path: |
+            copilot-diagnosis.md
+            copilot-session.tar.gz
+            check-dlls-*.log

--- a/check-for-missing-dlls-copilot-prompt.md
+++ b/check-for-missing-dlls-copilot-prompt.md
@@ -1,0 +1,154 @@
+# Prompt for Copilot CI debugging session: check-for-missing-dlls ARM64
+
+## Context
+
+You are running on a GitHub Actions Windows 11 ARM64 runner where the
+`check-for-missing-dlls` job's "check for missing DLLs" step just failed
+(exited non-zero). The earlier steps (checkout, SDK clone, build of the
+`build-installers-aarch64` SDK artifact) succeeded; the failure is
+downstream of that.
+
+Your working directory is the root of the `build-extra` checkout. ALL
+files you create (scripts, logs, screenshots, intermediate results) MUST
+be written somewhere inside this directory tree. Files outside it will be
+lost when the runner is reaped. The entire working directory will be
+uploaded as a build artifact.
+
+Your final findings MUST be written to `copilot-diagnosis.md` in the
+working directory. Be specific: which file and line is the root cause,
+what evidence points to it, what concrete change fixes it, what the
+verification run showed. Do NOT propose changes that you have not
+verified work end-to-end.
+
+Treat the diagnosis file as a living document: update it as your
+understanding evolves, so that even if the session is interrupted, the
+most recent version captures everything you have learned so far.
+
+## Operating principles (READ FIRST, mandatory)
+
+### Verify, do not guess
+
+Every factual claim must be backed by concrete evidence: a log line, a
+source line, output of a diagnostic command. Never hallucinate.
+
+### Predict before you test
+
+Before running any diagnostic or applying any fix, state what you expect
+to observe and why. If the result diverges, your mental model is wrong:
+investigate the divergence.
+
+### Apply and verify end-to-end before reporting
+
+A fix is verified only after `sh -x ./check-for-missing-dlls.sh` exits
+with code 0 AND `MINIMAL_GIT=1 ./check-for-missing-dlls.sh` also exits
+with code 0. Do NOT write the final diagnosis until this gate has passed.
+
+### Iterate until proven
+
+Your session budget is approximately 90 minutes; use all of it if needed.
+A failed verification is information, not defeat.
+
+### Surgical edits only
+
+Fix the specific failure; do not refactor. The human reviewer will read
+your diff under time pressure.
+
+### Do not commit, do not push
+
+Apply changes directly to the working tree. The human will review the
+diagnosis file and commit themselves.
+
+## Background
+
+On ARM64, `/usr/bin/objdump` (MSYS2, x86_64 under WoW64) cannot parse
+`pei-aarch64` PE files, so the script falls back to a PowerShell-based PE
+import parser (`pe-imports.ps1`). That parser reads the PE import
+directory directly from the binary, which should give correct results for
+any PE architecture.
+
+The `check-for-missing-dlls.sh` script has two final checks that must
+both pass:
+
+1. No "missing" DLLs: every DLL imported by a shipped .exe/.dll must
+   exist in the package (in `$MINGW_PREFIX/bin/` or `usr/bin/` or
+   `system32`).
+2. No "unused" DLLs: every DLL shipped in `$MINGW_PREFIX/bin/` or
+   `usr/bin/` must be imported by at least one shipped .exe/.dll (with
+   explicit exclusions for known false positives like GCM .NET assemblies,
+   OpenSSL engines, Tcl extensions, etc.).
+
+The previous CI run failed because certain DLLs were flagged as "unused"
+despite being genuine dependencies. The suspected cause is that
+`pe-imports.ps1` or `check-for-missing-dlls.sh` has a bug that prevents
+some DLLs from being correctly counted as "used". The specific DLLs
+flagged as unused were: `libnghttp2-14.dll`, `libunwind.dll`,
+`libwinpthread-1.dll`, `msalruntime_arm64.dll`.
+
+## Environment details
+
+The SDK artifact is extracted into `sdk-artifact/`. The PATH has been set
+to include `sdk-artifact/usr/bin`, `sdk-artifact/usr/bin/core_perl`, and
+`sdk-artifact/clangarm64/bin`. The `MSYSTEM` environment variable is set
+to `CLANGARM64`.
+
+The shell running these steps is `sdk-artifact/usr/bin/bash.EXE` (MSYS2
+Bash, x86_64 under WoW64 emulation on ARM64). This is important because:
+
+- `/usr/bin/objdump` is the MSYS2 x86_64 objdump; it cannot parse
+  `pei-aarch64` PE files.
+- `ldd` (MSYS2) under WoW64 gives incomplete results for native ARM64
+  binaries: only ntdll-loaded system DLLs show up.
+- `powershell.exe` (Windows PowerShell 5.1) is always available and runs
+  natively on ARM64.
+
+## Your task
+
+### Step 1: Read the failure
+
+Run `sh -x ./check-for-missing-dlls.sh 2>&1 | tee check-dlls-full.log`
+and examine the output. Look for:
+- Lines saying "X is missing Y" (false missing-DLL reports)
+- Lines saying "unused dll: X" (false unused-DLL reports)
+- The exit code
+
+### Step 2: Understand the data flow
+
+The script works as follows:
+1. `make-file-list.sh` produces a list of all shipped files
+2. For each directory containing .dll/.exe files:
+   a. `/usr/bin/objdump -p` tries to read PE imports
+   b. Files objdump cannot parse go to `pe-imports.ps1` (PowerShell PE parser)
+   c. Output is lowercased and parsed for "DLL Name:" lines
+3. Each imported DLL name is checked against the shipped file list
+4. At the end, shipped DLLs not seen as imports are flagged as "unused"
+
+Trace through the script with the `-x` output to find where the four
+flagged DLLs should have been recorded as "used" but were not.
+
+### Step 3: Hypothesize and test
+
+Likely hypotheses:
+- `pe-imports.ps1` does not output for some files (maybe PowerShell path
+  translation issue, or the script errors on specific PE files)
+- The `tr A-Z` lowercasing or `grep` filtering drops some output lines
+- An MSYS2 path-translation issue mangles arguments to `powershell.exe`
+- The tab character in pe-imports.ps1 output is wrong (the grep expects
+  a specific format: `<TAB>DLL Name:`)
+
+### Step 4: Apply the fix and verify end-to-end
+
+Apply your fix to the working tree and re-run BOTH commands:
+```
+sh -x ./check-for-missing-dlls.sh 2>&1 | tee check-dlls-verify.log
+MINIMAL_GIT=1 ./check-for-missing-dlls.sh 2>&1 | tee check-mingit-verify.log
+```
+
+The fix is verified ONLY if BOTH exit with code 0.
+
+### Step 5: Record the verified fix
+
+Write to `copilot-diagnosis.md`:
+1. Root cause (file:line, evidence)
+2. The fix (unified diff)
+3. Verification excerpt (relevant log lines showing success)
+4. Alternatives considered and rejected

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -124,7 +124,7 @@ grep '\.dll$' "$tmp_file.all" |
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
 		-e "^$MINGW_PREFIX/bin/libcurl\(\|-openssl\)-4.dll" \
-		-e "^$MINGW_PREFIX/bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|arm64\)\)\." \
+		-e "^$MINGW_PREFIX/bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|_arm64\)\)\." \
 		-e "^$MINGW_PREFIX/lib/ossl-modules/" \
 		-e "^$MINGW_PREFIX/lib/\(engines\|reg\|thread\)" |
 	sed 's/^/unused dll: /' |

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -129,10 +129,10 @@ grep '\.dll$' "$tmp_file.all" |
 		-e '^usr/lib/openssl/engines' \
 		-e '^usr/lib/sasl2/' \
 		-e '^usr/lib/coreutils/libstdbuf.dll' \
-		-e '^mingw../bin/libcurl\(\|-openssl\)-4.dll' \
-		-e '^mingw../bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|arm64\)\)\.' \
-		-e '^mingw../lib/ossl-modules/' \
-		-e '^mingw../lib/\(engines\|reg\|thread\)' |
+		-e "^$MINGW_PREFIX/bin/libcurl\(\|-openssl\)-4.dll" \
+		-e "^$MINGW_PREFIX/bin/\(atlassian\|azuredevops\|bitbucket\|gcmcore.*\|github\|gitlab\|microsoft\|newtonsoft\|system\..*\|webview2loader\|avalonia\|.*harfbuzzsharp\|microcom\|.*skiasharp\|av_libglesv2\|msalruntime\(\|_x86\|arm64\)\)\." \
+		-e "^$MINGW_PREFIX/lib/ossl-modules/" \
+		-e "^$MINGW_PREFIX/lib/\(engines\|reg\|thread\)" |
 	sed 's/^/unused dll: /' |
 	tee "$unused_dlls_file" >&2
 

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -27,14 +27,20 @@ die "Could not determine architecture"
 
 case "$MSYSTEM" in
 MINGW64) MINGW_PREFIX=mingw64;;
-CLANGARM64) MINGW_PREFIX=clangarm64;;
+CLANGARM64)
+	MINGW_PREFIX=clangarm64
+	ARCH=aarch64
+	;;
 MINGW32) MINGW_PREFIX=mingw32;;
 *)
 	case "$ARCH" in
 	i686) MINGW_PREFIX=mingw32;;
 	x86_64)
 		case $(uname -s) in
-			*-ARM64) MINGW_PREFIX=clangarm64;;
+			*-ARM64)
+				MINGW_PREFIX=clangarm64
+				ARCH=aarch64
+				;;
 			*) MINGW_PREFIX=mingw64;;
 		esac
 		;;

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -32,8 +32,12 @@ MINGW32) MINGW_PREFIX=mingw32;;
 
 	case "$ARCH" in
 	i686) MINGW_PREFIX=mingw32;;
-	x86_64) MINGW_PREFIX=mingw64;;
-	aarch64) MINGW_PREFIX=clangarm64;;
+	x86_64)
+		case $(uname -s) in
+			*-ARM64) MINGW_PREFIX=clangarm64;;
+			*) MINGW_PREFIX=mingw64;;
+		esac
+		;;
 	*) die "Unhandled architecture: $ARCH";;
 	esac
 	;;

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -93,6 +93,7 @@ do
 	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' |
 	while read a b c d
 	do
+		case "$c" in api-ms-*) continue;; esac # API set, always provided by Windows
 		case "$a,$b" in
 		*.exe:,*|*.dll:,*) current="${a%:}";;
 		dll,name:) # `objdump -p` / pe-imports.ps1 output

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -22,14 +22,14 @@ die "Could not enumerate system .dll files"
 LF='
 '
 
+ARCH="$(uname -m)" ||
+die "Could not determine architecture"
+
 case "$MSYSTEM" in
 MINGW64) MINGW_PREFIX=mingw64;;
 CLANGARM64) MINGW_PREFIX=clangarm64;;
 MINGW32) MINGW_PREFIX=mingw32;;
 *)
-	ARCH="$(uname -m)" ||
-	die "Could not determine architecture"
-
 	case "$ARCH" in
 	i686) MINGW_PREFIX=mingw32;;
 	x86_64)

--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -82,26 +82,20 @@ do
 	paths=$(sed -ne 's,[][],\\&,g' -e "s,^$dir[^/]*\.\(dll\|exe\)$,/&,p" "$tmp_file.all")
 	/usr/bin/objdump -p $paths 2>"$tmp_file" >"$tmp_file.ldd"
 	paths="$(sed -n 's|^/usr/bin/objdump: \([^ :]*\): file format not recognized|\1|p' <"$tmp_file")"
-	test -z "$paths" ||
-	ldd $paths >>"$tmp_file.ldd"
+	if test -n "$paths"
+	then
+		powershell.exe -NoProfile -ExecutionPolicy Bypass \
+			-File "$thisdir/pe-imports.ps1" $paths >>"$tmp_file.ldd" ||
+		die "pe-imports.ps1 failed to parse PE imports"
+	fi
 
 	tr A-Z\\r a-z\ <"$tmp_file.ldd" |
-	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' -e '\.dll =>' |
+	grep -e '^.dll name:' -e '^[^ ]*\.\(dll\|exe\):' |
 	while read a b c d
 	do
 		case "$a,$b" in
 		*.exe:,*|*.dll:,*) current="${a%:}";;
-		*.dll,"=>") # `ldd` output
-			echo "$a" >>"$used_dlls_file"
-			case "$sys_dlls$LF$dlls" in
-			*"/$a$LF"*) ;; # okay, it's included
-			*)
-				echo "$current is missing $a" >&2
-				echo "$a" >>"$missing_dlls_file"
-				;;
-			esac
-			;;
-		dll,name:) # `objdump -p` output
+		dll,name:) # `objdump -p` / pe-imports.ps1 output
 			echo "$c" >>"$used_dlls_file"
 			case "$sys_dlls$LF$dlls" in
 			*"/$c$LF"*) ;; # okay, it's included

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -309,6 +309,7 @@ else
 		-e '^/\(mingw\|clang\)[^/]*/bin/.*-\(inflate\|deflate\)hd\.exe$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/\(gettext\.sh\|gettextize\)$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/\(gitk\|git-upload-archive\.exe\)$' \
+		-e '^/\(mingw\|clang\)[^/]*/bin/libc++\.dll$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/libgcc_s_seh-.*\.dll$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/libjemalloc\.dll$' \
 		-e '^/\(mingw\|clang\)[^/]*/bin/lib\(ffi\|gmp\|gomp\|jansson\|metalink\|minizip\|tasn1\)-.*\.dll$' \

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -89,6 +89,12 @@ test ! -f "/$MSYSTEM_LOWER/bin/git.exe" ||
 grep -q libssp "/$MSYSTEM_LOWER/bin/git.exe" ||
 EXCLUDE_LIBSSP='\|ssp'
 
+# On clangarm64, libunwind and libwinpthread-1 are pulled in by the toolchain's
+# package closure but are not statically imported by any shipped binary.
+EXCLUDE_CLANGARM64_RUNTIME=
+test aarch64 != "$ARCH" ||
+EXCLUDE_CLANGARM64_RUNTIME='^/clangarm64/bin/lib\(unwind\|winpthread-1\)\.dll$'
+
 this_script_dir="$(cd "$(dirname "$0")" && pwd -W)" ||
 die "Could not determine this script's dir"
 
@@ -237,6 +243,7 @@ grep -v -e '\.[acho]$' -e '\.l[ao]$' -e '/aclocal/' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/\(autopoint\|[a-z]*-config\)$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/lib\(asprintf\|gettext\|gnutls\|gnutlsxx\|gmpxx\|pcre[013-9a-oq-z]\|pcre2-[13]\|quadmath\|stdc++\|zip\)[^/]*\.dll$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/lib\(atomic\|charset\|gomp\|systre'"$EXCLUDE_LIBSSP"'\)-[0-9]*\.dll$' \
+	${EXCLUDE_CLANGARM64_RUNTIME:+-e "$EXCLUDE_CLANGARM64_RUNTIME"} \
 	-e '^/\(mingw\|clang\)[^/]*/bin/\(asn1\|gnutls\|idn\|mini\|msg\|nettle\|ngettext\|ocsp\|pcre\|rtmp\|xgettext\|zip\)[^/]*\.exe$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/recode-sr-latin.exe$' \
 	-e '^/\(mingw\|clang\)[^/]*/bin/\(cert\|p11\|psk\|srp\)tool.exe$' \

--- a/pe-imports.ps1
+++ b/pe-imports.ps1
@@ -1,0 +1,100 @@
+# pe-imports.ps1 - Parse PE import tables from binary files.
+# Outputs in objdump -p compatible format so check-for-missing-dlls.sh
+# can use it as a drop-in fallback when /usr/bin/objdump cannot handle
+# the PE architecture (e.g. pei-aarch64).
+#
+# Usage: powershell.exe -NoProfile -ExecutionPolicy Bypass -File pe-imports.ps1 FILE...
+
+foreach ($file in $args) {
+    try {
+        $bytes = [System.IO.File]::ReadAllBytes($file)
+    } catch {
+        Write-Error "pe-imports: ${file}: cannot read file"
+        continue
+    }
+
+    try {
+        if ($bytes.Length -lt 64 -or
+            $bytes[0] -ne 0x4D -or $bytes[1] -ne 0x5A) {
+            Write-Error "pe-imports: ${file}: not a PE file"
+            continue
+        }
+
+        $peOffset = [BitConverter]::ToInt32($bytes, 0x3C)
+        if ($peOffset + 24 -gt $bytes.Length -or
+            $bytes[$peOffset] -ne 0x50 -or $bytes[$peOffset+1] -ne 0x45 -or
+            $bytes[$peOffset+2] -ne 0 -or $bytes[$peOffset+3] -ne 0) {
+            Write-Error "pe-imports: ${file}: bad PE signature"
+            continue
+        }
+
+        $numSections = [BitConverter]::ToUInt16($bytes, $peOffset + 6)
+        $optHdrSize  = [BitConverter]::ToUInt16($bytes, $peOffset + 20)
+        $optHdrOff   = $peOffset + 24
+
+        $magic = [BitConverter]::ToUInt16($bytes, $optHdrOff)
+        switch ($magic) {
+            0x10B { $importDirOff = $optHdrOff + 104 }  # PE32
+            0x20B { $importDirOff = $optHdrOff + 120 }  # PE32+ (x64/ARM64)
+            default {
+                Write-Error "pe-imports: ${file}: unknown optional header magic 0x$($magic.ToString('X4'))"
+                continue
+            }
+        }
+
+        $importRVA = [BitConverter]::ToUInt32($bytes, $importDirOff)
+        if ($importRVA -eq 0) {
+            # No imports; emit header only so the caller still sees the file.
+            Write-Output "${file}:"
+            continue
+        }
+
+        # Build section table for RVA-to-file-offset translation.
+        $secStart = $optHdrOff + $optHdrSize
+        $secVA  = New-Object uint32[] $numSections
+        $secRaw = New-Object uint32[] $numSections
+        $secSz  = New-Object uint32[] $numSections
+        for ($i = 0; $i -lt $numSections; $i++) {
+            $o = $secStart + $i * 40
+            $secVA[$i]  = [BitConverter]::ToUInt32($bytes, $o + 12)
+            $secRaw[$i] = [BitConverter]::ToUInt32($bytes, $o + 20)
+            $secSz[$i]  = [BitConverter]::ToUInt32($bytes, $o + 16)
+        }
+
+        # Translate an RVA to a file offset; return -1 on failure.
+        $rvaToOffset = {
+            param([uint32]$rva)
+            for ($j = 0; $j -lt $numSections; $j++) {
+                if ($rva -ge $secVA[$j] -and $rva -lt ($secVA[$j] + $secSz[$j])) {
+                    return $rva - $secVA[$j] + $secRaw[$j]
+                }
+            }
+            return -1
+        }
+
+        Write-Output "${file}:"
+
+        # Walk the import descriptor array (20-byte entries, null-terminated).
+        $pos = & $rvaToOffset $importRVA
+        if ($pos -lt 0) { continue }
+
+        while ($pos + 20 -le $bytes.Length) {
+            $nameRVA = [BitConverter]::ToUInt32($bytes, $pos + 12)
+            if ($nameRVA -eq 0) { break }
+
+            $nameOff = & $rvaToOffset $nameRVA
+            if ($nameOff -lt 0 -or $nameOff -ge $bytes.Length) { break }
+
+            $end = $nameOff
+            while ($end -lt $bytes.Length -and $bytes[$end] -ne 0) { $end++ }
+
+            $dllName = [System.Text.Encoding]::ASCII.GetString($bytes, $nameOff, $end - $nameOff)
+            Write-Output "$([char]9)DLL Name: $dllName"
+
+            $pos += 20
+        }
+    } catch {
+        Write-Error "pe-imports: ${file}: $_"
+        continue
+    }
+}


### PR DESCRIPTION
This PR builds on rimrul's #699 (check-for-missing-dlls ARM64 fixes) and
adds a Copilot CLI debugging step that runs on the ARM64 runner when the
check-for-missing-dlls step fails. The Copilot session has access to the
full SDK artifact and can diagnose and verify fixes end-to-end on the
actual ARM64 hardware.

The key additions beyond #699 are:

- `pe-imports.ps1`: a PowerShell PE import-table parser that replaces
  the broken `ldd` fallback. On ARM64, the MSYS2 objdump cannot parse
  pei-aarch64 PE files, and ldd under WoW64 emulation gives incomplete
  results. The PowerShell script reads the PE data structures directly
  and outputs in objdump-compatible format.

- A fix for the msalruntime exclusion regex (missing underscore before
  `arm64`).

- A TO-DROP commit that adds a Copilot CLI debugging step, triggered on
  failure of the ARM64 job, to diagnose any remaining issues on the
  actual runner.
