### PR TITLE
installer: fix a couple regressions

### DIFF
--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -68,6 +68,7 @@ begin
             Result:=i;
             Exit;
         end;
+	i:=i-1;
     end;
 
     Result:=0;

--- a/installer/helpers.inc.iss
+++ b/installer/helpers.inc.iss
@@ -54,26 +54,6 @@ begin
     Result[i]:=#0;
 end;
 
-// Search for the last occurence of a substring in another string or zero if not found.
-// RPos exists as a preprocessor function in innosetup, but not as a scripting function.
-function RPos(SubStr, S: AnyString): Integer;
-var
-    Len,i:Longint;
-begin
-    Len:=Length(SubStr);
-    
-    i:=Length(S)-Len+1;
-    while i>0 do begin
-        If (SameStr(SubStr,Copy(S,i,Len))) then begin
-            Result:=i;
-            Exit;
-        end;
-	i:=i-1;
-    end;
-
-    Result:=0;
-end;
-
 function AppendToArray(var AnArray:TArrayOfString;Str:String):Integer;
 begin
     Result:=GetArrayLength(AnArray)+1;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -845,7 +845,7 @@ begin
     i:=1; j:=i; k:=i;
     while (j<=Length(StdOut)) do begin
         c:=Ord(StdOut[j]);
-        if (c=10) then // found the end of key
+        if (i=k) and (c=10) then // first found LF marks the end of key
             k:=j
         else if (c=0) then begin // found the end of the value
             if (i<>k) then begin // Ignore keys without values (LF is missing)

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -801,7 +801,7 @@ end;
 
 function GetDefaultsFromGitConfig(WhichOne:String):Boolean;
 var
-    InstalledGitExe,ExtraOptions,Key,Value:String;
+    InstalledGitExe,ExtraOptions,StdOut,Key,Value:String;
     ExitCode,c,i,j,k:Integer;
     Output:TExecOutput;
 begin
