### PR TITLE
installer: fix compilation when no experimental options are enabled

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -2553,8 +2553,10 @@ begin
 #endif
 
     PageIDBeforeInstall:=CurrentCustomPageID;
+#ifdef HAVE_EXPERIMENTAL_OPTIONS
     if (PageIDBeforeInstall=ExperimentalOptionsPage.ID) and IsHiddenExperimentalOptionsPageEmpty then
         PageIDBeforeInstall:=PageIDBeforeInstall-1;
+#endif
 
     (*
      * Create a custom page for finding the processes that lock a module.
@@ -2630,9 +2632,12 @@ begin
             Result:=False
         else
             Result:=(PageID<>wpInfoBefore) and (PageID<>wpFinished);
-    end else if (PageID=ExperimentalOptionsPage.ID) and IsHiddenExperimentalOptionsPageEmpty then
+    end
+#ifdef HAVE_EXPERIMENTAL_OPTIONS
+    else if (PageID=ExperimentalOptionsPage.ID) and IsHiddenExperimentalOptionsPageEmpty then
         // Skip experimental options page if all options are hidden
         Result:=True
+#endif
     else
         Result:=False;
 #ifdef DEBUG_WIZARD_PAGE


### PR DESCRIPTION
### Description

When `HAVE_EXPERIMENTAL_OPTIONS` is undefined the Inno Setup compiler fails with the following error:
`Unknown identifier 'ExperimentalOptionsPage'`

### Technical Fix

Wrap the remaining references to `ExperimentalOptionsPage` in `#ifdef HAVE_EXPERIMENTAL_OPTIONS` blocks. This ensures the installer compiles successfully in environments where all experimental features are disabled.