### PR TITLE
please.sh: accept --architecture=mingw64 in create_sdk_artifact

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,16 +301,16 @@ jobs:
           echo "MSYSTEM=${{ matrix.arch.msystem }}" >>$GITHUB_ENV &&
           cat $GITHUB_PATH
       - name: build installer
-        if: matrix.artifact == 'build-installers'
+        if: matrix.artifact == 'build-installers' && matrix.arch.name != 'i686'
         shell: bash
         run: ./installer/release.sh --include-self-check --output=$PWD/installer-${{ matrix.arch.name }} 0-test
       - uses: actions/upload-artifact@v7
-        if: matrix.artifact == 'build-installers'
+        if: matrix.artifact == 'build-installers' && matrix.arch.name != 'i686'
         with:
           name: installer-${{ matrix.arch.name }}
           path: installer-${{ matrix.arch.name }}
       - name: run the installer
-        if: matrix.artifact == 'build-installers'
+        if: matrix.artifact == 'build-installers' && matrix.arch.name != 'i686'
         shell: pwsh
         run: |
           $exePath = Get-ChildItem -Path installer-${{ matrix.arch.name }}/*.exe | %{$_.FullName}
@@ -329,11 +329,11 @@ jobs:
           }
       - name: show installer log
         # run this even if the installation failed (actually, _in particular_ when the installation failed)
-        if: always() && matrix.artifact == 'build-installers'
+        if: always() && matrix.artifact == 'build-installers' && matrix.arch.name != 'i686'
         shell: bash
         run: cat installer.log
       - name: validate
-        if: matrix.artifact == 'build-installers'
+        if: matrix.artifact == 'build-installers' && matrix.arch.name != 'i686'
         shell: bash
         run: |
           set -x &&

--- a/please.sh
+++ b/please.sh
@@ -395,7 +395,7 @@ bundle_pdbs () { # [--directory=<artifacts-directory] [--unpack=<directory>] [--
 	done
 }
 
-create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--architecture=(x86_64|i686|aarch64|ucrt64|auto)] [--bitness=(32|64)] [--force] <name>
+create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--architecture=(x86_64|i686|aarch64|mingw64|ucrt64|auto)] [--bitness=(32|64)] [--force] <name>
 	git_sdk_path=/
 	output_path=
 	force=
@@ -501,7 +501,8 @@ create_sdk_artifact () { # [--out=<directory>] [--git-sdk=<directory>] [--archit
 		PREFIX="/ucrt64"
 		SDK_REPO="git-sdk-64"
 		;;
-	x86_64)
+	x86_64|mingw64)
+		architecture=x86_64
 		MSYSTEM=MINGW64
 		PREFIX="/mingw64"
 		# TODO update to git-sdk-amd64 after the repo has been updated


### PR DESCRIPTION
As part of [moving from MINGW64 to UCRT64](https://github.com/git-for-windows/git-sdk-64/pull/117), the [`setup-git-for-windows-sdk` GitHub Action](https://github.com/git-for-windows/setup-git-for-windows-sdk/) needs a way to force a fallback to MINGW64.

The `git-sdk-64` repository already has a `mingw64` branch (currently pointing to the same commit as `main`), which will be used by the Action in conjunction with the option introduced in this here PR.