### PR TITLE
installer: drop 32-bit support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path ${{ steps.build.outputs.result }}/*.exe | %{$_.FullName}
-          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
+          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /LOG=installer.log"
           $exitCode = $installer.ExitCode
           if ($exitCode -ne 0) {
             Write-Host "::error::Installer failed with exit code $exitCode!"
@@ -314,7 +314,7 @@ jobs:
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path installer-${{ matrix.arch.name }}/*.exe | %{$_.FullName}
-          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /ALLOWINSTALLING32ON64=1 /LOG=installer.log"
+          $installer = Start-Process -PassThru -Wait -FilePath "$exePath" -ArgumentList "/SILENT /VERYSILENT /NORESTART /SUPPRESSMSGBOXES /ALLOWDOWNGRADE=1 /LOG=installer.log"
           $exitCode = $installer.ExitCode
           if ($exitCode -ne 0) {
             Write-Host "::error::Installer failed with exit code $exitCode!"

--- a/installer/HowToRelease.txt
+++ b/installer/HowToRelease.txt
@@ -7,7 +7,9 @@ A setup executable is named as follows
  - followed by the Git for Windows version of the form A.B.C.D where
    A.B.C is the Git version on which the release is based, and
    A.B.C.windows.D is the tag in Git for Windows' repository
- - followed by the "bitness", i.e. "-32-bit" or "-64-bit"
+ - followed by an architecture suffix, i.e. "-arm64" or "-64-bit"
+   (we used to distinguish "x86" and "x86_64" as "32-bit" and "64-bit"
+   and the suffix stuck)
 
 Examples:
 
@@ -52,7 +54,6 @@ Here is a step-by-step instruction for the maintainer:
 
    # ensure current setup is up-to-date (including the Git packages)
    pacman -Syu
-   # on 32-bit, quit all MSys shells and run \autorebase.bat now
 
    # make installer (after updating the release notes)
    /usr/src/build-extra/installer/release.sh <git-for-windows-version>

--- a/installer/exec-with-capture.inc.iss
+++ b/installer/exec-with-capture.inc.iss
@@ -1,19 +1,12 @@
 [Code]
 
 type
-#if Ver < EncodeVer(7, 0, 0)
-    HANDLE = LongInt;
-#endif
     SECURITY_ATTRIBUTES = record
         nLength:DWORD;
-#ifdef SETUP_IS_X64
         nLengthPadding:DWORD;
-#endif
         lpSecurityDescriptor:ULONG_PTR;
         bInheritHandle:BOOL;
-#ifdef SETUP_IS_X64
         bInheritHandlePadding:DWORD;
-#endif
     end;
 
 function CreatePipe(var hReadPipe,hWritePipe:HANDLE;var lpPipeAttributes:SECURITY_ATTRIBUTES;nSize:DWORD):BOOL;
@@ -36,9 +29,7 @@ type
     LPBYTE = ULONG_PTR;
     STARTUPINFO = record
         cb:DWORD;
-#ifdef SETUP_IS_X64
         cbPadding:DWORD;
-#endif
         lpReserved:LPSTR;
         lpDesktop:LPSTR;
         lpTitle:LPSTR;
@@ -52,9 +43,7 @@ type
         dwFlags:DWORD;
         wShowWindow:WORD;
         cbReserved2:WORD;
-#ifdef SETUP_IS_X64
         cbReserved2Padding:DWORD;
-#endif
         lpReserved2:LPBYTE;
         hStdInput:HANDLE;
         hStdOutput:HANDLE;
@@ -79,16 +68,12 @@ type
     TMsg = record
         hwnd:HWND;
         message:UINT;
-#ifdef SETUP_IS_X64
         messagePadding:DWORD;
-#endif
         wParam:ULONG_PTR;
         lParam:ULONG_PTR;
         time:DWORD;
         pt:TPoint;
-#ifdef SETUP_IS_X64
         lPrivate:DWORD;
-#endif
     end;
 
 const

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -4,8 +4,8 @@
 
 #include "config.iss"
 
-#if !defined(APP_VERSION) || !defined(BITNESS) || !defined(MINGW_BITNESS)
-#error "config.iss should define APP_VERSION, BITNESS and MINGW_BITNESS"
+#if !defined(APP_VERSION) || !defined(MINGW_BITNESS)
+#error "config.iss should define APP_VERSION and MINGW_BITNESS"
 #endif
 
 #define APP_NAME      'Git'
@@ -25,10 +25,6 @@
 #define DEFAULT_BRANCH_NAME 'master'
 #endif
 
-#ifndef INSTALLER_FILENAME_SUFFIX
-#define INSTALLER_FILENAME_SUFFIX ''
-#endif
-
 [Setup]
 ; Compiler-related
 Compression=lzma2/ultra64
@@ -37,11 +33,7 @@ LZMAUseSeparateProcess=yes
 OutputBaseFilename={#FILENAME_VERSION}
 OutputDir={#GetEnv('TEMP')}
 #else
-#if INSTALLER_FILENAME_SUFFIX!=''
 OutputBaseFilename={#APP_NAME+'-'+FILENAME_VERSION+'-'+INSTALLER_FILENAME_SUFFIX}
-#else
-OutputBaseFilename={#APP_NAME+'-'+FILENAME_VERSION}-{#BITNESS}-bit
-#endif
 #ifdef OUTPUT_DIRECTORY
 OutputDir={#OUTPUT_DIRECTORY}
 #else
@@ -53,15 +45,9 @@ SolidCompression=yes
 #define SOURCE_DIR SourcePath+'\..\..\..\..'
 #endif
 SourceDir={#SOURCE_DIR}
-#if BITNESS=='64' && Ver>=EncodeVer(7, 0, 0)
-; Inno Setup 7 builds 32-bit installers unless told otherwise. SETUP_IS_X64
-; lets the Pascal Script code declare Windows API records for 64-bit.
-#define SETUP_IS_X64
+; Inno Setup 7 builds 32-bit installers unless told otherwise.
 SetupArchitecture=x64
-#endif
-#if BITNESS=='64' || INSTALLER_FILENAME_SUFFIX=='arm64'
 ArchitecturesInstallIn64BitMode=x64 arm64
-#endif
 #ifdef SIGNTOOL
 SignTool=signtool
 #endif
@@ -271,14 +257,6 @@ Type: files; Name: {app}\Git Bash.lnk
 ; Delete a home directory inside the Git for Windows directory.
 Type: dirifempty; Name: {app}\home\{username}
 Type: dirifempty; Name: {app}\home
-
-#if BITNESS=='32'
-; Delete the files required for rebaseall
-Type: files; Name: {app}\bin\msys-2.0.dll
-Type: files; Name: {app}\bin\rebase.exe
-Type: dirifempty; Name: {app}\bin
-Type: files; Name: {app}\etc\rebase.db.i386
-#endif
 
 ; Delete recorded install options
 Type: files; Name: {app}\etc\install-options.txt
@@ -1201,20 +1179,12 @@ begin
 #endif
 #endif
     UpdateInfFilenames;
-#if BITNESS=='32'
-    Result:=True;
-    if not IsX64 then
-        SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support.'+#13+'More information at https://gitforwindows.org/32-bit.html',mbError,MB_OK or MB_DEFBUTTON1,IDOK)
-    else if not ParamIsSet('ALLOWINSTALLING32ON64') and (SuppressibleMsgBox('Git for Windows (32-bit) is nearing its end of support. It is recommended to install the 64-bit variant of Git for Windows instead.'+#13+'More information at https://gitforwindows.org/32-bit.html'+#13+'Continue to install the 32-bit variant?',mbError,MB_YESNO or MB_DEFBUTTON2,IDNO)=IDNO) then
-        Result:=False;
-#else
     if not IsWin64 then begin
         LogError('The 64-bit version of Git requires a 64-bit Windows. Aborting.');
         Result:=False;
     end else begin
         Result:=True;
     end;
-#endif
     RegQueryStringValue(HKEY_LOCAL_MACHINE,'Software\GitForWindows','CurrentVersion',PreviousGitForWindowsVersion);
     // The Windows Terminal profile is new in v2.32.0
     HasUnseenComponents:=IsUpgrade('2.32.0');

--- a/installer/modules.inc.iss
+++ b/installer/modules.inc.iss
@@ -46,12 +46,6 @@ const
     WAIT_TIMEOUT = $00000102;
     WAIT_FAILED  = $ffffffff;
 type
-#if Ver < EncodeVer(7, 0, 0)
-    HMODULE   = DWORD;
-    LONG      = Longint;
-    ULONG     = Cardinal;
-    ULONG_PTR = DWORD;
-#endif
     BYTE_PTR  = ULONG_PTR;
 
     IdList=array of DWORD;

--- a/installer/release.sh
+++ b/installer/release.sh
@@ -117,23 +117,19 @@ esac
 # Evaluate architecture
 case "$MSYSTEM" in
 MINGW32)
-	BITNESS=32
-	ARCH=i686
-	MINGW_PACKAGE_PREFIX=mingw-w64-i686
+	die "The 32-bit installer was retired, see https://gitforwindows.org/32-bit.html"
 	;;
 MINGW64)
-	BITNESS=64
 	ARCH=x86_64
 	MINGW_PACKAGE_PREFIX=mingw-w64-x86_64
+	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX '64-bit'"
 	;;
 UCRT64)
-	BITNESS=64
 	ARCH=ucrt64
 	MINGW_PACKAGE_PREFIX=mingw-w64-ucrt-x86_64
 	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX 'ucrt64'"
 	;;
 CLANGARM64)
-	BITNESS=64
 	ARCH=aarch64
 	MINGW_PACKAGE_PREFIX=mingw-w64-clang-aarch64
 	inno_defines="$inno_defines$LF#define INSTALLER_FILENAME_SUFFIX 'arm64'$LF#define ARCHS_ALLOWED 'arm64 and x64compatible'"
@@ -261,13 +257,12 @@ test -z "$GITCONFIG_PATH" || {
 	for key in $keys
 	do
 		case "$key" in
-		pack.packsizelimit|diff.astextplain.*|filter.lfs.*|http.sslcainfo)
+		diff.astextplain.*|filter.lfs.*|http.sslcainfo)
 			# set in the system-wide config
 			value="$(git config -f "/$GITCONFIG_PATH" "$key")" &&
 			case "$key$value" in *"'"*) die "Cannot handle $key=$value because of the single quote";; esac &&
 			case "$key" in
 			filter.lfs.*) extra=" IsComponentSelected('gitlfs') And";;
-			pack.packsizelimit) test $BITNESS = 32 || continue; value=2g; extra=;;
 			*) extra=;;
 			esac &&
 			gitconfig="$gitconfig$LF    if$extra not GitSystemConfigSet('$key','$value') then$LF        Result:=False;" ||
@@ -347,10 +342,9 @@ test -z "$include_pdbs" || {
 die "Could not include .pdb files"
 
 etc_gitconfig_dir="${etc_gitconfig%/gitconfig}"
-printf "%s\n%s\n%s\n%s\n%s\n%s%s" \
+printf "%s\n%s\n%s\n%s\n%s%s" \
 	"#define APP_VERSION '$displayver'" \
 	"#define FILENAME_VERSION '$version'" \
-	"#define BITNESS '$BITNESS'" \
 	"#define MINGW_BITNESS '$MSYSTEM_LOWER'" \
 	"#define SOURCE_DIR '$(cygpath -aw /)'" \
 	"#define ETC_GITCONFIG_DIR '${etc_gitconfig_dir//\//\\}'" \


### PR DESCRIPTION
Git for Windows v2.48.1 was the last version to ship a 32-bit installer; since then only 32-bit MinGit is built, and that only until April 2029. See https://gitforwindows.org/32-bit.html for the background. The i686 code paths in the installer have been dead weight ever since, and the end-of-support warning shown by the 32-bit installer can never be reached by anything that is still being built.

Remove the MINGW32 arm of the architecture switch in `release.sh`, replacing it with a `die` that names the reason, so that anyone who still tries gets an explanation rather than "Unhandled MSYSTEM: MINGW32".

With MINGW32 gone, `BITNESS` can only ever be 64, so drop the variable altogether rather than keep a switch with a single position. That means `OutputBaseFilename` spells out `-64-bit` instead of interpolating it, which produces the exact same name the released asset has always had, as verified by compiling `install.iss` against a `config.iss` without `INSTALLER_FILENAME_SUFFIX`: `Git-2.55.0.5-64-bit.exe`.

The `pack.packsizelimit` entry needs to go from both the outer and the inner `case` in the system config handling: the inner arm `continue`d for anything that was not 32-bit, so leaving the outer pattern in place would have started writing the key into the 64-bit installers' system config for the first time. Generating `config.iss` before and after this commit confirms the output is unchanged apart from the dropped `BITNESS` define.

CI built the installer for i686 as part of the `sdk-artifacts` job, which would now fail on that `die`, so exclude that combination the same way `minimal` and `makepkg-git` already are. The `check-for-missing-dlls` job keeps building the i686 `build-installers` SDK artifact, so that coverage is retained. The two invocations of the installer lose `/ALLOWINSTALLING32ON64=1`, whose only consumer was the removed warning.

Note that `make-file-list.sh` and `mingit/` keep their i686 support, since 32-bit MinGit is still being built.