### PR TITLE
installer: actually build a 64-bit installer

### DIFF
--- a/installer/exec-with-capture.inc.iss
+++ b/installer/exec-with-capture.inc.iss
@@ -6,8 +6,14 @@ type
 #endif
     SECURITY_ATTRIBUTES = record
         nLength:DWORD;
-        lpSecurityDescriptor:LongInt;
+#ifdef SETUP_IS_X64
+        nLengthPadding:DWORD;
+#endif
+        lpSecurityDescriptor:ULONG_PTR;
         bInheritHandle:BOOL;
+#ifdef SETUP_IS_X64
+        bInheritHandlePadding:DWORD;
+#endif
     end;
 
 function CreatePipe(var hReadPipe,hWritePipe:HANDLE;var lpPipeAttributes:SECURITY_ATTRIBUTES;nSize:DWORD):BOOL;
@@ -26,10 +32,13 @@ type
         dwProcessId:DWORD;
         dwThreadId:DWORD;
     end;
-    LPSTR = LongInt;
-    LPBYTE = LongInt;
+    LPSTR = ULONG_PTR;
+    LPBYTE = ULONG_PTR;
     STARTUPINFO = record
         cb:DWORD;
+#ifdef SETUP_IS_X64
+        cbPadding:DWORD;
+#endif
         lpReserved:LPSTR;
         lpDesktop:LPSTR;
         lpTitle:LPSTR;
@@ -43,6 +52,9 @@ type
         dwFlags:DWORD;
         wShowWindow:WORD;
         cbReserved2:WORD;
+#ifdef SETUP_IS_X64
+        cbReserved2Padding:DWORD;
+#endif
         lpReserved2:LPBYTE;
         hStdInput:HANDLE;
         hStdOutput:HANDLE;
@@ -67,10 +79,16 @@ type
     TMsg = record
         hwnd:HWND;
         message:UINT;
-        wParam:LongInt;
-        lParam:LongInt;
+#ifdef SETUP_IS_X64
+        messagePadding:DWORD;
+#endif
+        wParam:ULONG_PTR;
+        lParam:ULONG_PTR;
         time:DWORD;
         pt:TPoint;
+#ifdef SETUP_IS_X64
+        lPrivate:DWORD;
+#endif
     end;
 
 const

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -53,6 +53,12 @@ SolidCompression=yes
 #define SOURCE_DIR SourcePath+'\..\..\..\..'
 #endif
 SourceDir={#SOURCE_DIR}
+#if BITNESS=='64' && Ver>=EncodeVer(7, 0, 0)
+; Inno Setup 7 builds 32-bit installers unless told otherwise. SETUP_IS_X64
+; lets the Pascal Script code declare Windows API records for 64-bit.
+#define SETUP_IS_X64
+SetupArchitecture=x64
+#endif
 #if BITNESS=='64' || INSTALLER_FILENAME_SUFFIX=='arm64'
 ArchitecturesInstallIn64BitMode=x64 arm64
 #endif


### PR DESCRIPTION
This fixes https://github.com/git-for-windows/git/issues/6372.

Confirming that the installer is now truly a x64 executable:

<img width="2368" height="1196" alt="image" src="https://github.com/user-attachments/assets/907619a7-e4c8-4cb5-b4e2-36d7b4a101f2" />

Inno Setup 7 introduced 64-bit installers, but building 32-bit ones stays the default in both editions; a 64-bit one is only produced when the `[Setup]` section directive `SetupArchitecture` is set to `x64`. Updating the compiler to Inno Setup 7.0.2 therefore did not change the architecture of the installer, even though the v2.55.0(5) release notes already announced it as a 64-bit executable.

Set `SetupArchitecture=x64` for the flavors that ship 64-bit Git, i.e. the ones where `release.sh` sets `BITNESS` to 64: MINGW64, UCRT64 and CLANGARM64. The i686 installer keeps building as a 32-bit executable. The directive does not exist in Inno Setup 6, hence the version guard.

Flipping that directive alone leaves the installer broken, though: Pascal Script records are always packed, and in a 64-bit installer pointers are eight bytes wide, so the Windows API records declared in `exec-with-capture.inc.iss` no longer match the layout those functions expect. `CreatePipe()` reads `lpSecurityDescriptor` from the wrong offset, fails with `ERROR_NOACCESS`, and `ExecWithCapture()` returns `False` without ever having run the command. Starting the wizard then greets the user with

	Unable to get system config (exit code 4294967295):

Widen the pointer-sized fields of `SECURITY_ATTRIBUTES` and `STARTUPINFO` to `ULONG_PTR` and add the padding that the aligned C structs have and a packed record does not, which brings them to the 24 and 104 bytes that the x64 ABI mandates. `MSG` needs the same treatment for a different reason: `PeekMessage()` writes the full 48 bytes of that struct, which is more than an unpadded record offers, corrupting the stack and killing the message pump with a fatal exception once a captured command runs long enough for the pump to kick in.

The padding is conditional on the new `SETUP_IS_X64` symbol, so 32-bit installers keep the record layout they have always had.

The `Win95` and `Win2000` code paths in `modules.inc.iss` declare records with the same problem (`PROCESSENTRY32`, `MODULEENTRY32`), but `MinVersion` is 6.3 and those paths are only taken on Windows versions before Vista, so they are left alone.
