### PR TITLE
installer: remove superfluous `ArchitecturesInstallIn64BitMode`

### DIFF
--- a/installer/install.iss
+++ b/installer/install.iss
@@ -47,7 +47,6 @@ SolidCompression=yes
 SourceDir={#SOURCE_DIR}
 ; Inno Setup 7 builds 32-bit installers unless told otherwise.
 SetupArchitecture=x64
-ArchitecturesInstallIn64BitMode=x64 arm64
 #ifdef SIGNTOOL
 SignTool=signtool
 #endif


### PR DESCRIPTION
SetupArchitecture=x64 is now defined unconditionally with the removal of 32-bit support in the installer. This setting also sets `ArchitecturesInstallIn64BitMode=x64compatible` by default, which matches on both arm64 and x64 systems. This line no longer needs to be defined explicitly.

Ref: https://jrsoftware.org/ishelp/index.php?topic=64bit

