### PR TITLE
installer: restrict ARM64 installs to compatible systems

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -88,6 +88,9 @@ UninstallDisplayIcon={app}\{#MINGW_BITNESS}\share\git\git-for-windows.ico
 #ifndef COMPILE_FROM_IDE
 VersionInfoVersion={#FILE_VERSION}
 #endif
+#ifdef ARCHS_ALLOWED
+ArchitecturesAllowed={#ARCHS_ALLOWED}
+#endif
 
 ; Cosmetic
 SetupIconFile={#SourcePath}\..\git.ico

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -127,7 +127,7 @@ MINGW64)
 CLANGARM64)
 	BITNESS=64
 	ARCH=aarch64
-	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX 'arm64'"
+	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX 'arm64'$LF#define ARCHS_ALLOWED 'arm64 and x64compatible'"
 	;;
 *)
 	die "Unhandled MSYSTEM: $MSYSTEM"


### PR DESCRIPTION
We currently allow the ARM64 Version of Git for Windows to be installed
on x64 systems, but users can't use the installed Git in that
situation. Prevent this frustrating experience early.

This fixes https://github.com/git-for-windows/git/issues/6115
