### PR TITLE
pacman-helper: avoid HTTP 400 with the new, long GitHub App installation tokens

### DIFF
--- a/pacman-helper.sh
+++ b/pacman-helper.sh
@@ -502,7 +502,7 @@ quick_action () { # <action> <file>...
 	then
 		echo "Would push $to_push to git-for-windows/pacman-repo" >&2
 	else
-		auth="$(printf 'PAT:%s' "$GITHUB_TOKEN" | base64)" &&
+		auth="$(printf 'PAT:%s' "$GITHUB_TOKEN" | base64 -w0)" &&
 		if test true = "$GITHUB_ACTIONS"
 		then
 			echo "::add-mask::$auth"


### PR DESCRIPTION
GitHub App installation tokens are changing from their old 40-character form to a variable-length format of around 520 characters. See https://github.blog/?p=95566 for full details.

The GNU coreutils implementation of `base64` wraps output after 76 columns by default. In the affected automation run, the resulting Basic Authorization value passed through Git's `http.extraHeader` spanned multiple lines, causing every Pacman repository push to fail with HTTP 400.

This was discovered after [this workflow run](https://github.com/git-for-windows/git-for-windows-automation/actions/runs/29616469313/job/88002560332) spent over three hours to build `mingw-w64-clang-aarch64-llvm` only to be denied the deployment with the symptom described above.