### PR TITLE
`render-release-notes`: fix the release-notes cache check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ edit-git-bash.exe
 !/archive/root/etc/protocols
 !/archive/root/etc/services
 /versions/cached-files/
+.release-notes.stamp

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ edit-git-bash.exe
 !/archive/root/etc/protocols
 !/archive/root/etc/services
 /versions/cached-files/
-.release-notes.stamp

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -212,26 +212,10 @@ pacman -Sy --noconfirm markdown ||
 pacman -S --noconfirm markdown ||
 die "Could not install markdown"
 
-# Only re-render when the inputs actually changed: compare content
-# fingerprints (sha256sum) instead of mtimes, which are unreliable in
-# clean CI checkouts. The output HTML's hash is part of the fingerprint,
-# so a missing or manually clobbered ReleaseNotes.html is regenerated
-# rather than skipped.
-stamp_file="$OUTPUTDIR${OUTPUTDIR:+/}.release-notes.stamp"
-
-fingerprint () {
-	sha256sum "$SCRIPT_PATH"/ReleaseNotes.md \
-		"$SCRIPT_PATH"/render-release-notes.sh \
-		"$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" 2>/dev/null |
-		sed 's/ .*//' | tr '\n' ' '
-}
-
-if test ! -f "$stamp_file" ||
-	test ! -f "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" ||
-	test "$(cat "$stamp_file" 2>/dev/null)" != "$(fingerprint)"
-then
+test -f "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" &&
+test "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" -nt "$SCRIPT_PATH"/ReleaseNotes.md &&
+test "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" -nt "$SCRIPT_PATH"/render-release-notes.sh || {
 	render_release_notes || die "Could not render $OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html"
-	fingerprint >"$stamp_file"
 	test -z "$COPYCSS" || {
 		test -z "$CSSDIR" && CSSDIR="$OUTPUTDIR" || CSSDIR="$OUTPUTDIR${OUTPUTDIR:+/}$CSSDIR"
 		test -z "$CSSDIR" || test -d "$CSSDIR" || mkdir -p "$CSSDIR"
@@ -239,6 +223,6 @@ then
 		test "x$SCRIPT_PATH" = "x$CSSDIR" ||
 		cp -u "$SCRIPT_PATH"/ReleaseNotes.css "$CSSDIR${CSSDIR:+/}ReleaseNotes.css"
 	}
-fi
+}
 
 test -z "$PREVIEW" || start "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html"

--- a/render-release-notes.sh
+++ b/render-release-notes.sh
@@ -212,10 +212,26 @@ pacman -Sy --noconfirm markdown ||
 pacman -S --noconfirm markdown ||
 die "Could not install markdown"
 
-test -f "$OUTPUTDIR${OUTPUTDIR:+/}Release.html" &&
-test "$OUTPUTDIR${OUTPUTDIR:+/}Release.html" -nt "$SCRIPT_PATH"/ReleaseNotes.md &&
-test "$OUTPUTDIR${OUTPUTDIR:+/}Release.html" -nt "$SCRIPT_PATH"/render-release-notes.sh || {
+# Only re-render when the inputs actually changed: compare content
+# fingerprints (sha256sum) instead of mtimes, which are unreliable in
+# clean CI checkouts. The output HTML's hash is part of the fingerprint,
+# so a missing or manually clobbered ReleaseNotes.html is regenerated
+# rather than skipped.
+stamp_file="$OUTPUTDIR${OUTPUTDIR:+/}.release-notes.stamp"
+
+fingerprint () {
+	sha256sum "$SCRIPT_PATH"/ReleaseNotes.md \
+		"$SCRIPT_PATH"/render-release-notes.sh \
+		"$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" 2>/dev/null |
+		sed 's/ .*//' | tr '\n' ' '
+}
+
+if test ! -f "$stamp_file" ||
+	test ! -f "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html" ||
+	test "$(cat "$stamp_file" 2>/dev/null)" != "$(fingerprint)"
+then
 	render_release_notes || die "Could not render $OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html"
+	fingerprint >"$stamp_file"
 	test -z "$COPYCSS" || {
 		test -z "$CSSDIR" && CSSDIR="$OUTPUTDIR" || CSSDIR="$OUTPUTDIR${OUTPUTDIR:+/}$CSSDIR"
 		test -z "$CSSDIR" || test -d "$CSSDIR" || mkdir -p "$CSSDIR"
@@ -223,6 +239,6 @@ test "$OUTPUTDIR${OUTPUTDIR:+/}Release.html" -nt "$SCRIPT_PATH"/render-release-n
 		test "x$SCRIPT_PATH" = "x$CSSDIR" ||
 		cp -u "$SCRIPT_PATH"/ReleaseNotes.css "$CSSDIR${CSSDIR:+/}ReleaseNotes.css"
 	}
-}
+fi
 
 test -z "$PREVIEW" || start "$OUTPUTDIR${OUTPUTDIR:+/}ReleaseNotes.html"


### PR DESCRIPTION
Fixes the broken release-notes cache check in `render-release-notes.sh`.

Problem
-------

The incremental cache check referenced a `Release.html` file that is never produced (the script writes `ReleaseNotes.html`), so the cache never hit and the release notes were always re-rendered.

Change
------

<details>
<summary>The original commit</summary>

40ebbc2 switched the cache to a content-fingerprint (sha256sum/stamp) check.

https://github.com/git-for-windows/build-extra/pull/731#pullrequestreview-5052343408
</details>
The current commit keeps only the `Release` -> `ReleaseNotes` typo fix, restoring the mtime-based check. Net effect: a previously rendered `ReleaseNotes.html` that is newer than both `ReleaseNotes.md` and this script is reused, avoiding an unnecessary re-render on repeated local runs.

Validation
----------

This change is confined to the cache-check condition; it does not alter how the HTML is rendered.
