### PR TITLE
pacman-helper: inline a `vercmp` Bash function into the patched repo-add

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -79,8 +79,48 @@ call_gpg () {
 repo_add () {
 	if test ! -s "$this_script_dir/repo-add"
 	then
-		# Make sure that GPGKEY is used unquoted
-		 sed 's/"\(\${\?GPGKEY}\?\)"/\1/g' </usr/bin/repo-add >"$this_script_dir/repo-add"
+		# The `build-installers` SDK that is used by the
+		# `pacman-packages` action of
+		# `git-for-windows/git-for-windows-automation` does not ship
+		# `vercmp.exe`. Inject a small Bash function of the same name
+		# (`repo-add` is a Bash script, so it picks it up at the call
+		# site without any PATH manipulation), and make sure that
+		# `GPGKEY` is used unquoted.
+		{
+			sed '1q' </usr/bin/repo-add &&
+			cat <<\VERCMP_EOF &&
+vercmp () {
+    [[ "$1" = "$2" ]] && { echo 0; return; }
+    local -a sa=( ${1//[^0-9A-Za-z]/ } )
+    local -a sb=( ${2//[^0-9A-Za-z]/ } )
+    local n=${#sa[@]}
+    (( ${#sb[@]} < n )) && n=${#sb[@]}
+    local i
+    for (( i = 0; i < n; i++ )); do
+        [[ "${sa[i]}" = "${sb[i]}" ]] && continue
+        if [[ "${sa[i]}" =~ ^[0-9]+$ && "${sb[i]}" =~ ^[0-9]+$ ]]; then
+            (( 10#${sa[i]} > 10#${sb[i]} )) && echo 1 || echo -1
+            return
+        fi
+        [[ "${sa[i]}" =~ ^[0-9]+$ ]] && { echo  1; return; }
+        [[ "${sb[i]}" =~ ^[0-9]+$ ]] && { echo -1; return; }
+        [[ "${sa[i]}" > "${sb[i]}" ]] && echo 1 || echo -1
+        return
+    done
+    (( ${#sa[@]} == ${#sb[@]} )) && { echo 0; return; }
+    local extra sign
+    if (( ${#sa[@]} > ${#sb[@]} )); then
+        extra=${sa[n]}
+        sign=1
+    else
+        extra=${sb[n]}
+        sign=-1
+    fi
+    [[ "$extra" =~ ^[A-Za-z] ]] && echo $(( -sign )) || echo $sign
+}
+VERCMP_EOF
+			sed '1d; s/"\(\${\?GPGKEY}\?\)"/\1/g' </usr/bin/repo-add
+		} >"$this_script_dir/repo-add"
 	fi &&
 	"$this_script_dir/repo-add" "$@"
 }


### PR DESCRIPTION
When `pacman-helper.sh quick_add` is run from the `pacman-packages` action of [`git-for-windows/git-for-windows-automation`](https://github.com/git-for-windows/git-for-windows-automation/blob/release/.github/actions/pacman-packages/action.yml), the SDK that the action sets up is the `build-installers` flavor, which intentionally ships only a small subset of `/usr/bin`. `vercmp.exe` is not in that subset, so every `repo-add` invocation prints two lines of noise of the form:

```
D:/a/_temp/build-extra/repo-add: line 254: vercmp: command not found
D:/a/_temp/build-extra/repo-add: line 254: ((: > 0 : arithmetic syntax error: operand expected (error token is "> 0 ")
```

(see e.g. [run 27414389819](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/27414389819/job/81026080873), which produced 64 such pairs before the unrelated `db3` leak bit it; that one is already fixed on `main` as 887f246147).

The errors themselves are benign because we invoke `repo-add` without `--prevent-downgrade`, so the suppressed "newer version already present" warning has no functional consequence, but I'd rather not pollute release logs with them.

Adding `vercmp.exe` (or any of the other plausible interpreters that came up while exploring this: `awk.exe`, `perl`, `expr.exe`) to `build-installers` would defeat the point of that minimal SDK. Instead, this extends the existing sed-based patching of `/usr/bin/repo-add` to also inject a small Bash function called `vercmp`. The patched copy is what `pacman-helper.sh` invokes, and `repo-add` is itself a Bash script, so the injected function is in scope at the call site with no PATH manipulation, no `export -f` gymnastics across process boundaries, and `pacman-helper.sh` itself stays POSIX `sh`.

The algorithm is essentially the same shape as the prior-art `version_compare` in `git-extra/git-update-git-for-windows`, with one fix (strict equality returns `0`, which `vercmp`'s contract requires but the prior art got wrong). It splits each version string on runs of non-alphanumeric characters and walks the resulting arrays segment by segment: two numeric segments compare numerically, a numeric vs. alphanumeric segment lets the numeric side win (matching pacman's behavior of treating pre-release suffixes as older), and otherwise it falls back to lexical comparison. When one string runs out of segments first, the longer string wins unless its extra segment starts with a letter, in which case it is treated as a pre-release.

All nine test cases from `git-update-git-for-windows --test-version-compare` pass, plus the strict-equality case and the exact strings from the failing run:

```
OK   vercmp 2.32.0.windows.1            2.32.1.windows.1            -> -1
OK   vercmp 2.32.1.windows.1            2.32.0.windows.1            -> 1
OK   vercmp 2.32.1.vfs.0.0              2.32.0.windows.1            -> 1
OK   vercmp 2.32.1.vfs.0.0              2.32.0.vfs.0.0              -> 1
OK   vercmp 2.32.0.vfs.0.1              2.32.0.vfs.0.2              -> -1
OK   vercmp 2.32.0-rc0.windows.1        2.31.1.windows.1            -> 1
OK   vercmp 2.32.0-rc2.windows.1        2.32.0.windows.1            -> -1
OK   vercmp 2.34.0.rc1.windows.1        2.33.1.windows.1            -> 1
OK   vercmp 2.34.0.rc2.windows.1        2.34.0.windows.1            -> -1
OK   vercmp 2.55.0.1-1                  2.55.0.1-1                  -> 0
OK   vercmp 2.54.0.1-1                  2.55.0.rc0.windows.1-1      -> -1
OK   vercmp 2.55.0.rc0.windows.1-1      2.54.0.1-1                  -> 1
OK   vercmp 2.55.0.windows.1-1          2.55.0.windows.1-2          -> -1
OK   vercmp 2.55.0.windows.1-2          2.55.0.windows.1-1          -> 1
OK   vercmp 2.54                        2.54.1                      -> -1
OK   vercmp 2.55.0.rc0                  2.55.0                      -> -1
```

### Known limitation

Within a mixed-alphanumeric segment such as `rc10` vs. `rc2` the lexical fallback gets the order wrong (would say `rc10` < `rc2`), but Git for Windows has never published an RC past single digits, so a full rpm-style sub-tokenization stays out of scope.

### Scope

`repo-remove` next door is patched the same way but does not call `vercmp` (it only takes package names, not versions), so its patching block is intentionally left alone.
