### PR TITLE
pacman-helper: tolerate removing a package absent from a database

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -131,15 +131,30 @@ repo_remove () {
 		# Make sure that GPGKEY is used unquoted
 		 sed 's/"\(\${\?GPGKEY}\?\)"/\1/g' </usr/bin/repo-remove >"$this_script_dir/repo-remove"
 	fi &&
-	"$this_script_dir/repo-remove" $(for arg
-	do
-		# repo-remove only accepts package _names_, but we are potentially given _files_.
-		# Handle this by distilling the package names from filenames.
-		case "$arg" in
-		*.pkg.tar.xz|*.pkg.tar.zst) echo "${arg%-*-*-*}";;
-		*) echo "$arg";;
-		esac
-	done)
+	# repo-remove only accepts package _names_, but we are potentially given
+	# _files_; distill the names from the file names. Furthermore, repo-remove
+	# fails the _entire_ operation (modifying nothing) when _any_ of the given
+	# names is absent from the database, e.g. a freshly-initialized, still-empty
+	# ucrt64 database. To allow removing a package even when it is not present in
+	# a given database, drop the names the database does not contain and skip the
+	# call altogether when nothing is left to remove.
+	dbfile="$1" &&
+	shift &&
+	present=" $(package_list "$dbfile" | sed 's/-[^-]*-[^-]*$//' | tr '\n' ' ')" &&
+	names= &&
+	{
+		for arg
+		do
+			case "$arg" in
+			*.pkg.tar.xz|*.pkg.tar.zst) name="${arg%-*-*-*}";;
+			*) name="$arg";;
+			esac
+			case "$present" in
+			*" $name "*) names="$names $name";;
+			esac
+		done
+	} &&
+	{ test -z "$names" || "$this_script_dir/repo-remove" "$dbfile" $names; }
 }
 
 update_versions_json () { # <file> <version> <tagname>


### PR DESCRIPTION
Removing the obsolete `git-credential-manager-core` packages via the _Remove Packages from the Pacman repository_ workflow [fails](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/27195671090) as soon as it reaches the freshly-initialized, still-empty `ucrt64` database: `repo-remove` reports `Package matching '...' not found.` and that aborts the entire `quick_remove`.

The underlying `repo-remove` is all-or-nothing: if any requested package name is absent from a database, it leaves the database untouched and exits non-zero. Now that `quick_action` runs the removal across the `mingw64` and `ucrt64` databases in addition to the architecture database, a package that only ever existed in one of them takes the whole operation down with it, even though "remove a package that isn't there" should simply be a no-op.

Rather than ignore `repo-remove`'s exit code (which would also paper over genuine failures and, because of the all-or-nothing behavior, silently skip packages that _are_ present alongside an absent one), this filters the requested names against each database's actual contents and only hands over the ones it actually contains, skipping the call entirely when nothing is left to remove. The match is on whole package names, so that e.g. `git-credential-manager` is not mistaken for `git-credential-manager-core`.

I verified the fix against constructed databases (package present, package absent from an empty database, a mix of present and absent, and the whole-name guard) and will follow up with a dry run of the actual workflow pointed at this branch.
