### PR TITLE
arm64: prefer native leaf command-line tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,10 @@ jobs:
           show_files artifacts.txt ||
           exit $?
 
-          test -z "$(git diff ${{github.event.pull_request.base.sha}}.. -- check-for-missing-dlls.sh)" ||
+          test -z "$(git diff ${{github.event.pull_request.base.sha}}.. -- \
+            check-for-missing-dlls.sh \
+            t/check-arm64-native-tools.sh \
+            t/check-arm64-native-tools.ps1)" ||
           echo "check-for-missing-dlls=true" >>$GITHUB_OUTPUT
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -406,3 +409,11 @@ jobs:
       - name: check for missing DLLs (MinGit)
         shell: bash
         run: MINIMAL_GIT=1 ./check-for-missing-dlls.sh
+      - name: check native ARM64 tools from Git Bash
+        if: matrix.arch.name == 'aarch64'
+        shell: bash
+        run: ./t/check-arm64-native-tools.sh
+      - name: check native ARM64 tools from Win32
+        if: matrix.arch.name == 'aarch64'
+        shell: pwsh
+        run: ./t/check-arm64-native-tools.ps1 -Root (Convert-Path sdk-artifact)

--- a/make-file-list.sh
+++ b/make-file-list.sh
@@ -387,6 +387,22 @@ else
 		-e "^\\($(echo $EXTRA_FILE_EXCLUDES |
 			sed 's/ /\\|/g')\\)\$"
 fi |
+if test aarch64 != "$ARCH" || test -n "$MINIMAL_GIT"
+then
+	cat
+else
+	{
+		grep -v \
+			-e '^/usr/bin/\(bunzip2\|bzcat\|bzip2\|bzip2recover\)\.exe$' \
+			-e '^/usr/bin/\(nettle-hash\|nettle-lfib-stream\|nettle-pbkdf2\|pkcs1-conv\|sexp-conv\)\.exe$' \
+			-e '^/usr/bin/\(p11-kit\|trust\)\.exe$'
+		cat <<-EOF
+		/clangarm64/bin/nettle-hash.exe
+		/clangarm64/bin/nettle-lfib-stream.exe
+		/clangarm64/bin/nettle-pbkdf2.exe
+		EOF
+	}
+fi |
 LC_CTYPE=C.UTF-8 grep --perl-regexp -v -e '^/usr/(lib|share)/terminfo/(?!.*/(cygwin|dumb|ms-terminal|screen.*|xterm.*)$)' |
 sed 's/^\///' | sort | uniq
 

--- a/t/check-arm64-native-tools.ps1
+++ b/t/check-arm64-native-tools.ps1
@@ -1,0 +1,35 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Root
+)
+
+$cases = @(
+    @{ Name = "bunzip2"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "bzcat"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "bzip2"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "bzip2recover"; Arguments = @(); ExitCode = 1 },
+    @{ Name = "nettle-hash"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "nettle-lfib-stream"; Arguments = @("--help"); ExitCode = 1 },
+    @{ Name = "nettle-pbkdf2"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "pkcs1-conv"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "sexp-conv"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "p11-kit"; Arguments = @("--help"); ExitCode = 0 },
+    @{ Name = "trust"; Arguments = @("--help"); ExitCode = 0 }
+)
+
+foreach ($case in $cases) {
+    $x64 = Join-Path $Root "usr\bin\$($case.Name).exe"
+    if (Test-Path -LiteralPath $x64) {
+        throw "The ARM64 payload still contains $x64"
+    }
+
+    $native = Join-Path $Root "clangarm64\bin\$($case.Name).exe"
+    if (-not (Test-Path -LiteralPath $native)) {
+        throw "The ARM64 payload does not contain $native"
+    }
+
+    & $native @($case.Arguments) *> $null
+    if ($LASTEXITCODE -ne $case.ExitCode) {
+        throw "$native returned $LASTEXITCODE instead of $($case.ExitCode)"
+    }
+}

