### PR TITLE
Prepare for Inno Setup 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@ edit-git-bash.exe
 /git-for-windows-keyring/git-for-windows-keyring-*.src.tar.gz
 /installer/InnoSetup/Examples/
 /installer/InnoSetup/Compil32.exe
+/installer/InnoSetup/ISIDE.exe
 /installer/InnoSetup/isscint.dll
+/installer/InnoSetup/isscint-x64.dll
 /installer/ReleaseNotes.html
 /installer/config.iss
 /installer/install.log

--- a/installer/exec-with-capture.inc.iss
+++ b/installer/exec-with-capture.inc.iss
@@ -1,7 +1,9 @@
 [Code]
 
 type
+#if Ver < EncodeVer(7, 0, 0)
     HANDLE = LongInt;
+#endif
     SECURITY_ATTRIBUTES = record
         nLength:DWORD;
         lpSecurityDescriptor:LongInt;

--- a/installer/modules.inc.iss
+++ b/installer/modules.inc.iss
@@ -46,11 +46,13 @@ const
     WAIT_TIMEOUT = $00000102;
     WAIT_FAILED  = $ffffffff;
 type
+#if Ver < EncodeVer(7, 0, 0)
     HMODULE   = DWORD;
     LONG      = Longint;
     ULONG     = Cardinal;
-    BYTE_PTR  = DWORD;
     ULONG_PTR = DWORD;
+#endif
+    BYTE_PTR  = ULONG_PTR;
 
     IdList=array of DWORD;
 


### PR DESCRIPTION
This prepares `build-extra` for Inno Setup 7 while deliberately retaining the vendored Inno Setup 6.7.3 compiler. The guarded sources support both versions, while the updater keeps `ISIDE.exe` and `isscint-x64.dll` locally available but untracked.

The ordering matters: this PR must merge before the separate `git-for-windows-automation` PR changes the `open-pr` updater to download the Inno Setup 7 x64 asset. The actual 7.0.2 vendor update follows only after both prerequisites are merged.

This is needed for https://github.com/git-for-windows/git/issues/6320.