### PR TITLE
Prepare for building UCRT64 packages

### DIFF
--- a/check-for-missing-dlls.sh
+++ b/check-for-missing-dlls.sh
@@ -27,6 +27,10 @@ die "Could not determine architecture"
 
 case "$MSYSTEM" in
 MINGW64) MINGW_PREFIX=mingw64;;
+UCRT64)
+	MINGW_PREFIX=ucrt64
+	ARCH=ucrt64
+	;;
 CLANGARM64)
 	MINGW_PREFIX=clangarm64
 	ARCH=aarch64

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -9,6 +9,10 @@ test -n "$ARCH" ||
 die "Need ARCH to be set"
 
 case "$ARCH" in
+ucrt64)
+	MSYSTEM_LOWER=ucrt64
+	PACMAN_ARCH=ucrt-x86_64
+	;;
 x86_64)
 	MSYSTEM_LOWER=mingw64
 	PACMAN_ARCH=x86_64

--- a/please.sh
+++ b/please.sh
@@ -389,7 +389,7 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 	done
 }
 
-create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--architecture=(x86_64|i686|aarch64|auto)] [--bitness=(32|64)] [--force] <name>
+create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--architecture=(x86_64|i686|aarch64|ucrt64|auto)] [--bitness=(32|64)] [--force] <name>
 	git_sdk_path=/
 	output_path=
 	force=
@@ -490,6 +490,11 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 	fi
 
 	case "$architecture" in
+	ucrt64)
+		MSYSTEM=UCRT64
+		PREFIX="/ucrt64"
+		SDK_REPO="git-sdk-64"
+		;;
 	x86_64)
 		MSYSTEM=MINGW64
 		PREFIX="/mingw64"

--- a/please.sh
+++ b/please.sh
@@ -670,7 +670,9 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 			git -C "$git_sdk_path" show HEAD:.sparse/minimal-sdk >"$sparse_checkout_file" &&
 			printf '\n' >>"$sparse_checkout_file" &&
 			git -C "$git_sdk_path" show HEAD:.sparse/makepkg-git >>"$sparse_checkout_file" &&
-			if test x86_64 = $architecture
+			if test x86_64 = $architecture &&
+				git -C "$git_sdk_path" rev-parse -q --verify \
+					HEAD:.sparse/makepkg-git-i686 >/dev/null
 			then
 				printf '\n' >>"$sparse_checkout_file" &&
 				git -C "$git_sdk_path" show HEAD:.sparse/makepkg-git-i686 >>"$sparse_checkout_file"


### PR DESCRIPTION
This is part of the MINGW64-to-UCRT64 migration in git-for-windows/git-sdk-64#117: the `.sparse/makepkg-git-i686` file is being retired, and the pseudo-architecture `ucrt64` needs to be introduced for the transitional period until git-sdk-64's `main` branch switches from MINGW64 to UCRT64.