--- a/t/check-arm64-native-tools.ps1
+++ b/t/check-arm64-native-tools.ps1
@@ -18,11 +18,6 @@ $cases = @(
 )
 
 foreach ($case in $cases) {
-    $x64 = Join-Path $Root "usr\bin\$($case.Name).exe"
-    if (Test-Path -LiteralPath $x64) {
-        throw "The ARM64 payload still contains $x64"
-    }
-
     $native = Join-Path $Root "clangarm64\bin\$($case.Name).exe"
     if (-not (Test-Path -LiteralPath $native)) {
         throw "The ARM64 payload does not contain $native"

--- a/t/check-arm64-native-tools.sh
+++ b/t/check-arm64-native-tools.sh
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+die () {
+	echo "$*" >&2
+	exit 1
+}
+
+thisdir="$(cd "$(dirname "$0")" && pwd)" ||
+die "Could not determine the test directory"
+selection_only=
+case "$1" in
+--selection-only) selection_only=t;;
+"") ;;
+*) die "Unknown option: $1";;
+esac
+tmp=${TMPDIR:-/tmp}/arm64-native-tools.$$
+trap 'rm -f "$tmp"' EXIT
+
+ARCH=aarch64 INCLUDE_GIT_UPDATE=1 \
+	"$thisdir/../make-file-list.sh" >"$tmp" ||
+die "Could not generate the ARM64 file list"
+
+for tool in bunzip2 bzcat bzip2 bzip2recover \
+	nettle-hash nettle-lfib-stream nettle-pbkdf2 pkcs1-conv sexp-conv \
+	p11-kit trust
+do
+	grep -qx "usr/bin/$tool.exe" "$tmp" &&
+	die "The ARM64 file list still contains usr/bin/$tool.exe"
+	grep -qx "clangarm64/bin/$tool.exe" "$tmp" ||
+	die "The ARM64 file list does not contain clangarm64/bin/$tool.exe"
+done
+
+for pattern in \
+	'^usr/bin/msys-bz2-[0-9].*\.dll$' \
+	'^usr/lib/perl5/.*/auto/Compress/Raw/Bzip2/Bzip2\.dll$' \
+	'^usr/bin/msys-hogweed-[0-9].*\.dll$' \
+	'^usr/bin/msys-nettle-[0-9].*\.dll$' \
+	'^usr/bin/msys-p11-kit-[0-9].*\.dll$' \
+	'^usr/lib/pkcs11/p11-kit-trust\.dll$' \
+	'^usr/libexec/p11-kit/p11-kit-remote\.exe$' \
+	'^usr/libexec/p11-kit/p11-kit-server\.exe$'
+do
+	grep -Eq "$pattern" "$tmp" ||
+	die "The ARM64 file list no longer contains required x64 payload matching $pattern"
+done
+
+test -z "$selection_only" || exit 0
+
+PATH=/clangarm64/bin:/usr/bin
+export PATH
+check_tool () {
+	tool=$1
+	expected=$2
+	shift 2
+
+	path=$(command -v "$tool") ||
+	die "Could not resolve $tool from Git Bash"
+	test "/clangarm64/bin/$tool" = "$path" ||
+	die "$tool resolves to $path instead of /clangarm64/bin/$tool"
+
+	"$tool" "$@" >"$tmp" 2>&1
+	actual=$?
+	test "$expected" = "$actual" ||
+	die "$tool returned $actual instead of $expected"
+}
+
+check_tool bunzip2 0 --help
+check_tool bzcat 0 --help
+check_tool bzip2 0 --help
+check_tool bzip2recover 1
+check_tool nettle-hash 0 --help
+check_tool nettle-lfib-stream 1 --help
+check_tool nettle-pbkdf2 0 --help
+check_tool pkcs1-conv 0 --help
+check_tool sexp-conv 0 --help
+check_tool p11-kit 0 --help
+check_tool trust 0 --help


### PR DESCRIPTION
## Summary  - for full `ARCH=aarch64` payloads, prefer the already-installed native CLANGARM64 commands over 11 standalone x64 MSYS executables - add the three native nettle commands that the generic MinGW filter previously removed - retain all x64 MSYS DLLs, plugins, and internal p11-kit helpers needed by remaining x64 consumers - leave MinGit and every non-ARM64 file list unchanged - test file-list selection plus CLI path and exit-code behavior from Git Bash and direct Win32 invocation on `windows-11-arm`  ## Payload delta  The exact `v2.55.0.windows.4` release baseline from #728 contains 432 x64, 209 ARM64, 90 AnyCPU, and one x86 PE file. A full staging tree built from current `git-sdk-arm64/main` starts at the same 432 x64 files. Applying this change and scanning with the #728 tooling locally produces:  | Architecture | Before | After | Delta | | --- | ---: | ---: | ---: | | x64 | 432 | 421 | -11 | | ARM64 | 123 | 126 | +3 | | AnyCPU | 45 | 45 | 0 | | x86 | 1 | 1 | 0 |  The current SDK has fewer ARM64/AnyCPU payload files than the released archive, but the x64 baseline count remains 432. The scanner reports no new foreign-architecture paths.  Removed x64 commands:  - `usr/bin/{bunzip2,bzcat,bzip2,bzip2recover}.exe` - `usr/bin/{nettle-hash,nettle-lfib-stream,nettle-pbkdf2,pkcs1-conv,sexp-conv}.exe` - `usr/bin/{p11-kit,trust}.exe`  The corresponding `clangarm64/bin` commands are selected. Eight were already in the file list; this change adds `nettle-hash.exe`, `nettle-lfib-stream.exe`, and `nettle-pbkdf2.exe` after the existing generic exclusion.  The change deliberately retains `msys-bz2-1.dll`, `msys-hogweed-7.dll`, `msys-nettle-9.dll`, `msys-p11-kit-0.dll`, the Perl Bzip2 and PKCS#11 plugins, and both x64 `usr/libexec/p11-kit` helpers. Reverse import analysis shows remaining x64 consumers including GnuPG, unzip, GnuTLS, and the p11-kit helpers. ncurses and OpenSSL are left for later tranches.  ## Validation  - generated a 7,813-file full ARM64 staging tree from `git-sdk-arm64/main` - ran the #728 architecture scanner against before/after manifests - ran `check-for-missing-dlls.sh` for full Git and MinGit - verified the MinGit file list is byte-for-byte unchanged - matched the removed x64 commands' Git Bash and Win32 help/usage exit codes locally - added ARM64-runner Git Bash and direct Win32 execution tests for every replacement 

Fork CI validation: https://github.com/crutkas/build-extra/actions/runs/31733197514 (all x86_64, i686, UCRT64, and ARM64 jobs passed).