@@ -837,27 +837,18 @@ begin
     if not ExecAndCaptureOutput(InstalledGitExe, 'config -l -z '+ExtraOptions, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) then
         LogError('Unable to get system config (exit code '+IntToStr(ExitCode)+'):'+#13+#10+StringJoin(#13+#10,Output.StdErr));
 
-    // git config -l -z outputs NUL-delimited key/value pairs, with a LF that denotes end of key
-    // ExecAndCaptureOutput splits the Output by lines. So each String in Output.StdOut could
-    // contain up to one Value followed by zero or more Keys, separated by NUL bytes.
-    Value:='';
-    j:=0;
-    while (j<Length(Output.StdOut)) do begin
-        c:=RPos(#0,Output.StdOut[j]);
-        k:=Length(Output.StdOut[j]);
-        if (c=0) then //No NUL in this Line, we've got a (potentially partial) value
-            if (Value='') then
-                Value:=Copy(Output.StdOut[j], 1, k)
-            else
-                Value:=Value+#10+Copy(Output.StdOut[j], 1, k)
-        else begin
-            i:=Pos(#0,Output.StdOut[j])
-            if (i>1) then
-                if (Value='') then
-                    Value:=Copy(Output.StdOut[j], 1, i)
-                else
-                    Value:=Value+#10+Copy(Output.StdOut[j], 1, i);
-            if (Value<>'') then begin // Ignore keys without values
+    // Split NUL-delimited key/value pairs, extract LF that denotes end of key
+    StdOut:=StringJoin(#10,Output.StdOut);
+    Value:=StdOut;
+    i:=1; j:=i; k:=i;
+    while (j<=Length(StdOut)) do begin
+        c:=Ord(StdOut[j]);
+        if (c=10) then
+            k:=j
+        else if (c=0) then begin
+            if (i<>k) then begin // Ignore keys without values
+                Key:=Copy(StdOut,i,k-i);
+                Value:=Copy(StdOut,k+1,j-k-1);
                 case Key of
                     'http.sslbackend':
                         case Value of
@@ -908,8 +899,9 @@ begin
                             RecordInferredDefault('Default Branch Option', Value)
                 end;
             end;
-            Key:=Copy(Output.StdOut[j],c+1,k-c-1);
-            Value:='';
+            i:=j+1;
+            j:=i;
+            k:=i;
         end;
         j:=j+1;
     end;

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -615,7 +615,7 @@ begin
             // Find out which form to use.
             if (BuiltinFSMonitorStopOption='') then begin
                 BuiltinFSMonitorStopOption:='(huh?)';
-                if not ExecAndCaptureOutput('"'+AppDir+'\cmd\git.exe"', 'fsmonitor--daemon -h', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) or (ExitCode<>129) then begin
+                if not ExecAndCaptureOutput(AppDir+'\cmd\git.exe', 'fsmonitor--daemon -h', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) or (ExitCode<>129) then begin
                     if (i<>1) and (i<>127) then // Suppress message if `git.exe` was not found, or if it does not know about the built-in FSMonitor
                         LogError('Could not get FSMonitor help (exit code '+IntToStr(ExitCode)+'):'+#13+StringJoin(#13,Output.StdOut)+#13+StringJoin(#13,Output.StdErr));
                     Exit;
@@ -764,14 +764,14 @@ var
     Output:TExecOutput;
 begin
     if (Value=#0) then begin
-        if ExecAndCaptureOutput('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe"', 'config --system --unset-all '+Key, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) And ((ExitCode=0) Or (ExitCode=5)) then
+        if ExecAndCaptureOutput(AppDir+'\{#MINGW_BITNESS}\bin\git.exe', 'config --system --unset-all '+Key, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) And ((ExitCode=0) Or (ExitCode=5)) then
             // exit code 5 means it was already unset, so that's okay
             Result:=True
         else begin
             LogError('Unable to unset system config "'+Key+'": exit code '+IntToStr(ExitCode)+#13+#10+StringJoin(#13+#10,Output.StdOut)+#13+#10+'stderr:'+#13+#10+StringJoin(#13+#10,Output.StdErr));
             Result:=False
         end
-    end else if ExecAndCaptureOutput('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe"', 'config --system --replace-all '+ShellQuote(Key)+' '+ShellQuote(Value), '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) And (ExitCode=0) then
+    end else if ExecAndCaptureOutput(AppDir+'\{#MINGW_BITNESS}\bin\git.exe', 'config --system --replace-all '+ShellQuote(Key)+' '+ShellQuote(Value), '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) And (ExitCode=0) then
         Result:=True
     else begin
         LogError('Unable to set system config "'+Key+'":="'+Value+'": exit code '+IntToStr(ExitCode)+#13+#10+StringJoin(#13+#10,Output.StdOut)+#13+#10+'stderr:'+#13+#10+StringJoin(#13+#10,Output.StdErr));
@@ -822,7 +822,7 @@ begin
         end
     end;
 
-    if not ExecAndCaptureOutput('"'+AppDir+'\{#MINGW_BITNESS}\bin\git.exe"', 'config -l -z '+ExtraOptions, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) then begin
+    if not ExecAndCaptureOutput(AppDir+'\{#MINGW_BITNESS}\bin\git.exe', 'config -l -z '+ExtraOptions, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) then begin
         if FileExists(AppDir+'\{#MINGW_BITNESS}\bin\git.exe') then
             LogError('Unable to get system config (exit code '+IntToStr(ExitCode)+'):'+#13+#10+StringJoin(#13+#10,Output.StdErr));
     end;
@@ -1053,7 +1053,7 @@ begin
     if not PreviousGitVersionInitialized then begin
         PreviousGitVersionInitialized:=True;
         if (RegQueryStringValue(HKEY_LOCAL_MACHINE,'Software\GitForWindows','InstallPath',Path))
-                and (ExecAndCaptureOutput('"'+Path+'\cmd\git.exe"', 'version', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output))
+                and (ExecAndCaptureOutput(Path+'\cmd\git.exe', 'version', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output))
                 and (ExitCode=0) then begin
             PreviousGitVersion:=Trim(Output.StdOut[0]);
         end;
@@ -2594,7 +2594,7 @@ begin
             if DirExists(AppDir) then begin
                 if not FileExists(ExpandConstant('{tmp}\blocked-file-util.exe')) then
                     ExtractTemporaryFile('blocked-file-util.exe');
-                Cmd:='"'+ExpandConstant('{tmp}\blocked-file-util.exe')+'"';
+                Cmd:=ExpandConstant('{tmp}\blocked-file-util.exe');
                 if not ExecAndCaptureOutput(Cmd, 'blocking-pids "'+AppDir+'"', '', SW_SHOWNORMAL, ewWaitUntilTerminated, Res, Output) or (Res<>0) then begin
                     Msg:='Skipping installation because '+AppDir+' is still in use:'+#13+#10+StringJoin(#13+#10,Output.StdErr);
                     if ParamIsSet('SKIPIFINUSE') or (ExpandConstant('{log}')='') then
@@ -2844,7 +2844,7 @@ begin
 
     if UninstallString<>'' then begin
         WizardForm.StatusLabel.Caption:='Removing previous Git version ('+PreviousGitForWindowsVersion+')';
-        if not ExecAndCaptureOutput(UninstallString,'/VERYSILENT /SILENT /NORESTART /SUPPRESSMSGBOXES', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ErrorCode, Output) then
+        if not ExecAndCaptureOutput(RemoveQuotes(UninstallString),'/VERYSILENT /SILENT /NORESTART /SUPPRESSMSGBOXES', '', SW_SHOWNORMAL, ewWaitUntilTerminated, ErrorCode, Output) then
             LogError('Could not uninstall previous version (stderr: '+StringJoin(#13+#10,Output.StdErr)+'). Trying to continue anyway.');
     end;
 end;
@@ -3094,7 +3094,7 @@ begin
     // (leaving C:\ProgramData\Scalar in place, in case
     // the user needs to downgrade again to get unblocked)
     WizardForm.StatusLabel.Caption:='Uninstalling .NET-based Scalar';
-    if (not ExecAndCaptureOutput(UninstallScalar, '/VERYSILENT /SILENT /NORESTART /SUPPRESSMSGBOXES /LOG', '', SW_SHOWNORMAL, ewWaitUntilTerminated, Res, Output)) or (Res<>0) then
+    if (not ExecAndCaptureOutput(RemoveQuotes(UninstallScalar), '/VERYSILENT /SILENT /NORESTART /SUPPRESSMSGBOXES /LOG', '', SW_SHOWNORMAL, ewWaitUntilTerminated, Res, Output)) or (Res<>0) then
         LogError('Could not uninstall Scalar (stderr: '+StringJoin(#13+#10,Output.StdErr)+'). Trying to continue anyway.');
 end;
 

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -801,7 +801,7 @@ end;
 
 function GetDefaultsFromGitConfig(WhichOne:String):Boolean;
 var
-    ExtraOptions,Key,Value:String;
+    InstalledGitExe,ExtraOptions,Key,Value:String;
     ExitCode,c,i,j,k:Integer;
     Output:TExecOutput;
 begin
@@ -809,6 +809,18 @@ begin
         // No previous installation detected, therefore we cannot execute `git config`
         Result:=True;
         Exit;
+    end;
+
+    InstalledGitExe:=AppDir+'\{#MINGW_BITNESS}\bin\git.exe';
+#if MINGW_BITNESS=='ucrt64'
+    if not FileExists(InstalledGitExe) then
+        // It could be an upgrade from MINGW64 to UCRT64
+        InstalledGitExe:=AppDir+'\mingw64\bin\git.exe';
+#endif
+    if not FileExists(InstalledGitExe) then begin
+        // AppDir might be a left-over from an incompletely-removed installation
+        Result:=True;
+        Exit
     end;
 
     case WhichOne of
@@ -822,10 +834,8 @@ begin
         end
     end;
 
-    if not ExecAndCaptureOutput(AppDir+'\{#MINGW_BITNESS}\bin\git.exe', 'config -l -z '+ExtraOptions, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) then begin
-        if FileExists(AppDir+'\{#MINGW_BITNESS}\bin\git.exe') then
-            LogError('Unable to get system config (exit code '+IntToStr(ExitCode)+'):'+#13+#10+StringJoin(#13+#10,Output.StdErr));
-    end;
+    if not ExecAndCaptureOutput(InstalledGitExe, 'config -l -z '+ExtraOptions, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) then
+        LogError('Unable to get system config (exit code '+IntToStr(ExitCode)+'):'+#13+#10+StringJoin(#13+#10,Output.StdErr));
 
     // git config -l -z outputs NUL-delimited key/value pairs, with a LF that denotes end of key
     // ExecAndCaptureOutput splits the Output by lines. So each String in Output.StdOut could

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -620,7 +620,7 @@ begin
                         LogError('Could not get FSMonitor help (exit code '+IntToStr(ExitCode)+'):'+#13+StringJoin(#13,Output.StdOut)+#13+StringJoin(#13,Output.StdErr));
                     Exit;
                 end else begin
-                    StdOut:=StringJoin(#13, Output.StdOut);
+                    StdOut:=StringJoin(#10, Output.StdOut);
                     i:=Pos('stop'+#10,StdOut);
                     if (i=0) then begin
                         LogError('Could not determine stop option from:'+#13+StdOut);

--- a/installer/install.iss
+++ b/installer/install.iss
@@ -837,18 +837,20 @@ begin
     if not ExecAndCaptureOutput(InstalledGitExe, 'config -l -z '+ExtraOptions, '', SW_SHOWNORMAL, ewWaitUntilTerminated, ExitCode, Output) then
         LogError('Unable to get system config (exit code '+IntToStr(ExitCode)+'):'+#13+#10+StringJoin(#13+#10,Output.StdErr));
 
-    // Split NUL-delimited key/value pairs, extract LF that denotes end of key
+    // `config -l -z` writes `<key>LF<value>NUL` pairs
     StdOut:=StringJoin(#10,Output.StdOut);
     Value:=StdOut;
+    // j iterates through the entire output;
+    // i tracks the start of the key, k of its end
     i:=1; j:=i; k:=i;
     while (j<=Length(StdOut)) do begin
         c:=Ord(StdOut[j]);
-        if (c=10) then
+        if (c=10) then // found the end of key
             k:=j
-        else if (c=0) then begin
-            if (i<>k) then begin // Ignore keys without values
-                Key:=Copy(StdOut,i,k-i);
-                Value:=Copy(StdOut,k+1,j-k-1);
+        else if (c=0) then begin // found the end of the value
+            if (i<>k) then begin // Ignore keys without values (LF is missing)
+                Key:=Copy(StdOut,i,k-i); // skip the LF delimiter
+                Value:=Copy(StdOut,k+1,j-k-1); // skip both LF and NUL delimiters
                 case Key of
                     'http.sslbackend':
                         case Value of
@@ -899,9 +901,9 @@ begin
                             RecordInferredDefault('Default Branch Option', Value)
                 end;
             end;
-            i:=j+1;
+            i:=j+1; // the next key starts after the NUL
             j:=i;
-            k:=i;
+            k:=i; // set the end of the key to the start, to identify value-less entries
         end;
         j:=j+1;
     end;


### PR DESCRIPTION
First of all: let `ExecAndCaptureOutput()` surround the Filename with quotes. Because when it comes to that `Filename` parameter, the docs of `ExecAndCaptureOutput()` at https://jrsoftware.org/ishelp/topic_isxfunc_execandcaptureoutput.htm refer to the documentation of the `Exec()` function, which say:

  Do not include quotes in the Filename parameter; the function will add
  them automatically.

While at it, also fix the parser of the output of `fsmonitor-daemon --help` (it joint the lines with Carriage Returns, but then looked for `stop` followed by a Line Feed; let's just use Line Feeds to join, too).

Also fix an infinite loop in `RPos()`. In fact, let's revert to the previous parsing logic, which was simpler because it did not have to parse line by line (which isn't the natural unit to parse `config -z` output, NUL would be the delimiter of choice).

While working on that, I also stumbled across a bug where multi-line values were mishandled (only the last line would be used, the rest would be packed into a "multi-line key", which is not allowed). That was an easy fix.

And finally, don't assume that `/ucrt64/bin/git.exe` was previously installed... That hid the bug where initially, the PR succeeded on x64 but failed on aarch64 (because the faulty config-parsing logic was skipped by mistake).